### PR TITLE
HODL Chicken Refactored

### DIFF
--- a/sapio_zoo/sapio_zoo/hodl_chicken.py
+++ b/sapio_zoo/sapio_zoo/hodl_chicken.py
@@ -45,19 +45,25 @@ class HodlChicken:
     winner_gets: Amount
     chicken_gets: Amount
 
+
 @HodlChicken.require
 def amounts_sum_correctly(self):
     # Make sure all sats will be spent when the game completes
-    return (self.alice_deposit + self.bob_deposit) == self.winner_gets + self.chicken_gets
+    return (
+        self.alice_deposit + self.bob_deposit
+    ) == self.winner_gets + self.chicken_gets
+
 
 @HodlChicken.require
 def equal_amounts(self):
     # Both participants should commit the same amount
     return self.alice_deposit == self.bob_deposit
 
+
 @HodlChicken.let
 def alice_is_a_chicken(self):
     return SignedBy(self.alice_key)
+
 
 @alice_is_a_chicken
 @HodlChicken.then
@@ -67,9 +73,11 @@ def alice_redeem(self) -> TransactionTemplate:
     tx.add_output(self.chicken_gets, self.alice_contract(self.chicken_gets))
     return tx
 
+
 @HodlChicken.let
 def bob_is_a_chicken(self):
     return SignedBy(self.bob_key)
+
 
 @bob_is_a_chicken
 @HodlChicken.then

--- a/sapio_zoo/tests/test_zoo/test_hodl_chicken.py
+++ b/sapio_zoo/tests/test_zoo/test_hodl_chicken.py
@@ -10,8 +10,8 @@ import unittest
 from .testutil import random_k
 from sapio_bitcoinlib.messages import COutPoint
 
-class TestHodlChicken(unittest.TestCase):
 
+class TestHodlChicken(unittest.TestCase):
     def test_hodl_chicken(self):
         alice_script = script_to_p2wsh(CScript([b"Alice's Key Goes Here!"]))
         bob_script = script_to_p2wsh(CScript([b"Bob's Key Goes Here!"]))
@@ -19,16 +19,22 @@ class TestHodlChicken(unittest.TestCase):
         bob_key = random_k()
 
         hodl_chicken = HodlChicken.create(
-            alice_contract=lambda x: PayToSegwitAddress.create(amount=AmountRange.of(x), address=alice_script),
-            bob_contract=lambda x: PayToSegwitAddress.create(amount=AmountRange.of(x), address=bob_script),
+            alice_contract=lambda x: PayToSegwitAddress.create(
+                amount=AmountRange.of(x), address=alice_script
+            ),
+            bob_contract=lambda x: PayToSegwitAddress.create(
+                amount=AmountRange.of(x), address=bob_script
+            ),
             alice_key=alice_key,
             bob_key=bob_key,
             alice_deposit=Sats(100_000_000),
             bob_deposit=Sats(100_000_000),
             winner_gets=Sats(150_000_000),
-            chicken_gets=Sats(50_000_000))
+            chicken_gets=Sats(50_000_000),
+        )
 
         hodl_chicken.bind(COutPoint(0, 0))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
See #33.

﻿- Rewrite Compiler to not use Metaclasses
- Upgrade syntax on std contracts
- Refactor sapio_zoo contracts
- Fix Server Broken Types
- Formatting fix
- initial hodl_chicken version
- Initial hodl chicken test
- Refactor to split signature checking and tx creation
- broken test
- Authorize by pubkey and pay out to contract
- Add License & Refactor HodlChicken to use new syntax


@pyskell  sign off here and will merge. I took liberty of adding BSD-new license under your name and Judica jointly (allows Judica to enforce BSD claim if someone does not follow the license, rather than just you).