### PR TITLE
Feature Compile Time Conditional Compilation

### DIFF
--- a/sapio-contrib/src/contracts/basic_examples.rs
+++ b/sapio-contrib/src/contracts/basic_examples.rs
@@ -6,6 +6,10 @@
 
 //! Some basic examples showing a kitchen sink of functionality
 use super::*;
+use sapio::contract::actions::ConditionalCompileType;
+use sapio_base::timelocks::RelTime;
+use std::collections::LinkedList;
+use std::convert::TryFrom;
 use std::marker::PhantomData;
 
 #[derive(JsonSchema, Serialize, Deserialize)]
@@ -85,4 +89,104 @@ where
     declare! {then, Self::begin_contest}
     declare! {finish, Self::all_signed}
     declare! {non updatable }
+}
+
+/// Trustless Escrowing Contract
+#[derive(JsonSchema, Serialize, Deserialize)]
+pub struct ExampleCompileIf {
+    alice: bitcoin::PublicKey,
+    bob: bitcoin::PublicKey,
+    alice_escrow: (CoinAmount, bitcoin::Address),
+    bob_escrow: (CoinAmount, bitcoin::Address),
+    escrow_disable: bool,
+    escrow_required_no_conflict_disabled: bool,
+    escrow_required_conflict_disabled: bool,
+    escrow_nullable: bool,
+    escrow_error: Option<String>,
+}
+
+impl ExampleCompileIf {
+    guard!(
+        cooperate | s,
+        ctx | { Clause::And(vec![Clause::Key(s.alice), Clause::Key(s.bob)]) }
+    );
+    compile_if!(
+        /// `should_escrow` disables any branch depending on it. If not set,
+        /// it checks to make the branch required. This is done in a conflict-free way;
+        /// that is that  if escrow_required_no_conflict_disabled is set and escrow_disable
+        /// is set there is no problem.
+        should_escrow
+            | s,
+        ctx | {
+            if s.escrow_disable {
+                ConditionalCompileType::Never
+            } else {
+                if s.escrow_required_no_conflict_disabled {
+                    ConditionalCompileType::Required
+                } else {
+                    ConditionalCompileType::Skippable
+                }
+            }
+        }
+    );
+    compile_if!(
+        /// `must_escrow` requires that any depending branch be taken.
+        /// It may conflict with escrow_disable, if they are both set then
+        /// compilation will fail.
+        must_escrow
+            | s,
+        ctx | {
+            if s.escrow_required_conflict_disabled {
+                ConditionalCompileType::Required
+            } else {
+                ConditionalCompileType::NoConstraint
+            }
+        }
+    );
+    compile_if!(
+        /// `escrow_nullable_ok` tells the compiler if it is OK if dependents on this
+        /// condition return 0 txiter items -- if so, the entire branch is pruned.
+        escrow_nullable_ok
+            | s,
+        ctx | {
+            if s.escrow_nullable {
+                ConditionalCompileType::Nullable
+            } else {
+                ConditionalCompileType::NoConstraint
+            }
+        }
+    );
+
+    compile_if!(
+        /// `escrow_error_chk` fails with the provided error, if any
+        escrow_error_chk
+            | s,
+        ctx | {
+            if let Some(e) = &s.escrow_error {
+                let mut l = LinkedList::new();
+                l.push_front(e.clone());
+                ConditionalCompileType::Fail(l)
+            } else {
+                ConditionalCompileType::NoConstraint
+            }
+        }
+    );
+    then! {use_escrow [Self::should_escrow, Self::must_escrow, Self::escrow_nullable_ok, Self::escrow_error_chk] [] |s, ctx| {
+        ctx.template()
+            .add_output(
+                s.alice_escrow.0.try_into()?,
+                &Compiled::from_address(s.alice_escrow.1.clone(), None),
+                None)?
+            .add_output(
+                s.bob_escrow.0.try_into()?,
+                &Compiled::from_address(s.bob_escrow.1.clone(), None),
+                None)?
+            .set_sequence(0, RelTime::try_from(std::time::Duration::from_secs(10*24*60*60))?.into())?.into()
+    }}
+}
+
+impl Contract for ExampleCompileIf {
+    declare! {finish, Self::cooperate}
+    declare! {then, Self::use_escrow}
+    declare! {non updatable}
 }

