### PR TITLE
Improve Macro Syntax & Code Generation

### DIFF
--- a/plugin-example/src/plugin.rs
+++ b/plugin-example/src/plugin.rs
@@ -34,19 +34,20 @@ pub struct TreePay {
 }
 
 impl TreePay {
-    then! {expand |s, ctx| {
+    then! {
+        fn expand(self, ctx) {
         let mut builder = ctx.template();
-        if s.participants.len() > s.radix {
+        if self.participants.len() > self.radix {
 
-            for c in s.participants.chunks(s.participants.len()/s.radix) {
+            for c in self.participants.chunks(self.participants.len()/self.radix) {
                 let mut amt =  bitcoin::util::amount::Amount::from_sat(0);
                 for Payment{amount, ..}  in c {
                     amt += *amount;
                 }
-                builder = builder.add_output(amt, &TreePay {participants: c.to_vec(), radix: s.radix}, None)?;
+                builder = builder.add_output(amt, &TreePay {participants: c.to_vec(), radix: self.radix}, None)?;
             }
         } else {
-            for Payment{amount, address} in s.participants.iter() {
+            for Payment{amount, address} in self.participants.iter() {
                 builder = builder.add_output(*amount, &Compiled::from_address(address.clone(), None), None)?;
             }
         }

--- a/sapio-contrib/src/contracts/basic_examples.rs
+++ b/sapio-contrib/src/contracts/basic_examples.rs
@@ -21,8 +21,8 @@ struct ExampleA {
 }
 
 impl ExampleA {
-    guard!{fn timeout(s, ctx) { Clause::Older(100) }}
-    guard!{cached fn signed(s, ctx) {Clause::And(vec![Clause::Key(s.alice), Clause::Key(s.bob)])}}
+    guard! {fn timeout(self, ctx) { Clause::Older(100) }}
+    guard! {cached fn signed(self, ctx) {Clause::And(vec![Clause::Key(self.alice), Clause::Key(self.bob)])}}
 }
 
 impl Contract for ExampleA {
@@ -63,7 +63,7 @@ struct ExampleB<T: BState> {
 }
 
 impl<T: BState> ExampleB<T> {
-    guard!{cached fn all_signed(s, ctx) {Clause::Threshold(T::get_n(s.threshold, s.participants.len()as u8) as usize, s.participants.iter().map(|k| Clause::Key(*k)).collect())}}
+    guard! {cached fn all_signed(self, ctx) {Clause::Threshold(T::get_n(self.threshold, self.participants.len()as u8) as usize, self.participants.iter().map(|k| Clause::Key(*k)).collect())}}
 }
 
 impl ExampleBThen for ExampleB<Finish> {}
@@ -106,7 +106,7 @@ pub struct ExampleCompileIf {
 }
 
 impl ExampleCompileIf {
-    guard! { fn cooperate(s, ctx) { Clause::And(vec![Clause::Key(s.alice), Clause::Key(s.bob)]) } }
+    guard! { fn cooperate(self, ctx) { Clause::And(vec![Clause::Key(self.alice), Clause::Key(self.bob)]) } }
     compile_if!(
         /// `should_escrow` disables any branch depending on it. If not set,
         /// it checks to make the branch required. This is done in a conflict-free way;

--- a/sapio-contrib/src/contracts/basic_examples.rs
+++ b/sapio-contrib/src/contracts/basic_examples.rs
@@ -21,8 +21,8 @@ struct ExampleA {
 }
 
 impl ExampleA {
-    guard!(timeout | s, ctx | { Clause::Older(100) });
-    guard!(cached signed |s, ctx| {Clause::And(vec![Clause::Key(s.alice), Clause::Key(s.bob)])});
+    guard!{fn timeout(s, ctx) { Clause::Older(100) }}
+    guard!{cached fn signed(s, ctx) {Clause::And(vec![Clause::Key(s.alice), Clause::Key(s.bob)])}}
 }
 
 impl Contract for ExampleA {
@@ -63,7 +63,7 @@ struct ExampleB<T: BState> {
 }
 
 impl<T: BState> ExampleB<T> {
-    guard!(cached all_signed |s, ctx| {Clause::Threshold(T::get_n(s.threshold, s.participants.len()as u8) as usize, s.participants.iter().map(|k| Clause::Key(*k)).collect())});
+    guard!{cached fn all_signed(s, ctx) {Clause::Threshold(T::get_n(s.threshold, s.participants.len()as u8) as usize, s.participants.iter().map(|k| Clause::Key(*k)).collect())}}
 }
 
 impl ExampleBThen for ExampleB<Finish> {}
@@ -106,7 +106,7 @@ pub struct ExampleCompileIf {
 }
 
 impl ExampleCompileIf {
-    guard! { cooperate | s, ctx | { Clause::And(vec![Clause::Key(s.alice), Clause::Key(s.bob)]) } }
+    guard! { fn cooperate(s, ctx) { Clause::And(vec![Clause::Key(s.alice), Clause::Key(s.bob)]) } }
     compile_if!(
         /// `should_escrow` disables any branch depending on it. If not set,
         /// it checks to make the branch required. This is done in a conflict-free way;
@@ -141,7 +141,7 @@ impl ExampleCompileIf {
         /// condition return 0 txiter items -- if so, the entire branch is pruned.
         fn escrow_nullable_ok(s, ctx) {
             if s.escrow_nullable {
-            ConditionalCompileType::Nullable
+                ConditionalCompileType::Nullable
             } else {
                 ConditionalCompileType::NoConstraint
             }

--- a/sapio-contrib/src/contracts/basic_examples.rs
+++ b/sapio-contrib/src/contracts/basic_examples.rs
@@ -112,11 +112,11 @@ impl ExampleCompileIf {
         /// it checks to make the branch required. This is done in a conflict-free way;
         /// that is that  if escrow_required_no_conflict_disabled is set and escrow_disable
         /// is set there is no problem.
-        fn should_escrow(s, ctx) {
-            if s.escrow_disable {
+        fn should_escrow(self, ctx) {
+            if self.escrow_disable {
                 ConditionalCompileType::Never
             } else {
-                if s.escrow_required_no_conflict_disabled {
+                if self.escrow_required_no_conflict_disabled {
                     ConditionalCompileType::Required
                 } else {
                     ConditionalCompileType::Skippable
@@ -128,8 +128,8 @@ impl ExampleCompileIf {
         /// `must_escrow` requires that any depending branch be taken.
         /// It may conflict with escrow_disable, if they are both set then
         /// compilation will fail.
-        fn must_escrow(s, ctx) {
-            if s.escrow_required_conflict_disabled {
+        fn must_escrow(self, ctx) {
+            if self.escrow_required_conflict_disabled {
                 ConditionalCompileType::Required
             } else {
                 ConditionalCompileType::NoConstraint
@@ -139,8 +139,8 @@ impl ExampleCompileIf {
     compile_if! {
         /// `escrow_nullable_ok` tells the compiler if it is OK if dependents on this
         /// condition return 0 txiter items -- if so, the entire branch is pruned.
-        fn escrow_nullable_ok(s, ctx) {
-            if s.escrow_nullable {
+        fn escrow_nullable_ok(self, ctx) {
+            if self.escrow_nullable {
                 ConditionalCompileType::Nullable
             } else {
                 ConditionalCompileType::NoConstraint
@@ -150,8 +150,8 @@ impl ExampleCompileIf {
 
     compile_if! {
         /// `escrow_error_chk` fails with the provided error, if any
-        fn escrow_error_chk(s, ctx) {
-            if let Some(e) = &s.escrow_error {
+        fn escrow_error_chk(self, ctx) {
+            if let Some(e) = &self.escrow_error {
                 let mut l = LinkedList::new();
                 l.push_front(e.clone());
                 ConditionalCompileType::Fail(l)

--- a/sapio-contrib/src/contracts/basic_examples.rs
+++ b/sapio-contrib/src/contracts/basic_examples.rs
@@ -160,7 +160,7 @@ impl ExampleCompileIf {
             }
         }
     }
-    then! {[Self::should_escrow, Self::must_escrow, Self::escrow_nullable_ok, Self::escrow_error_chk] []
+    then! {compile_if: [Self::should_escrow, Self::must_escrow, Self::escrow_nullable_ok, Self::escrow_error_chk]
         fn use_escrow(s, ctx) {
         ctx.template()
             .add_output(

--- a/sapio-contrib/src/contracts/basic_examples.rs
+++ b/sapio-contrib/src/contracts/basic_examples.rs
@@ -68,7 +68,7 @@ impl<T: BState> ExampleB<T> {
 
 impl ExampleBThen for ExampleB<Finish> {}
 impl ExampleBThen for ExampleB<Start> {
-    then! {begin_contest |s, ctx| {
+    then! {fn begin_contest(s, ctx) {
         ctx.template().add_output(
             s.amount.try_into()?,
             &ExampleB::<Finish> {
@@ -160,7 +160,8 @@ impl ExampleCompileIf {
             }
         }
     }
-    then! {use_escrow [Self::should_escrow, Self::must_escrow, Self::escrow_nullable_ok, Self::escrow_error_chk] [] |s, ctx| {
+    then! {[Self::should_escrow, Self::must_escrow, Self::escrow_nullable_ok, Self::escrow_error_chk] []
+        fn use_escrow(s, ctx) {
         ctx.template()
             .add_output(
                 s.alice_escrow.0.try_into()?,

--- a/sapio-contrib/src/contracts/basic_examples.rs
+++ b/sapio-contrib/src/contracts/basic_examples.rs
@@ -68,13 +68,13 @@ impl<T: BState> ExampleB<T> {
 
 impl ExampleBThen for ExampleB<Finish> {}
 impl ExampleBThen for ExampleB<Start> {
-    then! {fn begin_contest(s, ctx) {
+    then! {fn begin_contest(self, ctx) {
         ctx.template().add_output(
-            s.amount.try_into()?,
+            self.amount.try_into()?,
             &ExampleB::<Finish> {
-                participants: s.participants.clone(),
-                threshold: s.threshold,
-                amount: s.amount,
+                participants: self.participants.clone(),
+                threshold: self.threshold,
+                amount: self.amount,
                 pd: Default::default(),
             },
             None,
@@ -161,15 +161,15 @@ impl ExampleCompileIf {
         }
     }
     then! {compile_if: [Self::should_escrow, Self::must_escrow, Self::escrow_nullable_ok, Self::escrow_error_chk]
-        fn use_escrow(s, ctx) {
+        fn use_escrow(self, ctx) {
         ctx.template()
             .add_output(
-                s.alice_escrow.0.try_into()?,
-                &Compiled::from_address(s.alice_escrow.1.clone(), None),
+                self.alice_escrow.0.try_into()?,
+                &Compiled::from_address(self.alice_escrow.1.clone(), None),
                 None)?
             .add_output(
-                s.bob_escrow.0.try_into()?,
-                &Compiled::from_address(s.bob_escrow.1.clone(), None),
+                self.bob_escrow.0.try_into()?,
+                &Compiled::from_address(self.bob_escrow.1.clone(), None),
                 None)?
             .set_sequence(0, RelTime::try_from(std::time::Duration::from_secs(10*24*60*60))?.into())?.into()
     }}

--- a/sapio-contrib/src/contracts/channel.rs
+++ b/sapio-contrib/src/contracts/channel.rs
@@ -186,23 +186,23 @@ impl<T: State> Channel<T> {
     guard! {cached fn signed(self, ctx) {Clause::And(vec![Clause::Key(self.alice), Clause::Key(self.bob)])}}
 
     finish! {
-        update_state_a [Self::signed]
-            |s, ctx, o| {
-                Ok(Box::new(std::iter::empty()))
-            }
+        guarded_by: [Self::signed]
+        fn update_state_a(self, ctx, o) {
+            Ok(Box::new(std::iter::empty()))
+        }
     }
     finish! {
-        update_state_b [Self::signed]
-            |s, ctx, o| {
-                Ok(Box::new(std::iter::empty()))
-            }
+        guarded_by: [Self::signed]
+        fn update_state_b(self, ctx, o){
+            Ok(Box::new(std::iter::empty()))
+        }
     }
 
     finish! {
-        cooperate [Self::signed]
-            |s, ctx, o| {
-                Ok(Box::new(std::iter::empty()))
-            }
+        guarded_by: [Self::signed]
+        fn cooperate(self, ctx, o) {
+            Ok(Box::new(std::iter::empty()))
+        }
     }
 }
 

--- a/sapio-contrib/src/contracts/channel.rs
+++ b/sapio-contrib/src/contracts/channel.rs
@@ -182,8 +182,8 @@ struct Channel<T: State> {
 
 /// Functionality Available for a channel regardless of state
 impl<T: State> Channel<T> {
-    guard! {fn timeout(s, ctx) { Clause::Older(100) }}
-    guard! {cached fn signed(s, ctx) {Clause::And(vec![Clause::Key(s.alice), Clause::Key(s.bob)])}}
+    guard! {fn timeout(self, ctx) { Clause::Older(100) }}
+    guard! {cached fn signed(self, ctx) {Clause::And(vec![Clause::Key(self.alice), Clause::Key(self.bob)])}}
 
     finish! {
         update_state_a [Self::signed]

--- a/sapio-contrib/src/contracts/channel.rs
+++ b/sapio-contrib/src/contracts/channel.rs
@@ -211,12 +211,8 @@ trait FunctionalityAtState
 where
     Self: Sized,
 {
-    fn begin_contest<'a>() -> Option<ThenFunc<'a, Self>> {
-        None
-    }
-    fn finish_contest<'a>() -> Option<ThenFunc<'a, Self>> {
-        None
-    }
+    then! {begin_contest}
+    then! {finish_contest}
 }
 
 /// Override begin_contest when state = Start

--- a/sapio-contrib/src/contracts/channel.rs
+++ b/sapio-contrib/src/contracts/channel.rs
@@ -217,7 +217,7 @@ where
 
 /// Override begin_contest when state = Start
 impl FunctionalityAtState for Channel<Start> {
-    then! {begin_contest |s, ctx| {
+    then! {fn begin_contest(s, ctx) {
         ctx.template().add_output(
             s.amount.try_into()?,
             &Channel::<Stop> {
@@ -235,7 +235,7 @@ impl FunctionalityAtState for Channel<Start> {
 
 /// Override finish_contest when state = Start
 impl FunctionalityAtState for Channel<Stop> {
-    then! {finish_contest [Self::timeout] |s, ctx| {
+    then! { [Self::timeout] fn finish_contest (s, ctx) {
         ctx.template().add_output(s.amount.try_into()?, &s.resolution, None)?.into()
     }}
 }

--- a/sapio-contrib/src/contracts/channel.rs
+++ b/sapio-contrib/src/contracts/channel.rs
@@ -235,7 +235,7 @@ impl FunctionalityAtState for Channel<Start> {
 
 /// Override finish_contest when state = Start
 impl FunctionalityAtState for Channel<Stop> {
-    then! { [Self::timeout] fn finish_contest (s, ctx) {
+    then! { guarded_by: [Self::timeout] fn finish_contest (s, ctx) {
         ctx.template().add_output(s.amount.try_into()?, &s.resolution, None)?.into()
     }}
 }

--- a/sapio-contrib/src/contracts/channel.rs
+++ b/sapio-contrib/src/contracts/channel.rs
@@ -181,7 +181,10 @@ struct Channel<T: State> {
 }
 
 /// Functionality Available for a channel regardless of state
-impl<T: State> Channel<T> {
+impl<T: State> Channel<T>
+where
+    Channel<T>: Contract,
+{
     guard! {fn timeout(self, ctx) { Clause::Older(100) }}
     guard! {cached fn signed(self, ctx) {Clause::And(vec![Clause::Key(self.alice), Clause::Key(self.bob)])}}
 
@@ -209,7 +212,7 @@ impl<T: State> Channel<T> {
 /// Functionality that differs depending on current State
 trait FunctionalityAtState
 where
-    Self: Sized,
+    Self: Sized + Contract,
 {
     then! {begin_contest}
     then! {finish_contest}

--- a/sapio-contrib/src/contracts/channel.rs
+++ b/sapio-contrib/src/contracts/channel.rs
@@ -182,8 +182,8 @@ struct Channel<T: State> {
 
 /// Functionality Available for a channel regardless of state
 impl<T: State> Channel<T> {
-    guard!(timeout | s, ctx | { Clause::Older(100) });
-    guard!(cached signed |s, ctx| {Clause::And(vec![Clause::Key(s.alice), Clause::Key(s.bob)])});
+    guard! {fn timeout(s, ctx) { Clause::Older(100) }}
+    guard! {cached fn signed(s, ctx) {Clause::And(vec![Clause::Key(s.alice), Clause::Key(s.bob)])}}
 
     finish! {
         update_state_a [Self::signed]

--- a/sapio-contrib/src/contracts/channel.rs
+++ b/sapio-contrib/src/contracts/channel.rs
@@ -217,16 +217,16 @@ where
 
 /// Override begin_contest when state = Start
 impl FunctionalityAtState for Channel<Start> {
-    then! {fn begin_contest(s, ctx) {
+    then! {fn begin_contest(self, ctx) {
         ctx.template().add_output(
-            s.amount.try_into()?,
+            self.amount.try_into()?,
             &Channel::<Stop> {
                 pd: Default::default(),
-                alice: s.alice,
-                bob: s.bob,
-                amount: s.amount.try_into().unwrap(),
-                resolution: s.resolution.clone(),
-                db: s.db.clone(),
+                alice: self.alice,
+                bob: self.bob,
+                amount: self.amount.try_into().unwrap(),
+                resolution: self.resolution.clone(),
+                db: self.db.clone(),
             },
             None,
         )?.into()
@@ -235,9 +235,12 @@ impl FunctionalityAtState for Channel<Start> {
 
 /// Override finish_contest when state = Start
 impl FunctionalityAtState for Channel<Stop> {
-    then! { guarded_by: [Self::timeout] fn finish_contest (s, ctx) {
-        ctx.template().add_output(s.amount.try_into()?, &s.resolution, None)?.into()
-    }}
+    then! {
+        guarded_by: [Self::timeout]
+        fn finish_contest (self, ctx) {
+            ctx.template().add_output(self.amount.try_into()?, &self.resolution, None)?.into()
+        }
+    }
 }
 
 /// Implement Contract for Channel<T> and functionality will be correctly assembled for different

--- a/sapio-contrib/src/contracts/derivatives/exploding.rs
+++ b/sapio-contrib/src/contracts/derivatives/exploding.rs
@@ -9,14 +9,14 @@ use super::*;
 use sapio_base::timelocks::*;
 /// Generic functionality required for Exploding contracts
 pub trait Explodes: 'static + Sized {
-    then!(
+    then! {
         /// What to do when the timeout expires
         explodes
-    );
-    then!(
+    }
+    then! {
         /// what to do when the holder wishes to strike
         strikes
-    );
+    }
 }
 
 impl<T> Contract for ExplodingOption<T>
@@ -55,9 +55,8 @@ where
     GenericBet: TryFrom<T, Error = CompilationError>,
     T: Clone,
 {
-    then!(
-        explodes | s,
-        ctx | {
+    then! {
+        fn explodes (s, ctx) {
             ctx.template()
                 .add_output(
                     s.party_one.into(),
@@ -72,11 +71,11 @@ where
                 .set_lock_time(s.timeout)?
                 .into()
         }
-    );
+    }
 
-    then!(
-        strikes[Self::signed] | s,
-        ctx | {
+    then! {
+        [Self::signed]
+        fn strikes(s, ctx) {
             ctx.template()
                 .add_output(
                     (s.party_one + s.party_two).into(),
@@ -85,7 +84,7 @@ where
                 )?
                 .into()
         }
-    );
+    }
 }
 
 /// Similar to `ExplodingOption` except that the option requires an additional
@@ -103,9 +102,8 @@ where
     GenericBet: TryFrom<T, Error = CompilationError>,
     T: Clone,
 {
-    then!(
-        explodes | s,
-        ctx | {
+    then! {
+        fn explodes(s, ctx) {
             Ok(Box::new(std::iter::once(
                 ctx.template()
                     .add_output(
@@ -117,11 +115,10 @@ where
                     .into(),
             )))
         }
-    );
+    }
 
-    then!(
-        strikes | s,
-        ctx | {
+    then! {
+        fn strikes(s, ctx) {
             ctx.template()
                 .add_amount(s.party_two)
                 .add_sequence()
@@ -132,5 +129,5 @@ where
                 )?
                 .into()
         }
-    );
+    }
 }

--- a/sapio-contrib/src/contracts/derivatives/exploding.rs
+++ b/sapio-contrib/src/contracts/derivatives/exploding.rs
@@ -56,30 +56,30 @@ where
     T: Clone,
 {
     then! {
-        fn explodes (s, ctx) {
+        fn explodes (self, ctx) {
             ctx.template()
                 .add_output(
-                    s.party_one.into(),
-                    &Compiled::from_address(s.key_p1.clone(), None),
+                    self.party_one.into(),
+                    &Compiled::from_address(self.key_p1.clone(), None),
                     None,
                 )?
                 .add_output(
-                    s.party_two.into(),
-                    &Compiled::from_address(s.key_p2.clone(), None),
+                    self.party_two.into(),
+                    &Compiled::from_address(self.key_p2.clone(), None),
                     None,
                 )?
-                .set_lock_time(s.timeout)?
+                .set_lock_time(self.timeout)?
                 .into()
         }
     }
 
     then! {
         guarded_by: [Self::signed]
-        fn strikes(s, ctx) {
+        fn strikes(self, ctx) {
             ctx.template()
                 .add_output(
-                    (s.party_one + s.party_two).into(),
-                    &GenericBet::try_from(s.opt.clone())?,
+                    (self.party_one + self.party_two).into(),
+                    &GenericBet::try_from(self.opt.clone())?,
                     None,
                 )?
                 .into()
@@ -103,28 +103,28 @@ where
     T: Clone,
 {
     then! {
-        fn explodes(s, ctx) {
+        fn explodes(self, ctx) {
             Ok(Box::new(std::iter::once(
                 ctx.template()
                     .add_output(
-                        s.party_one.into(),
-                        &Compiled::from_address(s.key_p1.clone(), None),
+                        self.party_one.into(),
+                        &Compiled::from_address(self.key_p1.clone(), None),
                         None,
                     )?
-                    .set_lock_time(s.timeout)?
+                    .set_lock_time(self.timeout)?
                     .into(),
             )))
         }
     }
 
     then! {
-        fn strikes(s, ctx) {
+        fn strikes(self, ctx) {
             ctx.template()
-                .add_amount(s.party_two)
+                .add_amount(self.party_two)
                 .add_sequence()
                 .add_output(
-                    (s.party_one + s.party_two).into(),
-                    &GenericBet::try_from(s.opt.clone())?,
+                    (self.party_one + self.party_two).into(),
+                    &GenericBet::try_from(self.opt.clone())?,
                     None,
                 )?
                 .into()

--- a/sapio-contrib/src/contracts/derivatives/exploding.rs
+++ b/sapio-contrib/src/contracts/derivatives/exploding.rs
@@ -48,7 +48,7 @@ pub struct ExplodingOption<T: 'static> {
 }
 
 impl<T> ExplodingOption<T> {
-    guard!{fn signed(s, ctx) { s.key_p2_pk.clone() }}
+    guard! {fn signed(self, ctx) { self.key_p2_pk.clone() }}
 }
 impl<T> Explodes for ExplodingOption<T>
 where

--- a/sapio-contrib/src/contracts/derivatives/exploding.rs
+++ b/sapio-contrib/src/contracts/derivatives/exploding.rs
@@ -74,7 +74,7 @@ where
     }
 
     then! {
-        [Self::signed]
+        guarded_by: [Self::signed]
         fn strikes(s, ctx) {
             ctx.template()
                 .add_output(

--- a/sapio-contrib/src/contracts/derivatives/exploding.rs
+++ b/sapio-contrib/src/contracts/derivatives/exploding.rs
@@ -48,7 +48,7 @@ pub struct ExplodingOption<T: 'static> {
 }
 
 impl<T> ExplodingOption<T> {
-    guard!(signed | s, ctx | { s.key_p2_pk.clone() });
+    guard!{fn signed(s, ctx) { s.key_p2_pk.clone() }}
 }
 impl<T> Explodes for ExplodingOption<T>
 where

--- a/sapio-contrib/src/contracts/derivatives/mod.rs
+++ b/sapio-contrib/src/contracts/derivatives/mod.rs
@@ -97,11 +97,12 @@ impl GenericBet {
             )),
         }
     }
-    guard!(
+    guard! {
         /// Action when the price is greater than or equal to the price in the middle
-        gte | s,
-        ctx | { s.price(true) }
-    );
+        fn gte(s, ctx) {
+            s.price(true)
+        }
+    }
     then!(
         pay_gte[Self::gte] | s,
         ctx | {
@@ -113,11 +114,12 @@ impl GenericBet {
         }
     );
 
-    guard!(
+    guard!{
         /// Action when the price is less than or equal to the price in the middle
-        lt | s,
-        ctx | { s.price(false) }
-    );
+        fn lt(s, ctx) {
+            s.price(false)
+        }
+    }
     then!(
         pay_lt[Self::lt] | s,
         ctx | {
@@ -128,12 +130,10 @@ impl GenericBet {
             }
         }
     );
-    guard!(
+    guard!{
         /// Allow for both parties to cooperative close
-        cooperate
-            | s,
-        ctx | { s.cooperate.clone() }
-    );
+        fn cooperate(s, ctx) { s.cooperate.clone() }
+    }
 
     // elided: unilateral close initiation after certain relative delay
 }

--- a/sapio-contrib/src/contracts/derivatives/mod.rs
+++ b/sapio-contrib/src/contracts/derivatives/mod.rs
@@ -104,8 +104,8 @@ impl GenericBet {
         }
     }
     then!(
-        pay_gte[Self::gte] | s,
-        ctx | {
+        [Self::gte]
+        fn pay_gte(s, ctx) {
             if let Some(tmpl) = s.recurse_over(s.outcomes.len() / 2..s.outcomes.len(), ctx)? {
                 Ok(Box::new(std::iter::once(Ok(tmpl))))
             } else {
@@ -121,8 +121,8 @@ impl GenericBet {
         }
     }
     then!(
-        pay_lt[Self::lt] | s,
-        ctx | {
+        [Self::lt]
+        fn pay_lt( s, ctx) {
             if let Some(tmpl) = s.recurse_over(0..s.outcomes.len() / 2, ctx)? {
                 Ok(Box::new(std::iter::once(Ok(tmpl))))
             } else {

--- a/sapio-contrib/src/contracts/derivatives/mod.rs
+++ b/sapio-contrib/src/contracts/derivatives/mod.rs
@@ -105,8 +105,8 @@ impl GenericBet {
     }
     then!(
         guarded_by: [Self::gte]
-        fn pay_gte(s, ctx) {
-            if let Some(tmpl) = s.recurse_over(s.outcomes.len() / 2..s.outcomes.len(), ctx)? {
+        fn pay_gte(self, ctx) {
+            if let Some(tmpl) = self.recurse_over(self.outcomes.len() / 2..self.outcomes.len(), ctx)? {
                 Ok(Box::new(std::iter::once(Ok(tmpl))))
             } else {
                 Ok(Box::new(std::iter::empty()))
@@ -122,8 +122,8 @@ impl GenericBet {
     }
     then!(
         guarded_by: [Self::lt]
-        fn pay_lt( s, ctx) {
-            if let Some(tmpl) = s.recurse_over(0..s.outcomes.len() / 2, ctx)? {
+        fn pay_lt(self, ctx) {
+            if let Some(tmpl) = self.recurse_over(0..self.outcomes.len() / 2, ctx)? {
                 Ok(Box::new(std::iter::once(Ok(tmpl))))
             } else {
                 Ok(Box::new(std::iter::empty()))

--- a/sapio-contrib/src/contracts/derivatives/mod.rs
+++ b/sapio-contrib/src/contracts/derivatives/mod.rs
@@ -99,8 +99,8 @@ impl GenericBet {
     }
     guard! {
         /// Action when the price is greater than or equal to the price in the middle
-        fn gte(s, ctx) {
-            s.price(true)
+        fn gte(self, ctx) {
+            self.price(true)
         }
     }
     then!(
@@ -114,10 +114,10 @@ impl GenericBet {
         }
     );
 
-    guard!{
+    guard! {
         /// Action when the price is less than or equal to the price in the middle
-        fn lt(s, ctx) {
-            s.price(false)
+        fn lt(self, ctx) {
+            self.price(false)
         }
     }
     then!(
@@ -130,9 +130,9 @@ impl GenericBet {
             }
         }
     );
-    guard!{
+    guard! {
         /// Allow for both parties to cooperative close
-        fn cooperate(s, ctx) { s.cooperate.clone() }
+        fn cooperate(self, ctx) { self.cooperate.clone() }
     }
 
     // elided: unilateral close initiation after certain relative delay

--- a/sapio-contrib/src/contracts/derivatives/mod.rs
+++ b/sapio-contrib/src/contracts/derivatives/mod.rs
@@ -104,7 +104,7 @@ impl GenericBet {
         }
     }
     then!(
-        [Self::gte]
+        guarded_by: [Self::gte]
         fn pay_gte(s, ctx) {
             if let Some(tmpl) = s.recurse_over(s.outcomes.len() / 2..s.outcomes.len(), ctx)? {
                 Ok(Box::new(std::iter::once(Ok(tmpl))))
@@ -121,7 +121,7 @@ impl GenericBet {
         }
     }
     then!(
-        [Self::lt]
+        guarded_by: [Self::lt]
         fn pay_lt( s, ctx) {
             if let Some(tmpl) = s.recurse_over(0..s.outcomes.len() / 2, ctx)? {
                 Ok(Box::new(std::iter::once(Ok(tmpl))))

--- a/sapio-contrib/src/contracts/dynamic.rs
+++ b/sapio-contrib/src/contracts/dynamic.rs
@@ -43,7 +43,7 @@ impl AnyContract for D<'static> {
 #[derive(JsonSchema, Deserialize)]
 pub struct DynamicExample;
 impl DynamicExample {
-    then! {fn next (s, ctx) {
+    then! {fn next (self, ctx) {
         let v:
             Vec<fn() -> Option<actions::ThenFunc<'static, D<'static>>>>
             = vec![];

--- a/sapio-contrib/src/contracts/dynamic.rs
+++ b/sapio-contrib/src/contracts/dynamic.rs
@@ -43,7 +43,7 @@ impl AnyContract for D<'static> {
 #[derive(JsonSchema, Deserialize)]
 pub struct DynamicExample;
 impl DynamicExample {
-    then! {next |s, ctx| {
+    then! {fn next (s, ctx) {
         let v:
             Vec<fn() -> Option<actions::ThenFunc<'static, D<'static>>>>
             = vec![];

--- a/sapio-contrib/src/contracts/federated_sidechain.rs
+++ b/sapio-contrib/src/contracts/federated_sidechain.rs
@@ -53,7 +53,9 @@ where
     begin_recovery}
 }
 impl StateDependentActions for FederatedPegIn<CanBeginRecovery> {
-    then! {begin_recovery [Self::recovery_signed] |s, ctx| {
+    then! {
+        [Self::recovery_signed]
+        fn begin_recovery(s, ctx) {
         ctx.template().add_output(
             s.amount.try_into()?,
             &FederatedPegIn::<CanFinishRecovery> {

--- a/sapio-contrib/src/contracts/federated_sidechain.rs
+++ b/sapio-contrib/src/contracts/federated_sidechain.rs
@@ -69,17 +69,17 @@ impl StateDependentActions for FederatedPegIn<CanBeginRecovery> {
     }}
 }
 impl StateDependentActions for FederatedPegIn<CanFinishRecovery> {
-    guard! {finish_recovery |s, ctx| {
+    guard! {fn finish_recovery (s, ctx) {
         Clause::And(vec![Clause::Older(4725 /* 4 weeks? */), Clause::Threshold(s.thresh_recovery, s.keys_recovery.iter().cloned().map(Clause::Key).collect())])
     }}
 }
 
 impl<T: RecoveryState> FederatedPegIn<T> {
-    guard! {recovery_signed |s, ctx| {
+    guard! {fn recovery_signed (s, ctx) {
         Clause::Threshold(s.thresh_recovery, s.keys_recovery.iter().cloned().map(Clause::Key).collect())
     }}
 
-    guard! {normal_signed |s, ctx| {
+    guard! {fn normal_signed(s, ctx) {
         Clause::Threshold(s.thresh_normal, s.keys.iter().cloned().map(Clause::Key).collect())
     }}
 }

--- a/sapio-contrib/src/contracts/federated_sidechain.rs
+++ b/sapio-contrib/src/contracts/federated_sidechain.rs
@@ -55,15 +55,15 @@ where
 impl StateDependentActions for FederatedPegIn<CanBeginRecovery> {
     then! {
         guarded_by: [Self::recovery_signed]
-        fn begin_recovery(s, ctx) {
+        fn begin_recovery(self, ctx) {
         ctx.template().add_output(
-            s.amount.try_into()?,
+            self.amount.try_into()?,
             &FederatedPegIn::<CanFinishRecovery> {
-                keys: s.keys.clone(),
-                thresh_normal: s.thresh_normal,
-                keys_recovery: s.keys_recovery.clone(),
-                thresh_recovery: s.thresh_recovery,
-                amount: s.amount,
+                keys: self.keys.clone(),
+                thresh_normal: self.thresh_normal,
+                keys_recovery: self.keys_recovery.clone(),
+                thresh_recovery: self.thresh_recovery,
+                amount: self.amount,
                 _pd: PhantomData::default()
             },
             None

--- a/sapio-contrib/src/contracts/federated_sidechain.rs
+++ b/sapio-contrib/src/contracts/federated_sidechain.rs
@@ -54,7 +54,7 @@ where
 }
 impl StateDependentActions for FederatedPegIn<CanBeginRecovery> {
     then! {
-        [Self::recovery_signed]
+        guarded_by: [Self::recovery_signed]
         fn begin_recovery(s, ctx) {
         ctx.template().add_output(
             s.amount.try_into()?,

--- a/sapio-contrib/src/contracts/federated_sidechain.rs
+++ b/sapio-contrib/src/contracts/federated_sidechain.rs
@@ -69,18 +69,18 @@ impl StateDependentActions for FederatedPegIn<CanBeginRecovery> {
     }}
 }
 impl StateDependentActions for FederatedPegIn<CanFinishRecovery> {
-    guard! {fn finish_recovery (s, ctx) {
-        Clause::And(vec![Clause::Older(4725 /* 4 weeks? */), Clause::Threshold(s.thresh_recovery, s.keys_recovery.iter().cloned().map(Clause::Key).collect())])
+    guard! {fn finish_recovery(self, ctx) {
+        Clause::And(vec![Clause::Older(4725 /* 4 weeks? */), Clause::Threshold(self.thresh_recovery, self.keys_recovery.iter().cloned().map(Clause::Key).collect())])
     }}
 }
 
 impl<T: RecoveryState> FederatedPegIn<T> {
-    guard! {fn recovery_signed (s, ctx) {
-        Clause::Threshold(s.thresh_recovery, s.keys_recovery.iter().cloned().map(Clause::Key).collect())
+    guard! {fn recovery_signed (self, ctx) {
+        Clause::Threshold(self.thresh_recovery, self.keys_recovery.iter().cloned().map(Clause::Key).collect())
     }}
 
-    guard! {fn normal_signed(s, ctx) {
-        Clause::Threshold(s.thresh_normal, s.keys.iter().cloned().map(Clause::Key).collect())
+    guard! {fn normal_signed(self, ctx) {
+        Clause::Threshold(self.thresh_normal, self.keys.iter().cloned().map(Clause::Key).collect())
     }}
 }
 

--- a/sapio-contrib/src/contracts/hodl_chicken.rs
+++ b/sapio-contrib/src/contracts/hodl_chicken.rs
@@ -86,16 +86,16 @@ impl HodlChickenInner {
     guard! {fn bob_is_a_chicken(self, ctx) {Clause::Key(self.bob_key)}}
     then! {
         guarded_by: [Self::alice_is_a_chicken]
-        fn alice_redeem(s, ctx) {
+        fn alice_redeem(self, ctx) {
         ctx.template()
             .add_output(
-                Amount::from_sat(s.winner_gets),
-                &s.bob_contract.winner,
+                Amount::from_sat(self.winner_gets),
+                &self.bob_contract.winner,
                 None,
             )?
             .add_output(
-                Amount::from_sat(s.chicken_gets),
-                &s.alice_contract.loser,
+                Amount::from_sat(self.chicken_gets),
+                &self.alice_contract.loser,
                 None,
             )?
             .into()
@@ -103,16 +103,16 @@ impl HodlChickenInner {
 
     then! {
         guarded_by: [Self::bob_is_a_chicken]
-        fn bob_redeem(s, ctx) {
+        fn bob_redeem(self, ctx) {
             ctx.template()
                 .add_output(
-                    Amount::from_sat(s.winner_gets),
-                    &s.alice_contract.winner,
+                    Amount::from_sat(self.winner_gets),
+                    &self.alice_contract.winner,
                     None,
                 )?
                 .add_output(
-                    Amount::from_sat(s.chicken_gets),
-                    &s.bob_contract.loser,
+                    Amount::from_sat(self.chicken_gets),
+                    &self.bob_contract.loser,
                     None,
                 )?
                 .into()

--- a/sapio-contrib/src/contracts/hodl_chicken.rs
+++ b/sapio-contrib/src/contracts/hodl_chicken.rs
@@ -82,8 +82,8 @@ impl TryFrom<HodlChickenChecks> for HodlChickenInner {
 }
 
 impl HodlChickenInner {
-    guard! {fn alice_is_a_chicken(s, ctx) {Clause::Key(s.alice_key)}}
-    guard! {fn bob_is_a_chicken(s, ctx) {Clause::Key(s.bob_key)}}
+    guard! {fn alice_is_a_chicken(self, ctx) {Clause::Key(self.alice_key)}}
+    guard! {fn bob_is_a_chicken(self, ctx) {Clause::Key(self.bob_key)}}
     then! {alice_redeem [Self::alice_is_a_chicken] |s, ctx| {
         ctx.template()
             .add_output(

--- a/sapio-contrib/src/contracts/hodl_chicken.rs
+++ b/sapio-contrib/src/contracts/hodl_chicken.rs
@@ -82,8 +82,8 @@ impl TryFrom<HodlChickenChecks> for HodlChickenInner {
 }
 
 impl HodlChickenInner {
-    guard! {alice_is_a_chicken |s, ctx| {Clause::Key(s.alice_key)}}
-    guard! {bob_is_a_chicken |s, ctx| {Clause::Key(s.bob_key)}}
+    guard! {fn alice_is_a_chicken(s, ctx) {Clause::Key(s.alice_key)}}
+    guard! {fn bob_is_a_chicken(s, ctx) {Clause::Key(s.bob_key)}}
     then! {alice_redeem [Self::alice_is_a_chicken] |s, ctx| {
         ctx.template()
             .add_output(

--- a/sapio-contrib/src/contracts/hodl_chicken.rs
+++ b/sapio-contrib/src/contracts/hodl_chicken.rs
@@ -84,7 +84,7 @@ impl TryFrom<HodlChickenChecks> for HodlChickenInner {
 impl HodlChickenInner {
     guard! {fn alice_is_a_chicken(self, ctx) {Clause::Key(self.alice_key)}}
     guard! {fn bob_is_a_chicken(self, ctx) {Clause::Key(self.bob_key)}}
-    then! {alice_redeem [Self::alice_is_a_chicken] |s, ctx| {
+    then! {[Self::alice_is_a_chicken] fn alice_redeem(s, ctx) {
         ctx.template()
             .add_output(
                 Amount::from_sat(s.winner_gets),
@@ -99,7 +99,7 @@ impl HodlChickenInner {
             .into()
     }}
 
-    then! {bob_redeem [Self::bob_is_a_chicken] |s, ctx| {
+    then! {[Self::bob_is_a_chicken] fn bob_redeem(s, ctx) {
         ctx.template()
             .add_output(
                 Amount::from_sat(s.winner_gets),

--- a/sapio-contrib/src/contracts/hodl_chicken.rs
+++ b/sapio-contrib/src/contracts/hodl_chicken.rs
@@ -84,7 +84,9 @@ impl TryFrom<HodlChickenChecks> for HodlChickenInner {
 impl HodlChickenInner {
     guard! {fn alice_is_a_chicken(self, ctx) {Clause::Key(self.alice_key)}}
     guard! {fn bob_is_a_chicken(self, ctx) {Clause::Key(self.bob_key)}}
-    then! {[Self::alice_is_a_chicken] fn alice_redeem(s, ctx) {
+    then! {
+        guarded_by: [Self::alice_is_a_chicken]
+        fn alice_redeem(s, ctx) {
         ctx.template()
             .add_output(
                 Amount::from_sat(s.winner_gets),
@@ -99,20 +101,23 @@ impl HodlChickenInner {
             .into()
     }}
 
-    then! {[Self::bob_is_a_chicken] fn bob_redeem(s, ctx) {
-        ctx.template()
-            .add_output(
-                Amount::from_sat(s.winner_gets),
-                &s.alice_contract.winner,
-                None,
-            )?
-            .add_output(
-                Amount::from_sat(s.chicken_gets),
-                &s.bob_contract.loser,
-                None,
-            )?
-            .into()
-    }}
+    then! {
+        guarded_by: [Self::bob_is_a_chicken]
+        fn bob_redeem(s, ctx) {
+            ctx.template()
+                .add_output(
+                    Amount::from_sat(s.winner_gets),
+                    &s.alice_contract.winner,
+                    None,
+                )?
+                .add_output(
+                    Amount::from_sat(s.chicken_gets),
+                    &s.bob_contract.loser,
+                    None,
+                )?
+                .into()
+        }
+    }
 }
 
 impl Contract for HodlChickenInner {

--- a/sapio-contrib/src/contracts/readme_contracts.rs
+++ b/sapio-contrib/src/contracts/readme_contracts.rs
@@ -100,15 +100,15 @@ impl TrustlessEscrow {
     guard! {
     fn cooperate (self, ctx ) { Clause::And(vec![Clause::Key(self.alice), Clause::Key(self.bob)]) }
     }
-    then! {fn use_escrow(s, ctx) {
+    then! {fn use_escrow(self, ctx) {
         ctx.template()
             .add_output(
-                s.alice_escrow.0.try_into()?,
-                &Compiled::from_address(s.alice_escrow.1.clone(), None),
+                self.alice_escrow.0.try_into()?,
+                &Compiled::from_address(self.alice_escrow.1.clone(), None),
                 None)?
             .add_output(
-                s.bob_escrow.0.try_into()?,
-                &Compiled::from_address(s.bob_escrow.1.clone(), None),
+                self.bob_escrow.0.try_into()?,
+                &Compiled::from_address(self.bob_escrow.1.clone(), None),
                 None)?
             .set_sequence(0, RelTime::try_from(std::time::Duration::from_secs(10*24*60*60))?.into())?.into()
     }}

--- a/sapio-contrib/src/contracts/readme_contracts.rs
+++ b/sapio-contrib/src/contracts/readme_contracts.rs
@@ -100,7 +100,7 @@ impl TrustlessEscrow {
     guard! {
     fn cooperate (self, ctx ) { Clause::And(vec![Clause::Key(self.alice), Clause::Key(self.bob)]) }
     }
-    then! {use_escrow |s, ctx| {
+    then! {fn use_escrow(s, ctx) {
         ctx.template()
             .add_output(
                 s.alice_escrow.0.try_into()?,

--- a/sapio-contrib/src/contracts/readme_contracts.rs
+++ b/sapio-contrib/src/contracts/readme_contracts.rs
@@ -22,7 +22,7 @@ pub struct PayToPublicKey {
 }
 
 impl PayToPublicKey {
-    guard! {fn with_key(s, ctx) { Clause::Key(s.key) }}
+    guard! {fn with_key(self, ctx) { Clause::Key(self.key) }}
 }
 
 impl Contract for PayToPublicKey {
@@ -40,14 +40,14 @@ pub struct BasicEscrow {
 
 impl BasicEscrow {
     guard! {
-        fn redeem(s, ctx) {
+        fn redeem(self, ctx) {
             Clause::Threshold(
                 1,
                 vec![
-                    Clause::Threshold(2, vec![Clause::Key(s.alice), Clause::Key(s.bob)]),
+                    Clause::Threshold(2, vec![Clause::Key(self.alice), Clause::Key(self.bob)]),
                     Clause::And(vec![
-                        Clause::Key(s.escrow),
-                        Clause::Threshold(1, vec![Clause::Key(s.alice), Clause::Key(s.bob)]),
+                        Clause::Key(self.escrow),
+                        Clause::Threshold(1, vec![Clause::Key(self.alice), Clause::Key(self.bob)]),
                     ]),
                 ],
             )
@@ -70,15 +70,15 @@ pub struct BasicEscrow2 {
 
 impl BasicEscrow2 {
     guard! {
-        fn use_escrow(s, ctx) {
+        fn use_escrow(self, ctx) {
             Clause::And(vec![
-                Clause::Key(s.escrow),
-                Clause::Threshold(2, vec![Clause::Key(s.alice), Clause::Key(s.bob)]),
+                Clause::Key(self.escrow),
+                Clause::Threshold(2, vec![Clause::Key(self.alice), Clause::Key(self.bob)]),
             ])
         }
     }
     guard! {
-        fn cooperate(s, ctx) { Clause::And(vec![Clause::Key(s.alice), Clause::Key(s.bob)]) }
+        fn cooperate(self, ctx) { Clause::And(vec![Clause::Key(self.alice), Clause::Key(self.bob)]) }
     }
 }
 
@@ -98,7 +98,7 @@ pub struct TrustlessEscrow {
 
 impl TrustlessEscrow {
     guard! {
-    fn cooperate (s, ctx ) { Clause::And(vec![Clause::Key(s.alice), Clause::Key(s.bob)]) }
+    fn cooperate (self, ctx ) { Clause::And(vec![Clause::Key(self.alice), Clause::Key(self.bob)]) }
     }
     then! {use_escrow |s, ctx| {
         ctx.template()

--- a/sapio-contrib/src/contracts/readme_contracts.rs
+++ b/sapio-contrib/src/contracts/readme_contracts.rs
@@ -22,7 +22,7 @@ pub struct PayToPublicKey {
 }
 
 impl PayToPublicKey {
-    guard!(with_key | s, ctx | { Clause::Key(s.key) });
+    guard! {fn with_key(s, ctx) { Clause::Key(s.key) }}
 }
 
 impl Contract for PayToPublicKey {
@@ -39,9 +39,8 @@ pub struct BasicEscrow {
 }
 
 impl BasicEscrow {
-    guard!(
-        redeem | s,
-        ctx | {
+    guard! {
+        fn redeem(s, ctx) {
             Clause::Threshold(
                 1,
                 vec![
@@ -53,7 +52,7 @@ impl BasicEscrow {
                 ],
             )
         }
-    );
+    }
 }
 
 impl Contract for BasicEscrow {
@@ -70,19 +69,17 @@ pub struct BasicEscrow2 {
 }
 
 impl BasicEscrow2 {
-    guard!(
-        use_escrow | s,
-        ctx | {
+    guard! {
+        fn use_escrow(s, ctx) {
             Clause::And(vec![
                 Clause::Key(s.escrow),
                 Clause::Threshold(2, vec![Clause::Key(s.alice), Clause::Key(s.bob)]),
             ])
         }
-    );
-    guard!(
-        cooperate | s,
-        ctx | { Clause::And(vec![Clause::Key(s.alice), Clause::Key(s.bob)]) }
-    );
+    }
+    guard! {
+        fn cooperate(s, ctx) { Clause::And(vec![Clause::Key(s.alice), Clause::Key(s.bob)]) }
+    }
 }
 
 impl Contract for BasicEscrow2 {
@@ -100,10 +97,9 @@ pub struct TrustlessEscrow {
 }
 
 impl TrustlessEscrow {
-    guard!(
-        cooperate | s,
-        ctx | { Clause::And(vec![Clause::Key(s.alice), Clause::Key(s.bob)]) }
-    );
+    guard! {
+    fn cooperate (s, ctx ) { Clause::And(vec![Clause::Key(s.alice), Clause::Key(s.bob)]) }
+    }
     then! {use_escrow |s, ctx| {
         ctx.template()
             .add_output(

--- a/sapio-contrib/src/contracts/treepay.rs
+++ b/sapio-contrib/src/contracts/treepay.rs
@@ -29,7 +29,7 @@ pub struct TreePay {
 }
 
 impl TreePay {
-    then! {expand |s, ctx| {
+    then! {fn expand(s, ctx) {
         let mut builder = ctx.template();
         if s.participants.len() > s.radix {
 

--- a/sapio-contrib/src/contracts/treepay.rs
+++ b/sapio-contrib/src/contracts/treepay.rs
@@ -29,19 +29,19 @@ pub struct TreePay {
 }
 
 impl TreePay {
-    then! {fn expand(s, ctx) {
+    then! {fn expand(self, ctx) {
         let mut builder = ctx.template();
-        if s.participants.len() > s.radix {
+        if self.participants.len() > self.radix {
 
-            for c in s.participants.chunks(s.participants.len()/s.radix) {
+            for c in self.participants.chunks(self.participants.len()/self.radix) {
                 let mut amt =  bitcoin::util::amount::Amount::from_sat(0);
                 for Payment{amount, ..}  in c {
                     amt += amount.clone().try_into()?;
                 }
-                builder = builder.add_output(amt, &TreePay {participants: c.to_vec(), radix: s.radix}, None)?;
+                builder = builder.add_output(amt, &TreePay {participants: c.to_vec(), radix: self.radix}, None)?;
             }
         } else {
-            for Payment{amount, address} in s.participants.iter() {
+            for Payment{amount, address} in self.participants.iter() {
                 builder = builder.add_output((*amount).try_into()?, &Compiled::from_address(address.clone(), None), None)?;
             }
         }

--- a/sapio-contrib/src/contracts/undo_send.rs
+++ b/sapio-contrib/src/contracts/undo_send.rs
@@ -32,8 +32,7 @@ pub struct UndoSendInternal {
 
 impl UndoSendInternal {
     then!(
-        complete | s,
-        ctx | {
+        fn complete(s, ctx) {
             ctx.template()
                 .add_output(s.amount.try_into()?, &s.to_contract, None)?
                 .set_sequence(0, s.timeout)?
@@ -41,8 +40,7 @@ impl UndoSendInternal {
         }
     );
     then!(
-        undo | s,
-        ctx | {
+        fn undo (s, ctx) {
             ctx.template()
                 .add_output(s.amount.try_into()?, &s.from_contract, None)?
                 .into()

--- a/sapio-contrib/src/contracts/undo_send.rs
+++ b/sapio-contrib/src/contracts/undo_send.rs
@@ -32,17 +32,17 @@ pub struct UndoSendInternal {
 
 impl UndoSendInternal {
     then!(
-        fn complete(s, ctx) {
+        fn complete(self, ctx) {
             ctx.template()
-                .add_output(s.amount.try_into()?, &s.to_contract, None)?
-                .set_sequence(0, s.timeout)?
+                .add_output(self.amount.try_into()?, &self.to_contract, None)?
+                .set_sequence(0, self.timeout)?
                 .into()
         }
     );
     then!(
-        fn undo (s, ctx) {
+        fn undo (self, ctx) {
             ctx.template()
-                .add_output(s.amount.try_into()?, &s.from_contract, None)?
+                .add_output(self.amount.try_into()?, &self.from_contract, None)?
                 .into()
         }
     );

--- a/sapio-contrib/src/contracts/vault.rs
+++ b/sapio-contrib/src/contracts/vault.rs
@@ -28,7 +28,7 @@ pub struct Vault {
 }
 
 impl Vault {
-    then! {step |s, ctx| {
+    then! {fn step(s, ctx) {
         let builder = ctx.template()
         .add_output(s.amount_step.try_into()?,
                 &UndoSendInternal {
@@ -55,7 +55,7 @@ impl Vault {
             builder
         }.into()
     }}
-    then! {to_cold |s, ctx| {
+    then! {fn to_cold (s, ctx) {
         let amount = bitcoin::Amount::try_from(s.amount_step).map_err(|_e| contract::CompilationError::TerminateCompilation)?.checked_mul(s.n_steps).ok_or(contract::CompilationError::TerminateCompilation)?;
         ctx.template()
             .add_output(amount, &(s.cold_storage)(amount.into(), ctx)?, None)?

--- a/sapio-contrib/src/contracts/vault.rs
+++ b/sapio-contrib/src/contracts/vault.rs
@@ -28,26 +28,26 @@ pub struct Vault {
 }
 
 impl Vault {
-    then! {fn step(s, ctx) {
+    then! {fn step(self, ctx) {
         let builder = ctx.template()
-        .add_output(s.amount_step.try_into()?,
+        .add_output(self.amount_step.try_into()?,
                 &UndoSendInternal {
-                    from_contract: (s.cold_storage)(s.amount_step, ctx)?,
-                    to_contract: Compiled::from_address(s.hot_storage.clone(), None),
-                    timeout: s.mature,
-                    amount: s.amount_step.into(),
+                    from_contract: (self.cold_storage)(self.amount_step, ctx)?,
+                    to_contract: Compiled::from_address(self.hot_storage.clone(), None),
+                    timeout: self.mature,
+                    amount: self.amount_step.into(),
                 }, None)?
-       .set_sequence(0, s.timeout)?;
+       .set_sequence(0, self.timeout)?;
 
-        if s.n_steps > 1 {
-            let sub_amount = bitcoin::Amount::try_from(s.amount_step).map_err(|_e| contract::CompilationError::TerminateCompilation)?.checked_mul(s.n_steps - 1).ok_or(contract::CompilationError::TerminateCompilation)?;
+        if self.n_steps > 1 {
+            let sub_amount = bitcoin::Amount::try_from(self.amount_step).map_err(|_e| contract::CompilationError::TerminateCompilation)?.checked_mul(self.n_steps - 1).ok_or(contract::CompilationError::TerminateCompilation)?;
             let sub_vault = Vault {
-                cold_storage: s.cold_storage.clone(),
-                hot_storage: s.hot_storage.clone(),
-                n_steps: s.n_steps -1,
-                amount_step: s.amount_step,
-                timeout: s.timeout,
-                mature: s.mature,
+                cold_storage: self.cold_storage.clone(),
+                hot_storage: self.hot_storage.clone(),
+                n_steps: self.n_steps -1,
+                amount_step: self.amount_step,
+                timeout: self.timeout,
+                mature: self.mature,
 
             };
             builder.add_output(sub_amount, &sub_vault, None)?
@@ -55,10 +55,10 @@ impl Vault {
             builder
         }.into()
     }}
-    then! {fn to_cold (s, ctx) {
-        let amount = bitcoin::Amount::try_from(s.amount_step).map_err(|_e| contract::CompilationError::TerminateCompilation)?.checked_mul(s.n_steps).ok_or(contract::CompilationError::TerminateCompilation)?;
+    then! {fn to_cold (self, ctx) {
+        let amount = bitcoin::Amount::try_from(self.amount_step).map_err(|_e| contract::CompilationError::TerminateCompilation)?.checked_mul(self.n_steps).ok_or(contract::CompilationError::TerminateCompilation)?;
         ctx.template()
-            .add_output(amount, &(s.cold_storage)(amount.into(), ctx)?, None)?
+            .add_output(amount, &(self.cold_storage)(amount.into(), ctx)?, None)?
             .into()
     }}
 }

--- a/sapio/Cargo.toml
+++ b/sapio/Cargo.toml
@@ -25,6 +25,7 @@ schemars = "0.8.0"
 serde_json = "1.0"
 serde = "1.0"
 serde_derive = "1.0"
+paste = "1.0"
 
 [dependencies.bitcoin]
 package = "sapio-bitcoin"

--- a/sapio/src/contract/actions.rs
+++ b/sapio/src/contract/actions.rs
@@ -131,7 +131,7 @@ pub struct ThenFunc<'a, ContractSelf: 'a> {
 
 /// A function which by default finishes, but may receive some context object which can induce the
 /// generation of additional transactions (as a suggestion)
-pub struct FinishOrFunc<'a, ContractSelf: 'a, Extra> {
+pub struct FinishOrFunc<'a, ContractSelf: 'a, StatefulArguments> {
     /// Guards returns Clauses -- if any -- before the coins should be unlocked
     pub guard: GuardList<'a, ContractSelf>,
     /// conditional_compile_if returns ConditionallyCompileType to determine if a function
@@ -141,5 +141,5 @@ pub struct FinishOrFunc<'a, ContractSelf: 'a, Extra> {
     /// Implementors should aim to return as few `TxTmpl`s as possible for enhanced
     /// semantics, preferring to split across multiple `FinishOrFunc`'s.
     /// These `TxTmpl`s are non-binding, merely suggested.
-    pub func: fn(&ContractSelf, &Context, Option<&Extra>) -> TxTmplIt,
+    pub func: fn(&ContractSelf, &Context, Option<&StatefulArguments>) -> TxTmplIt,
 }

--- a/sapio/src/contract/macros.rs
+++ b/sapio/src/contract/macros.rs
@@ -67,9 +67,11 @@ macro_rules! declare {
 /// formats for calling are:
 /// ```ignore
 /// /// A Guarded CTV Function
-/// then!(name [guard_1, ... guard_n] |s| {/*Result<Box<Iterator<TransactionTemplate>>>*/} );
+/// then!(guarded_by: [guard_1, ... guard_n] fn name(self, ctx) {/*Result<Box<Iterator<TransactionTemplate>>>*/} );
+/// /// A Conditional CTV Function
+/// then!(compile_if: [compile_if_1, ... compile_if_n] fn name(self, ctx) {/*Result<Box<Iterator<TransactionTemplate>>>*/} );
 /// /// An Unguarded CTV Function
-/// then!(name |s| {/*Result<Box<Iterator<TransactionTemplate>>>*/} );
+/// then!(fn name(self, ctx) {/*Result<Box<Iterator<TransactionTemplate>>>*/} );
 /// /// Null Implementation
 /// then!(name);
 /// ```
@@ -156,9 +158,11 @@ macro_rules! then {
 /// formats for calling are:
 /// ```ignore
 /// /// A Guarded CTV Function
-/// finish!(name [guard_1, ... guard_n] |s| {/*Result<Box<Iterator<TransactionTemplate>>>*/} );
+/// finish!(guarded_by: [guard_1, ... guard_n] fn name(self, ctx, o) {/*Result<Box<Iterator<TransactionTemplate>>>*/} );
+/// /// A Conditional CTV Function
+/// finish!(compile_if: [compile_if_1, ... compile_if_n] fn name(self, ctx, o) {/*Result<Box<Iterator<TransactionTemplate>>>*/} );
 /// /// Null Implementation
-/// then!(name);
+/// finish!(name);
 /// ```
 /// Unlike a `then!`, `finish!` must always have guards.
 #[macro_export]
@@ -243,9 +247,9 @@ macro_rules! finish {
 /// The guard macro is used to define a `Guard`. Guards may be cached or uncached.
 /// formats for calling are:
 /// ```ignore
-/// guard!(name |s| {/*Clause*/})
+/// guard!(fn name(self, ctx) {/*Clause*/})
 /// /// The guard should only be invoked once
-/// guard!(cached name |s| {/*Clause*/})
+/// guard!(cached fn name(self, ctx) {/*Clause*/})
 /// ```
 #[macro_export]
 macro_rules! guard {
@@ -297,7 +301,7 @@ macro_rules! guard {
 /// The compile_if macro is used to define a `ConditionallyCompileIf`.
 /// formats for calling are:
 /// ```ignore
-/// compile_if!(name |s| {/*ConditionallyCompileType*/})
+/// compile_if!(fn name(self, ctx) {/*ConditionallyCompileType*/})
 /// ```
 #[macro_export]
 macro_rules! compile_if {

--- a/sapio/src/contract/macros.rs
+++ b/sapio/src/contract/macros.rs
@@ -171,12 +171,12 @@ macro_rules! finish {
         $crate::contract::macros::paste!{
 
             $(#[$meta])*
-            fn [<FINISH_ $name>](&self, _ctx:&$crate::contract::Context, $o: Option<&Args>)-> $crate::contract::TxTmplIt
+            fn [<FINISH_ $name>](&self, _ctx:&$crate::contract::Context, $o: Option<&<Self as $crate::contract::Contract>::StatefulArguments>)-> $crate::contract::TxTmplIt
             {
                 unimplemented!();
             }
             $(#[$meta])*
-            fn $name<'a>() -> Option<$crate::contract::actions::FinishOrFunc<'a, Self, Args>> {None}
+            fn $name<'a>() -> Option<$crate::contract::actions::FinishOrFunc<'a, Self, <Self as $crate::contract::Contract>::StatefulArguments>> {None}
         }
     };
     {
@@ -190,10 +190,10 @@ macro_rules! finish {
         $crate::contract::macros::paste!{
 
             $(#[$meta])*
-            fn [<FINISH_ $name>](&$s, $ctx:&$crate::contract::Context, $o: Option<&Args>) -> $crate::contract::TxTmplIt
+            fn [<FINISH_ $name>](&$s, $ctx:&$crate::contract::Context, $o: Option<&<Self as $crate::contract::Contract>::StatefulArguments>) -> $crate::contract::TxTmplIt
             $b
             $(#[$meta])*
-            fn $name<'a>() -> Option<$crate::contract::actions::FinishOrFunc<'a, Self, Args>>{
+            fn $name<'a>() -> Option<$crate::contract::actions::FinishOrFunc<'a, Self, <Self as $crate::contract::Contract>::StatefulArguments>>{
                 Some($crate::contract::actions::FinishOrFunc{
                     guard: &$guard_list,
                     conditional_compile_if: &$conditional_compile_list,

--- a/sapio/src/contract/macros.rs
+++ b/sapio/src/contract/macros.rs
@@ -173,7 +173,7 @@ macro_rules! guard {
      };
     {
         $(#[$meta:meta])*
-        $name:ident |$s:ident, $ctx:ident| $b:block} => {
+        fn $name:ident($s:ident, $ctx:ident) $b:block} => {
             $(#[$meta])*
             fn $name() -> Option<$crate::contract::actions::Guard<Self>> {
                 Some($crate::contract::actions::Guard::Fresh( |$s: &Self, $ctx: &$crate::contract::Context| $b))
@@ -181,7 +181,8 @@ macro_rules! guard {
         };
     {
         $(#[$meta:meta])*
-        cached $name:ident |$s:ident, $ctx:ident| $b:block} => {
+        cached
+        fn $name:ident($s:ident, $ctx:ident) $b:block} => {
             $(#[$meta])*
             fn $name() -> Option<$crate::contract::actions::Guard<Self>> {
                 Some($crate::contract::actions::Guard::Cache( |$s: &Self, $ctx:&$crate::contract::Context| $b))

--- a/sapio/src/contract/macros.rs
+++ b/sapio/src/contract/macros.rs
@@ -199,10 +199,11 @@ macro_rules! guard {
         $(#[$meta:meta])*
         fn $name:ident($s:ident, $ctx:ident) $b:block} => {
             $crate::contract::macros::paste!{
+                $(#[$meta])*
                 fn [<GUARD_ $name>](&$s, $ctx:&$crate::contract::Context) -> $crate::sapio_base::Clause
                 $b
                 $(#[$meta])*
-                    fn  $name() -> Option<$crate::contract::actions::Guard<Self>> {
+                fn  $name() -> Option<$crate::contract::actions::Guard<Self>> {
                     Some($crate::contract::actions::Guard::Fresh(Self::[<GUARD_ $name>]))
                 }
 
@@ -213,6 +214,7 @@ macro_rules! guard {
         cached
         fn $name:ident($s:ident, $ctx:ident) $b:block} => {
             $crate::contract::macros::paste!{
+                $(#[$meta])*
                 fn [<GUARD_ $name>](&$s, $ctx:&$crate::contract::Context) -> $crate::sapio_base::Clause
                 $b
 
@@ -236,6 +238,7 @@ macro_rules! compile_if {
         $name:ident
     } => {
             $crate::contract::macros::paste!{
+                $(#[$meta])*
                 fn [<COMPILE_IF $name>](&self, _ctx: &$crate::contract::Context) -> $crate::contract::actions::ConditionalCompileType {
                     unimplemented!()
                 }
@@ -250,6 +253,7 @@ macro_rules! compile_if {
         fn $name:ident($s:ident, $ctx:ident) $b:block
     } => {
             $crate::contract::macros::paste!{
+                $(#[$meta])*
                 fn [<COMPILE_IF $name>](&$s, $ctx: &$crate::contract::Context) -> $crate::contract::actions::ConditionalCompileType
                 $b
                 $(#[$meta])*

--- a/sapio/src/contract/macros.rs
+++ b/sapio/src/contract/macros.rs
@@ -93,8 +93,8 @@ macro_rules! then {
     };
     {
         $(#[$meta:meta])*
-        $conditional_compile_list:tt
-        $guard_list:tt
+        compile_if: $conditional_compile_list:tt
+        guarded_by: $guard_list:tt
         fn $name:ident($s:ident, $ctx:ident)
         $b:block
     } => {
@@ -120,19 +120,33 @@ macro_rules! then {
     } => {
         then!{
             $(#[$meta])*
-            [] []
+            compile_if: []
+            guarded_by: []
             fn $name($s, $ctx) $b
         }
     };
 
     {
         $(#[$meta:meta])*
-        $guard_list:tt
+        guarded_by: $guard_list:tt
         fn $name:ident($s:ident, $ctx:ident) $b:block
     } => {
         then!{
             $(#[$meta])*
-            [] $guard_list
+            compile_if: []
+            guarded_by: $guard_list
+            fn $name($s, $ctx) $b }
+    };
+
+    {
+        $(#[$meta:meta])*
+        compile_if: $conditional_compile_list:tt
+        fn $name:ident($s:ident, $ctx:ident) $b:block
+    } => {
+        then!{
+            $(#[$meta])*
+            compile_if: $conditional_compile_list
+            guarded_by: []
             fn $name($s, $ctx) $b }
     };
 

--- a/sapio/src/contract/macros.rs
+++ b/sapio/src/contract/macros.rs
@@ -79,13 +79,20 @@ macro_rules! then {
         $(#[$meta:meta])*
         $name:ident $conditional_compile_list:tt $guard_list:tt |$s:ident, $ctx:ident| $b:block
     } => {
-        $(#[$meta])*
-        fn $name<'a>() -> Option<$crate::contract::actions::ThenFunc<'a, Self>>{
-            Some($crate::contract::actions::ThenFunc{
-                guard: &$guard_list,
-                conditional_compile_if: &$conditional_compile_list,
-                func:|$s: &Self, $ctx:&$crate::contract::Context| $b
-            })
+
+        $crate::contract::macros::paste!{
+
+            $(#[$meta])*
+            fn [<THEN_ $name>]($s: &Self, $ctx:&$crate::contract::Context) -> $crate::contract::TxTmplIt
+            $b
+            $(#[$meta])*
+            fn $name<'a>() -> Option<$crate::contract::actions::ThenFunc<'a, Self>>{
+                Some($crate::contract::actions::ThenFunc{
+                    guard: &$guard_list,
+                    conditional_compile_if: &$conditional_compile_list,
+                    func: Self::[<THEN_ $name>]
+                })
+            }
         }
     };
     {
@@ -109,8 +116,17 @@ macro_rules! then {
     {
         $(#[$meta:meta])*
         $name:ident} => {
-        $(#[$meta])*
-        fn $name<'a>() -> Option<$crate::contract::actions::ThenFunc<'a, Self>> {None}
+
+        $crate::contract::macros::paste!{
+
+            $(#[$meta])*
+            fn [<THEN_ $name>](_s: &Self, _ctx:&$crate::contract::Context)-> $crate::contract::TxTmplIt
+            {
+                unimplemented!();
+            }
+            $(#[$meta])*
+            fn $name<'a>() -> Option<$crate::contract::actions::ThenFunc<'a, Self>> {None}
+        }
     };
 }
 

--- a/sapio/src/contract/macros.rs
+++ b/sapio/src/contract/macros.rs
@@ -171,12 +171,12 @@ macro_rules! finish {
         $crate::contract::macros::paste!{
 
             $(#[$meta])*
-            fn [<FINISH_ $name>](&self, _ctx:&$crate::contract::Context, $o: Option<&<Self as $crate::contract::Contract>::StatefulArguments>)-> $crate::contract::TxTmplIt
+            fn [<FINISH_ $name>](&self, _ctx:&$crate::contract::Context, $o: Option<&<Self as $crate::contract::AnyContract>::StatefulArguments>)-> $crate::contract::TxTmplIt
             {
                 unimplemented!();
             }
             $(#[$meta])*
-            fn $name<'a>() -> Option<$crate::contract::actions::FinishOrFunc<'a, Self, <Self as $crate::contract::Contract>::StatefulArguments>> {None}
+            fn $name<'a>() -> Option<$crate::contract::actions::FinishOrFunc<'a, Self, <Self as $crate::contract::AnyContract>::StatefulArguments>> {None}
         }
     };
     {
@@ -190,10 +190,10 @@ macro_rules! finish {
         $crate::contract::macros::paste!{
 
             $(#[$meta])*
-            fn [<FINISH_ $name>](&$s, $ctx:&$crate::contract::Context, $o: Option<&<Self as $crate::contract::Contract>::StatefulArguments>) -> $crate::contract::TxTmplIt
+            fn [<FINISH_ $name>](&$s, $ctx:&$crate::contract::Context, $o: Option<&<Self as $crate::contract::AnyContract>::StatefulArguments>) -> $crate::contract::TxTmplIt
             $b
             $(#[$meta])*
-            fn $name<'a>() -> Option<$crate::contract::actions::FinishOrFunc<'a, Self, <Self as $crate::contract::Contract>::StatefulArguments>>{
+            fn $name<'a>() -> Option<$crate::contract::actions::FinishOrFunc<'a, Self, <Self as $crate::contract::AnyContract>::StatefulArguments>>{
                 Some($crate::contract::actions::FinishOrFunc{
                     guard: &$guard_list,
                     conditional_compile_if: &$conditional_compile_list,

--- a/sapio/src/contract/macros.rs
+++ b/sapio/src/contract/macros.rs
@@ -77,7 +77,26 @@ macro_rules! declare {
 macro_rules! then {
     {
         $(#[$meta:meta])*
-        $name:ident $conditional_compile_list:tt $guard_list:tt |$s:ident, $ctx:ident| $b:block
+        $name:ident
+    } => {
+
+        $crate::contract::macros::paste!{
+
+            $(#[$meta])*
+            fn [<THEN_ $name>](_s: &Self, _ctx:&$crate::contract::Context)-> $crate::contract::TxTmplIt
+            {
+                unimplemented!();
+            }
+            $(#[$meta])*
+            fn $name<'a>() -> Option<$crate::contract::actions::ThenFunc<'a, Self>> {None}
+        }
+    };
+    {
+        $(#[$meta:meta])*
+        $conditional_compile_list:tt
+        $guard_list:tt
+        fn $name:ident($s:ident, $ctx:ident)
+        $b:block
     } => {
 
         $crate::contract::macros::paste!{
@@ -97,37 +116,26 @@ macro_rules! then {
     };
     {
         $(#[$meta:meta])*
-        $name:ident |$s:ident, $ctx:ident| $b:block
+        fn $name:ident($s:ident, $ctx:ident) $b:block
     } => {
         then!{
             $(#[$meta])*
-            $name [] [] |$s, $ctx| $b }
-    };
-
-    {
-        $(#[$meta:meta])*
-        $name:ident $guard_list:tt |$s:ident, $ctx:ident| $b:block
-    } => {
-        then!{
-            $(#[$meta])*
-            $name [] $guard_list |$s, $ctx| $b }
-    };
-
-    {
-        $(#[$meta:meta])*
-        $name:ident} => {
-
-        $crate::contract::macros::paste!{
-
-            $(#[$meta])*
-            fn [<THEN_ $name>](_s: &Self, _ctx:&$crate::contract::Context)-> $crate::contract::TxTmplIt
-            {
-                unimplemented!();
-            }
-            $(#[$meta])*
-            fn $name<'a>() -> Option<$crate::contract::actions::ThenFunc<'a, Self>> {None}
+            [] []
+            fn $name($s, $ctx) $b
         }
     };
+
+    {
+        $(#[$meta:meta])*
+        $guard_list:tt
+        fn $name:ident($s:ident, $ctx:ident) $b:block
+    } => {
+        then!{
+            $(#[$meta])*
+            [] $guard_list
+            fn $name($s, $ctx) $b }
+    };
+
 }
 
 /// The then macro is used to define a `FinishFunc` or a `FinishOrFunc`

--- a/sapio/src/contract/macros.rs
+++ b/sapio/src/contract/macros.rs
@@ -207,7 +207,7 @@ macro_rules! compile_if {
      };
     {
         $(#[$meta:meta])*
-        $name:ident |$s:ident, $ctx:ident| $b:block
+        fn $name:ident($s:ident, $ctx:ident) $b:block
     } => {
             $(#[$meta])*
             fn $name() -> Option<$crate::contract::actions::ConditionallyCompileIf<Self>> {

--- a/sapio/src/contract/macros.rs
+++ b/sapio/src/contract/macros.rs
@@ -208,18 +208,6 @@ macro_rules! finish {
     };
     {
         $(#[$meta:meta])*
-        fn $name:ident($s:ident, $ctx:ident, $o:ident) $b:block
-    } => {
-        finish!{
-            $(#[$meta])*
-            compile_if: []
-            guarded_by: []
-            fn $name($s, $ctx, $o) $b
-        }
-    };
-
-    {
-        $(#[$meta:meta])*
         guarded_by: $guard_list:tt
         fn $name:ident($s:ident, $ctx:ident, $o:ident) $b:block
     } => {
@@ -230,17 +218,6 @@ macro_rules! finish {
             fn $name($s, $ctx, $o) $b }
     };
 
-    {
-        $(#[$meta:meta])*
-        compile_if: $conditional_compile_list:tt
-        fn $name:ident($s:ident, $ctx:ident, $o:ident) $b:block
-    } => {
-        finish!{
-            $(#[$meta])*
-            compile_if: $conditional_compile_list
-            guarded_by: []
-            fn $name($s, $ctx, $o) $b }
-    };
 
 }
 

--- a/sapio/src/contract/macros.rs
+++ b/sapio/src/contract/macros.rs
@@ -6,6 +6,8 @@
 
 //! macros for making defining Sapio contracts less verbose.
 
+pub use paste::paste;
+
 /// The declare macro is used to declare the list of pathways in a Contract trait impl.
 /// formats for calling are:
 /// ```ignore
@@ -166,26 +168,42 @@ macro_rules! guard {
     {
         $(#[$meta:meta])*
         $name:ident} => {
-            $(#[$meta])*
-            fn $name() -> Option<$crate::contract::actions::Guard<Self>> {
-                None
+            $crate::contract::macros::paste!{
+                $(#[$meta])*
+                fn [<GUARD_ $name>](&self, _ctx:&$crate::contract::Context) -> $crate::sapio_base::Clause {
+                    unimplemented!();
+                }
+                $(#[$meta])*
+                fn $name() -> Option<$crate::contract::actions::Guard<Self>> {
+                    None
+                }
             }
      };
     {
         $(#[$meta:meta])*
         fn $name:ident($s:ident, $ctx:ident) $b:block} => {
-            $(#[$meta])*
-            fn $name() -> Option<$crate::contract::actions::Guard<Self>> {
-                Some($crate::contract::actions::Guard::Fresh( |$s: &Self, $ctx: &$crate::contract::Context| $b))
+            $crate::contract::macros::paste!{
+                fn [<GUARD_ $name>](&$s, $ctx:&$crate::contract::Context) -> $crate::sapio_base::Clause
+                $b
+                $(#[$meta])*
+                    fn  $name() -> Option<$crate::contract::actions::Guard<Self>> {
+                    Some($crate::contract::actions::Guard::Fresh(Self::[<GUARD_ $name>]))
+                }
+
             }
         };
     {
         $(#[$meta:meta])*
         cached
         fn $name:ident($s:ident, $ctx:ident) $b:block} => {
-            $(#[$meta])*
-            fn $name() -> Option<$crate::contract::actions::Guard<Self>> {
-                Some($crate::contract::actions::Guard::Cache( |$s: &Self, $ctx:&$crate::contract::Context| $b))
+            $crate::contract::macros::paste!{
+                fn [<GUARD_ $name>](&$s, $ctx:&$crate::contract::Context) -> $crate::sapio_base::Clause
+                $b
+
+                $(#[$meta])*
+                fn $name() -> Option<$crate::contract::actions::Guard<Self>> {
+                    Some($crate::contract::actions::Guard::Cache(Self::[<GUARD_ $name>]))
+                }
             }
         };
 }

--- a/sapio/src/contract/macros.rs
+++ b/sapio/src/contract/macros.rs
@@ -83,7 +83,7 @@ macro_rules! then {
         $crate::contract::macros::paste!{
 
             $(#[$meta])*
-            fn [<THEN_ $name>](_s: &Self, _ctx:&$crate::contract::Context)-> $crate::contract::TxTmplIt
+            fn [<THEN_ $name>](&self, _ctx:&$crate::contract::Context)-> $crate::contract::TxTmplIt
             {
                 unimplemented!();
             }
@@ -102,7 +102,7 @@ macro_rules! then {
         $crate::contract::macros::paste!{
 
             $(#[$meta])*
-            fn [<THEN_ $name>]($s: &Self, $ctx:&$crate::contract::Context) -> $crate::contract::TxTmplIt
+            fn [<THEN_ $name>](&$s, $ctx:&$crate::contract::Context) -> $crate::contract::TxTmplIt
             $b
             $(#[$meta])*
             fn $name<'a>() -> Option<$crate::contract::actions::ThenFunc<'a, Self>>{

--- a/sapio/src/contract/macros.rs
+++ b/sapio/src/contract/macros.rs
@@ -219,18 +219,27 @@ macro_rules! compile_if {
         $(#[$meta:meta])*
         $name:ident
     } => {
-            $(#[$meta])*
-            fn $name() -> Option<$crate::contract::actions::ConditionallyCompileIf<Self>> {
-                None
+            $crate::contract::macros::paste!{
+                fn [<COMPILE_IF $name>](&self, _ctx: &$crate::contract::Context) -> $crate::contract::actions::ConditionalCompileType {
+                    unimplemented!()
+                }
+                $(#[$meta])*
+                fn $name() -> Option<$crate::contract::actions::ConditionallyCompileIf<Self>> {
+                    None
+                }
             }
      };
     {
         $(#[$meta:meta])*
         fn $name:ident($s:ident, $ctx:ident) $b:block
     } => {
-            $(#[$meta])*
-            fn $name() -> Option<$crate::contract::actions::ConditionallyCompileIf<Self>> {
-                Some($crate::contract::actions::ConditionallyCompileIf::Fresh( |$s: &Self, $ctx: &$crate::contract::Context| $b))
+            $crate::contract::macros::paste!{
+                fn [<COMPILE_IF $name>](&$s, $ctx: &$crate::contract::Context) -> $crate::contract::actions::ConditionalCompileType
+                $b
+                $(#[$meta])*
+                fn $name() -> Option<$crate::contract::actions::ConditionallyCompileIf<Self>> {
+                    Some($crate::contract::actions::ConditionallyCompileIf::Fresh(Self::[<COMPILE_IF $name>]))
+                }
             }
         };
 }

--- a/sapio/src/lib.rs
+++ b/sapio/src/lib.rs
@@ -13,3 +13,5 @@ extern crate serde;
 pub mod contract;
 pub mod template;
 pub mod util;
+
+pub use sapio_base;


### PR DESCRIPTION
This PR dramatically improves the syntax for the macros in Sapio to look more like standard rust code.

This is prep work for converting to proc macros