### PR TITLE
Remove unnecessary pkg-resources dependency from requirements.txt

### DIFF
--- a/bitcoin_script_compiler/requirements.txt
+++ b/bitcoin_script_compiler/requirements.txt
@@ -8,7 +8,6 @@ mccabe==0.6.1
 mypy==0.770
 mypy-extensions==0.4.3
 numpy==1.18.2
-pkg-resources==0.0.0
 pylint==2.4.4
 pyrsistent==0.16.0
 rope==0.16.0

--- a/sapio_bitcoinlib/requirements.txt
+++ b/sapio_bitcoinlib/requirements.txt
@@ -8,7 +8,6 @@ mccabe==0.6.1
 mypy==0.770
 mypy-extensions==0.4.3
 numpy==1.18.2
-pkg-resources==0.0.0
 pylint==2.4.4
 pyrsistent==0.16.0
 rope==0.16.0

--- a/sapio_compiler/requirements.txt
+++ b/sapio_compiler/requirements.txt
@@ -8,7 +8,6 @@ mccabe==0.6.1
 mypy==0.770
 mypy-extensions==0.4.3
 numpy==1.18.2
-pkg-resources==0.0.0
 pylint==2.4.4
 pyrsistent==0.16.0
 rope==0.16.0

--- a/sapio_server/requirements.txt
+++ b/sapio_server/requirements.txt
@@ -8,7 +8,6 @@ mccabe==0.6.1
 mypy==0.770
 mypy-extensions==0.4.3
 numpy==1.18.2
-pkg-resources==0.0.0
 pylint==2.4.4
 pyrsistent==0.16.0
 rope==0.16.0

--- a/sapio_stdlib/requirements.txt
+++ b/sapio_stdlib/requirements.txt
@@ -8,7 +8,6 @@ mccabe==0.6.1
 mypy==0.770
 mypy-extensions==0.4.3
 numpy==1.18.2
-pkg-resources==0.0.0
 pylint==2.4.4
 pyrsistent==0.16.0
 rope==0.16.0

--- a/sapio_zoo/requirements.txt
+++ b/sapio_zoo/requirements.txt
@@ -8,7 +8,6 @@ mccabe==0.6.1
 mypy==0.770
 mypy-extensions==0.4.3
 numpy==1.18.2
-pkg-resources==0.0.0
 pylint==2.4.4
 pyrsistent==0.16.0
 rope==0.16.0


### PR DESCRIPTION
Remove unnecessary `pkg-resources` dependency from `requirements.txt`.

Context: https://github.com/pypa/pip/issues/4022