--- a/sapio-contrib/src/contracts/dynamic.rs
+++ b/sapio-contrib/src/contracts/dynamic.rs
@@ -50,7 +50,7 @@ impl DynamicExample {
         let d : D = D{v};
 
         let d2 = DynamicContract::<(), String> {
-            then: vec![|| None, || Some(sapio::contract::actions::ThenFunc{guard: &[], func: |_s, _ctx| Err(CompilationError::TerminateCompilation)})],
+            then: vec![|| None, || Some(sapio::contract::actions::ThenFunc{conditional_compile_if: &[], guard: &[], func: |_s, _ctx| Err(CompilationError::TerminateCompilation)})],
             finish: vec![],
             finish_or: vec![],
             data: "E.g., Create a Vault".into(),

--- a/sapio/src/contract/actions.rs
+++ b/sapio/src/contract/actions.rs
@@ -8,6 +8,7 @@
 use super::Context;
 use super::TxTmplIt;
 use sapio_base::Clause;
+use std::collections::LinkedList;
 /// A Guard is a function which generates some condition that must be met to unlock a script.
 /// If bool = true, the computation of the guard is cached, which is useful if e.g. Guard
 /// must contact a remote server or it should be the same across calls *for a given contract
@@ -22,12 +23,106 @@ pub enum Guard<ContractSelf> {
 /// A List of Guards, for convenience
 pub type GuardList<'a, T> = &'a [fn() -> Option<Guard<T>>];
 
+/// Conditional Compilation function has specified that compilation of this
+/// function should be required or not.
+pub enum ConditionalCompileType {
+    /// May proceed without calling this function at all
+    Skippable,
+    /// If no errors are returned, and no txtmpls are returned,
+    /// it is not an error and the branch is pruned.
+    Nullable,
+    /// The default condition if no ConditionallyCompileIf function is set, the
+    /// branch is present and it is required.
+    Required,
+    /// This branch must never be used
+    Never,
+    /// No Constraint, nothing is changed by this rule
+    NoConstraint,
+    /// The branch should always trigger an error, with some reasons
+    Fail(LinkedList<String>),
+}
+
+impl ConditionalCompileType {
+    /// Merge two `ConditionalCompileTypes` into one conditions.
+    /// Precedence:
+    ///     Fail > non-Fail ==> Fail
+    ///     forall X. X > NoConstraint ==> X
+    ///     Required > {Skippable, Nullable} ==> Required
+    ///     Skippable > Nullable ==> Skippable
+    ///     Never >< Required ==> Fail
+    ///     Never > {Skippable, Nullable}  ==> Never
+    pub fn merge(self, other: Self) -> Self {
+        match (self, other) {
+            (ConditionalCompileType::NoConstraint, x) => x,
+            (x, ConditionalCompileType::NoConstraint) => x,
+            // Merge error messages
+            (ConditionalCompileType::Fail(mut v), ConditionalCompileType::Fail(mut v2)) => {
+                ConditionalCompileType::Fail({
+                    v.append(&mut v2);
+                    v
+                })
+            }
+            // Fail ignored and overrides other conditions.
+            (ConditionalCompileType::Fail(v), _) | (_, ConditionalCompileType::Fail(v)) => {
+                ConditionalCompileType::Fail(v)
+            }
+            // Never and Required Conflict
+            (ConditionalCompileType::Required, ConditionalCompileType::Never)
+            | (ConditionalCompileType::Never, ConditionalCompileType::Required) => {
+                let mut l = LinkedList::new();
+                l.push_front(String::from("Never and Required incompatible"));
+                ConditionalCompileType::Fail(l)
+            }
+            // Never stays Never
+            (ConditionalCompileType::Never, ConditionalCompileType::Skippable)
+            | (ConditionalCompileType::Skippable, ConditionalCompileType::Never)
+            | (ConditionalCompileType::Never, ConditionalCompileType::Nullable)
+            | (ConditionalCompileType::Nullable, ConditionalCompileType::Never)
+            | (ConditionalCompileType::Never, ConditionalCompileType::Never) => {
+                ConditionalCompileType::Never
+            }
+            // Required stays Required
+            (ConditionalCompileType::Required, ConditionalCompileType::Skippable)
+            | (ConditionalCompileType::Skippable, ConditionalCompileType::Required)
+            | (ConditionalCompileType::Required, ConditionalCompileType::Nullable)
+            | (ConditionalCompileType::Nullable, ConditionalCompileType::Required)
+            | (ConditionalCompileType::Required, ConditionalCompileType::Required) => {
+                ConditionalCompileType::Required
+            }
+            (ConditionalCompileType::Skippable, ConditionalCompileType::Skippable)
+            | (ConditionalCompileType::Skippable, ConditionalCompileType::Nullable)
+            | (ConditionalCompileType::Nullable, ConditionalCompileType::Skippable) => {
+                ConditionalCompileType::Skippable
+            }
+            (ConditionalCompileType::Nullable, ConditionalCompileType::Nullable) => {
+                ConditionalCompileType::Nullable
+            }
+        }
+    }
+}
+
+/// A `ConditionallyCompileIf` is a function wrapper which generates some
+/// condition that must be met to disable a branch.
+///
+/// We use a separate function so that static analysis tools may operate without
+/// running the actual `ThenFunc`.
+pub enum ConditionallyCompileIf<ContractSelf> {
+    /// Fresh Variant may be called repeatedly
+    Fresh(fn(&ContractSelf, &Context) -> ConditionalCompileType),
+}
+
+/// A List of ConditionallyCompileIfs, for convenience
+pub type ConditionallyCompileIfList<'a, T> = &'a [fn() -> Option<ConditionallyCompileIf<T>>];
+
 /// A ThenFunc takes a list of Guards and a TxTmplIt generator.  Each TxTmpl returned from the
 /// ThenFunc is Covenant Permitted only if the AND of all guards is satisfied.
 pub struct ThenFunc<'a, ContractSelf: 'a> {
     /// Guards returns Clauses -- if any -- before the internal func's returned
     /// TxTmpls should execute on-chain
     pub guard: GuardList<'a, ContractSelf>,
+    /// conditional_compile_if returns ConditionallyCompileType to determine if a function
+    /// should be included.
+    pub conditional_compile_if: ConditionallyCompileIfList<'a, ContractSelf>,
     /// func returns an iterator of possible transactions
     /// Implementors should aim to return as few `TxTmpl`s as possible for enhanced
     /// semantics, preferring to split across multiple `ThenFunc`'s
@@ -39,6 +134,9 @@ pub struct ThenFunc<'a, ContractSelf: 'a> {
 pub struct FinishOrFunc<'a, ContractSelf: 'a, Extra> {
     /// Guards returns Clauses -- if any -- before the coins should be unlocked
     pub guard: GuardList<'a, ContractSelf>,
+    /// conditional_compile_if returns ConditionallyCompileType to determine if a function
+    /// should be included.
+    pub conditional_compile_if: ConditionallyCompileIfList<'a, ContractSelf>,
     /// func returns an iterator of possible transactions
     /// Implementors should aim to return as few `TxTmpl`s as possible for enhanced
     /// semantics, preferring to split across multiple `FinishOrFunc`'s.

--- a/sapio/src/contract/error.rs
+++ b/sapio/src/contract/error.rs
@@ -9,6 +9,7 @@
 //! errors created by the user we allow boxing an error trait.
 use crate::contract::object::ObjectError;
 use sapio_ctv_emulator_trait::EmulatorError;
+use std::collections::LinkedList;
 use std::error::Error;
 use std::fmt;
 /// Sapio's core error type.
@@ -40,6 +41,8 @@ pub enum CompilationError {
     TimeLockError(sapio_base::timelocks::LockTimeError),
     /// Error creating an object,
     CompiledObjectError(ObjectError),
+    /// Failure in conditional compilation logic
+    ConditionalCompilationFailed(LinkedList<String>),
     /// Unknown Error type -- either from a user or from some unhandled dependency
     Custom(Box<dyn std::error::Error>),
 }

--- a/sapio/src/contract/macros.rs
+++ b/sapio/src/contract/macros.rs
@@ -188,3 +188,30 @@ macro_rules! guard {
             }
         };
 }
+
+/// The compile_if macro is used to define a `ConditionallyCompileIf`.
+/// formats for calling are:
+/// ```ignore
+/// compile_if!(name |s| {/*ConditionallyCompileType*/})
+/// ```
+#[macro_export]
+macro_rules! compile_if {
+    {
+        $(#[$meta:meta])*
+        $name:ident
+    } => {
+            $(#[$meta])*
+            fn $name() -> Option<$crate::contract::actions::ConditionallyCompileIf<Self>> {
+                None
+            }
+     };
+    {
+        $(#[$meta:meta])*
+        $name:ident |$s:ident, $ctx:ident| $b:block
+    } => {
+            $(#[$meta])*
+            fn $name() -> Option<$crate::contract::actions::ConditionallyCompileIf<Self>> {
+                Some($crate::contract::actions::ConditionallyCompileIf::Fresh( |$s: &Self, $ctx: &$crate::contract::Context| $b))
+            }
+        };
+}


### PR DESCRIPTION
This PR adds the conditional compilation feature discussed in #87.

The way it is implemented is that a branch (finish or then) can accept a list of compile_if items that instruct the compiler to take one of a set of different actions (e.g., add no constraint, require this, skip this unless required, allow this to be pruned if nothing is returned, never compile this). The list of actions has a  merging rules for consistent behavior and can generate a failure if incompatible constraints are set.


Missing solid unit tests.

Closes #87 