### PR TITLE
Decentralized Coordination Free Minining Pool

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.48.0
+          - 1.50.0
           - beta
           - stable
     steps:
@@ -71,8 +71,8 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - name: Pin cc if rust 1.48
-        if: matrix.rust == '1.48.0'
+      - name: Pin cc if rust 1.50
+        if: matrix.rust == '1.50.0'
         run: cargo generate-lockfile
       - name: Running cargo
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["sapio", "sapio-ws", "sapio-front", "sapio-contrib", "ctv_emulators", "sapio-base", "cli", "tools", "plugins", 'emulator-trait']
+members = ["sapio", "sapio-ws", "sapio-front", "sapio-contrib", "ctv_emulators", "sapio-base", "cli", "tools", "plugins", 'emulator-trait', 'examples/dcf_mining_pool']
 exclude = ["plugin-example", "integration_tests"]

--- a/examples/dcf_mining_pool/Cargo.toml
+++ b/examples/dcf_mining_pool/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "dcf_mining_pool"
+version = "0.1.0"
+authors = ["Jeremy Rubin <j@rubin.io>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+
+schemars = "0.8.0"
+serde_json = "1.0"
+serde = "1.0"
+serde_derive = "1.0"
+tokio = { version = "1", features = ["full"] }
+bitcoincore-rpc-async = "3.0.1"
+
+[dependencies.wasm-bindgen]
+version = "0.2.69"
+
+[dependencies.bitcoin]
+package = "sapio-bitcoin"
+version = "^0.26.0"
+features = ['use-serde', 'rand']
+[dependencies.sapio]
+path = "../../sapio"
+version = "0.1.0"
+
+[dependencies.sapio-base]
+path = "../../sapio-base"
+version = "0.1.0"
+
+
+
+[dependencies.sapio-ctv-emulator-trait]
+path="../../emulator-trait"
+version = "0.1.0"
+
+[dependencies.miniscript]
+package = "sapio-miniscript"
+version = "^5.1.0"
+features = ['compiler', 'use-serde', 'rand', 'use-schemars', 'serde']
+optional = true
+

--- a/examples/dcf_mining_pool/src/main.rs
+++ b/examples/dcf_mining_pool/src/main.rs
@@ -1,0 +1,214 @@
+// Copyright Judica, Inc 2021
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+//  License, v. 2.0. If a copy of the MPL was not distributed with this
+//  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+use crate::contract::Context;
+use crate::miner_payout::MiningPayout;
+use crate::miner_payout::PoolShare;
+use bitcoin::hash_types::BlockHash;
+use bitcoin::Address;
+use bitcoin::Amount;
+use bitcoin::Block;
+use bitcoin::PublicKey;
+use bitcoin::Script;
+use bitcoincore_rpc_async as rpc;
+use rpc::RpcApi;
+use sapio::contract::Compilable;
+use sapio::contract::Contract;
+use sapio::*;
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::RwLock;
+
+mod miner_payout;
+struct BlockNotes {
+    block: Block,
+    key: Option<PublicKey>,
+    participated: Option<bool>,
+    reward: Amount,
+}
+impl BlockNotes {
+    fn from_block(block: Block) -> BlockNotes {
+        let mut key = None;
+        // Extract key from first OP_RETURN 123 45 67 89 <33 bytes>
+        if let Some(coinbase) = block.coinbase() {
+            for out in coinbase.output.iter() {
+                if out.script_pubkey.is_op_return() {
+                    match out.script_pubkey.as_bytes() {
+                        [OP_RETURN, 123, 45, 67, 89, tail @ ..] => {
+                            if tail.len() == 33 {
+                                key = PublicKey::from_slice(tail).ok();
+                                if key.is_some() {
+                                    break;
+                                }
+                            }
+                        }
+                        _ => continue,
+                    }
+                }
+            }
+        }
+        let participated = if key.is_none() { Some(false) } else { None };
+        BlockNotes {
+            block,
+            key,
+            participated,
+            reward: Amount::from_sat(0),
+        }
+    }
+}
+struct Coordinator {
+    cache: HashMap<BlockHash, Arc<RwLock<BlockNotes>>>,
+    client: rpc::Client,
+    ctx: Context,
+}
+
+impl Coordinator {
+    async fn compute_for_block(
+        &mut self,
+        tip_in: &BlockHash,
+        n: usize,
+    ) -> Result<bool, Box<dyn std::error::Error>> {
+        let mut tip = *tip_in;
+        let mut to_scan = vec![];
+        // ensure our cache has all relevant info
+        let cache = &mut self.cache;
+        for i in 0..n {
+            let locked_note = match cache.entry(tip) {
+                Entry::Occupied(o) => o.into_mut(),
+                Entry::Vacant(v) => {
+                    let block = self.client.get_block(&tip).await?;
+                    let mut note = BlockNotes::from_block(block);
+                    if note.key.is_some() {
+                        let stats: serde_json::Value = self
+                            .client
+                            .call("getblockstats", &[serde_json::to_value(tip)?])
+                            .await?;
+                        let subsidy = stats
+                            .get("subsidy")
+                            .and_then(serde_json::Value::as_u64)
+                            .ok_or("blockstates error")?;
+                        let fee = stats
+                            .get("totalfee")
+                            .and_then(serde_json::Value::as_u64)
+                            .ok_or("blockstats error")?;
+                        note.reward = Amount::from_sat(fee + subsidy);
+                    }
+                    v.insert(Arc::new(RwLock::new(note)))
+                }
+            };
+            let note = locked_note.read().unwrap();
+            // fast response of the block has no key definitely no participating
+            if i == 0 && note.participated == Some(false) {
+                return Ok(false);
+            }
+            // get stats for these blocks...
+            if note.key.is_some() && note.participated.is_none() {
+                // scan all contendors except the first tip
+                if i > 0 {
+                    to_scan.push(locked_note.clone());
+                }
+            }
+            tip = note.block.header.prev_blockhash;
+        }
+        // scan all the parents we aren't sure about
+        // goes from oldest to newest
+        while let Some(scan) = to_scan.pop() {
+            let h = scan.read().unwrap().block.block_hash();
+            let v: Pin<Box<dyn Future<Output = _>>> = Box::pin(self.compute_for_block(&h, n));
+            v.await;
+        }
+
+        let mut tip = *tip_in;
+        let mut known_participants = vec![];
+        // ensure our cache has all relevant info
+        for i in 0..n {
+            let note = self.cache[&tip].clone();
+            let note_r = note.read().unwrap();
+            if note_r.participated == Some(true) {
+                std::mem::drop(note_r);
+                known_participants.push(note);
+            }
+        }
+        let mp = MiningPool {
+            blocks: known_participants,
+            tip: self.cache[tip_in].clone(),
+        };
+        let output = mp.compile(&self.ctx.with_amount(mp.tip.read().unwrap().reward)?)?;
+        let script: Script = output.address.into();
+
+        let mut result = false;
+        if let Some(coinbase) = mp.tip.read().unwrap().block.coinbase() {
+            for out in coinbase.output.iter() {
+                if out.script_pubkey == script && out.value == output.amount_range.max().as_sat() {
+                    result = true;
+                    break;
+                }
+            }
+        }
+        let mut tip = mp.tip.write().unwrap();
+        tip.participated = Some(result);
+        return Ok(result);
+    }
+}
+
+use std::sync::{Arc, Mutex};
+struct MiningPool {
+    blocks: Vec<Arc<RwLock<BlockNotes>>>,
+    tip: Arc<RwLock<BlockNotes>>,
+}
+
+use sapio::contract::error::CompilationError;
+impl MiningPool {
+    then! {
+        fn pay_miners(self, ctx) {
+            let mut blocks = self.blocks.clone();
+            blocks.push(self.tip.clone());
+            blocks.sort_by_cached_key(|a| {
+                a.read().unwrap().block
+                .header
+                .block_hash()
+            });
+            let participants : Vec<PoolShare> = blocks.iter().map(|note|
+                Ok(PoolShare {
+                    amount: Amount::from_sat(0),
+                    // guaranteed if here to have a pk
+                    key: note.read().unwrap().key.unwrap()
+                })
+            ).collect::<Result<_,CompilationError>>()?;
+            let mut ctx_extra_funding :Context= ctx.clone();
+            ctx_extra_funding.add_amount(Amount::from_btc(21_000_000.0).unwrap());
+
+            let mut contract = MiningPayout {
+                    /// all of the payments needing to be sent
+                    participants,
+                    radix: 4,
+                    fee_sats_per_tx: Amount::from_sat(100),
+                };
+            let fee_estimate =
+                contract.compile(ctx)?.amount_range.max();
+            let reward = self.tip.read().unwrap().reward - fee_estimate;
+            let reward_per_miner = ( reward) / (blocks.len() as u64);
+
+            for reward in contract.participants.iter_mut() {
+                reward.amount = reward_per_miner;
+            }
+            ctx.template().add_output(
+                reward,
+                &contract,
+                None
+            )?.into()
+        }
+    }
+}
+impl Contract for MiningPool {
+    declare! {then, Self::pay_miners}
+    declare! {non updatable}
+}
+
+fn main() {
+    loop {}
+}

--- a/examples/dcf_mining_pool/src/miner_payout.rs
+++ b/examples/dcf_mining_pool/src/miner_payout.rs
@@ -1,0 +1,151 @@
+// Copyright Judica, Inc 2021
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+//  License, v. 2.0. If a copy of the MPL was not distributed with this
+//  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+use bitcoin::Address;
+use bitcoin::PublicKey;
+use sapio::contract::*;
+use sapio::util::amountrange::*;
+use sapio::*;
+use sapio_base::Clause;
+use schemars::*;
+use serde::*;
+use std::collections::VecDeque;
+/// A payment to a specific address
+#[derive(JsonSchema, Serialize, Deserialize, Clone)]
+pub struct PoolShare {
+    /// The amount to send
+    #[serde(with = "bitcoin::util::amount::serde::as_btc")]
+    #[schemars(with = "f64")]
+    pub amount: bitcoin::util::amount::Amount,
+    /// # Address
+    /// The Address to send to
+    pub key: bitcoin::PublicKey,
+}
+/// Documentation placed here will be visible to users!
+#[derive(JsonSchema, Serialize, Deserialize)]
+pub struct MiningPayout {
+    /// all of the payments needing to be sent
+    pub participants: Vec<PoolShare>,
+    /// the radix of the tree to build. Optimal for users should be around 4 or
+    /// 5 (with CTV, not emulators).
+    pub radix: usize,
+    #[serde(with = "bitcoin::util::amount::serde::as_sat")]
+    #[schemars(with = "u64")]
+    pub fee_sats_per_tx: bitcoin::util::amount::Amount,
+}
+
+use bitcoin::util::amount::Amount;
+trait CoopKeys {
+    fn get_keys(&self) -> Vec<PublicKey>;
+}
+trait PayThisThing: CoopKeys {
+    fn as_compilable(&self) -> &dyn Compilable;
+}
+
+struct JustAKey(PublicKey, Box<dyn Compilable>);
+impl CoopKeys for JustAKey {
+    fn get_keys(&self) -> Vec<PublicKey> {
+        vec![self.0.clone()]
+    }
+}
+impl JustAKey {
+    fn new(payment: &PoolShare, ctx: &Context) -> Result<Self, CompilationError> {
+        let mut amt = AmountRange::new();
+        amt.update_range(payment.amount);
+        let address = Address::p2wpkh(&payment.key, ctx.network)
+            .map_err(|_| CompilationError::TerminateCompilation)?;
+        let b: Box<dyn Compilable> = Box::new(Compiled::from_address(address, Some(amt)));
+        Ok(JustAKey(payment.key, b))
+    }
+}
+impl PayThisThing for JustAKey {
+    fn as_compilable(&self) -> &dyn Compilable {
+        self.1.as_ref()
+    }
+}
+struct PayoutBundle {
+    contracts: Vec<(Amount, Box<dyn PayThisThing>)>,
+    fees: Amount,
+}
+impl CoopKeys for PayoutBundle {
+    fn get_keys(&self) -> Vec<PublicKey> {
+        let mut v = vec![];
+        for c in self.contracts.iter() {
+            v.append(&mut c.1.get_keys());
+        }
+        v
+    }
+}
+impl PayThisThing for PayoutBundle {
+    fn as_compilable(&self) -> &dyn Compilable {
+        self
+    }
+}
+impl PayoutBundle {
+    guard! {
+        fn cooperate(self, ctx) {
+           let v : Vec<_>= self.get_keys().into_iter().map(Clause::Key).collect();
+           Clause::Threshold(v.len(), v)
+        }
+    }
+    then! {
+        fn expand(self, ctx) {
+            let mut bld = ctx.template();
+            for (amt, ct) in self.contracts.iter() {
+                bld = bld.add_output(*amt, ct.as_compilable(), None)?;
+            }
+            bld.add_fees(self.fees)?.into()
+        }
+    }
+
+    fn total_to_pay(&self) -> Amount {
+        let mut amt = self.fees;
+        for (x, _) in self.contracts.iter() {
+            amt += *x;
+        }
+        amt
+    }
+}
+impl Contract for PayoutBundle {
+    declare! {then, Self::expand}
+    declare! {finish, Self::cooperate}
+    declare! {non updatable}
+}
+impl MiningPayout {
+    guard! {
+        fn cooperate(self, ctx) {
+           let v : Vec<_>= self.participants.iter().map(|x|Clause::Key(x.key.clone())).collect();
+           Clause::Threshold(v.len(), v)
+        }
+    }
+    then! {
+        fn expand(self, ctx) {
+
+            let mut queue : VecDeque<(Amount, Box<dyn PayThisThing>)> = self.participants.iter().map(|payment| {
+                let b: Box<dyn PayThisThing> = Box::new(JustAKey::new(payment, ctx)?);
+                Ok((payment.amount, b))
+            }).collect::<Result<VecDeque<_>, CompilationError>>()?;
+
+            loop {
+                let v : Vec<_> = queue.drain(0..std::cmp::min(self.radix, queue.len())).collect();
+                if queue.len() == 0 {
+                    let mut builder = ctx.template();
+                    for pay in v.iter() {
+                        builder = builder.add_output(pay.0, pay.1.as_compilable(), None)?;
+                    }
+                    builder =builder.add_fees(self.fee_sats_per_tx)?;
+                    return builder.into();
+                } else {
+                    let pay = Box::new(PayoutBundle{contracts:v, fees: self.fee_sats_per_tx});
+                    queue.push_back((pay.total_to_pay(), pay))
+                }
+            }
+    }}
+}
+impl Contract for MiningPayout {
+    declare! {then, Self::expand}
+    declare! {finish, Self::cooperate}
+    declare! {non updatable}
+}

--- a/sapio-front/src/session.rs
+++ b/sapio-front/src/session.rs
@@ -5,11 +5,11 @@
 //  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 //! An interactive compilation session designed to be compatible with sapio-lang/TUX
-use sapio::util::extended_address::ExtendedAddress;
 use bitcoin::hashes::hex::ToHex;
 use bitcoin::hashes::Hash;
 use bitcoin::util::amount::Amount;
 use sapio::contract::{Compilable, CompilationError, Compiled, Context};
+use sapio::util::extended_address::ExtendedAddress;
 use sapio_ctv_emulator_trait::CTVAvailable;
 use schemars::schema::RootSchema;
 use schemars::JsonSchema;
@@ -173,11 +173,7 @@ impl Action {
                         .collect(),
                 };
                 println!("{:?}", program);
-                Some(Reaction::Created(
-                    c.amount_range.max(),
-                    a,
-                    program,
-                ))
+                Some(Reaction::Created(c.amount_range.max(), a, program))
             }
             Action::Save(_address) => Some(Reaction::Saved(true)),
             Action::Bind(_out, _address) => Some(Reaction::Bound(vec![])),

--- a/sapio/src/contract/compiler.rs
+++ b/sapio/src/contract/compiler.rs
@@ -272,15 +272,17 @@ where
         };
 
         let miniscript = policy.compile().map_err(Into::<CompilationError>::into)?;
-        let address = bitcoin::Address::p2wsh(&miniscript.encode(), ctx.network);
-        let descriptor = Some(Descriptor::new_wsh(miniscript)?);
+        let descriptor = Descriptor::new_wsh(miniscript)?;
+        let address = descriptor.address(ctx.network)?.into();
+        let descriptor = Some(descriptor);
+        let policy = Some(policy);
 
         Ok(Compiled {
             ctv_to_tx,
             suggested_txs,
-            address: address.into(),
+            address,
             descriptor,
-            policy: Some(policy),
+            policy,
             amount_range,
         })
     }

--- a/sapio/src/contract/context.rs
+++ b/sapio/src/contract/context.rs
@@ -15,6 +15,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 /// Context is used to track statet during compilation such as remaining value.
 /// Context type is not copyable/clonable externally
+#[derive(Clone)]
 pub struct Context {
     /* TODO: Add Context Fields! */
     available_funds: Amount,

--- a/sapio/src/contract/object.rs
+++ b/sapio/src/contract/object.rs
@@ -5,9 +5,9 @@
 //  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 //! Object is the output of Sapio Compilation & can be linked to a specific coin
-use crate::util::extended_address::ExtendedAddress;
 use crate::template::Template;
 use crate::util::amountrange::AmountRange;
+use crate::util::extended_address::ExtendedAddress;
 use ::miniscript::{self, *};
 
 use bitcoin::hashes::sha256;


### PR DESCRIPTION
Implements PoC Functionality described in https://utxos.org/uses/miningpools/

TODO:

- [ ] Add logic for creating block templates & printing the header to stdout
- [ ] Make payouts into channels
- [ ] Add cut-through functionality https://docs.google.com/presentation/d/1tmvv3og8Hs-1h6JMlePmlMouycN1RM_MBWdQp7taKuw/edit#slide=id.g9b0b672a9f_1_8


![](https://utxos.org/images/uses/bagpool.svg)


In a typical mining pool, miners works together to create a shared block reward. The shared reward
is distributed among participants based on difficulty shares, that is, partial work proofs that
"prove" a miner was working on an appropriate block.

An appropriate block pays the reward to the pool operator, who then distributes (less a fee) the
rewards to the other miners.

Using `OP_CHECKTEMPLATEVERIFY`, miners can instead look at a set of *qualified* historical blocks
deterministically (e.g., the last N, or all blocks not older than some time T, or blocks between T1
and T2) and share their block reward with the miner behind those blocks. `OP_CHECKTEMPLATEVERIFY` is
an enabling technology here because it is cheap to issue remittences to all of these miners. A block
would be considered qualified if it also followed the same pooling rule.

To participate in such a pool, a miner has to have enough hashpower to mine at least one block to
enter the pool. Then, the system can reduce the variance that a miner is exposed to, as demonstrated
in the picture. Trusted mining pools can still exist to get miners up to a reasonable level of
hashrate to participate in the trustless pools effectively, but these pools would be smaller and
bear less risk.

This type of mining pool has no trusted operator and requires no coordination. This eliminates
various types of mining pool attacks, such as block witholding.

The below code shows a simple simulation of experienced variances among a set of miners with a fixed
sharing policy versus a set of miners without any sharing.

```python
import numpy as np
from matplotlib import pyplot as plt
# TODO: Handle halvings?
BLOCK_REWARD = 12.5
STANDARD_SHARE = 0.75

AVG_INTERVAL = 10.0*60.0
class Block:
    def __init__(self, miner_id, height, shares, percent_shares, reward, lookback, time):
        self.miner_id = miner_id
        self.height = height
        self.shares = shares
        # Compute our personal take of the revenue
        self.revenue = (1-percent_shares)*reward if shares else reward
        self.percent_shares = percent_shares
        self.shares = []
        self.time = time
        if percent_shares != 0 and shares:
            total_avail = percent_shares * reward
            total_percent = sum(block.percent_shares for block in lookback)
            # If the prior blocks were in the pool
            if total_percent != 0:
                # Pay past miners something for their help
                # based on the percent they shared of the total percent shared to us.
                # TODO: Maybe EWMA is better than straight average?
                self.shares = [(block.miner_id, block.percent_shares/total_percent * total_avail)
                                for block in lookback]
            else:
                # Before the pool exists...
                # We still give them something (to solve the bootstrap problem...)
                # This could be done by issuing forward-looking block height locked payments
                # to future miners or by one-time coordination
                self.shares = [(block.miner_id, 1.0/len(lookback) * total_avail) 
                                for block in lookback]


def sim(n_miners = 100, p_shares = 0.5,
        n_blocks = 10000, n_blocks_lookback=144,
        share_amt = 143.0/144, power=1.5):
    # Make an array of miners IDs
    miners = np.array(range(n_miners))

    # Distribute hashrate on some power law and normalize so probabilities sum to 1
    miner_hashrate = np.random.power(power, n_miners)
    miner_hashrate /= np.sum(miner_hashrate)

    # Flip a biased coin to determine if a miner is in the pool or not
    miner_shares = np.random.random(n_miners) <= p_shares

    # A list of all blocks (a... block... chain)
    blocks = []
    # A queue for just the last n_blocks_lookback sharing blocks
    sharing_blocks = []
    block_time = 0
    # Initialize the sharing blocks queue
    while len(sharing_blocks) == 0 or 
        sharing_blocks[-1].time-sharing_blocks[0].time >= n_blocks_lookback*AVG_INTERVAL:

        miner = np.random.choice(miners, p = miner_hashrate)
        block_time += np.random.poisson(AVG_INTERVAL)
        # we share 0 percent here because we don't know how many there are...
        blocks.append(Block(miner, len(blocks), miner_shares[miner],
                      0.0, BLOCK_REWARD, sharing_blocks, block_time))
        if miner_shares[miner]:
            sharing_blocks.append(blocks[-1])

    # Now mine n_blocks
    for x in range(n_blocks):
        miner = np.random.choice(miners, p = miner_hashrate)
        block_time += np.random.poisson(AVG_INTERVAL)
        blocks.append(Block(miner, len(blocks), miner_shares[miner],
                            share_amt, BLOCK_REWARD, sharing_blocks, block_time))
        if miner_shares[miner]:
            sharing_blocks.append(blocks[-1])
            if sharing_blocks[-1].time-sharing_blocks[0].time >= 
                n_blocks_lookback*AVG_INTERVAL:
                sharing_blocks.pop(0)
    tabulate_and_show(n_miners, miner_shares, miner_hashrate, blocks)
# Compute the revenues
def tabulate_and_show(n_miners, miner_shares, miner_hashrate, blocks):
    # have a column for each miner with space for an entry per block
    revenues = np.zeros((n_miners, len(blocks)))
    for block in blocks:
        h = block.height
        # give the miner their revenue
        revenues[block.miner_id, h] += block.revenue
        # if the block shares, assign the shares to each miner
        for (to, amt) in block.shares:
            revenues[to, h] += amt
    # Compute the column variance on the revenues
    norm = np.outer(miner_hashrate, BLOCK_REWARD* np.ones((len(blocks)))).clip(1)
    var = np.var(revenues/norm , axis=1)
    # Show the averages for just the sharing miners
    # and then just the non sharing miners
    # TODO: better measure of difference than average?
    #       Perhaps weighted average by hashrate?
    print("Avg var, sharing miners %f"% (np.sqrt(np.average(var*miner_shares))/70.0))
    print("Avg var, solo miners %f"%(np.sqrt(np.average(var*(miner_shares ^ 1)))/70.0))
    # cumsum the instantaneous revenues to get something nice for charting
    chart = np.cumsum(revenues, axis=1)

    fig, host = plt.subplots()
    host.set_title("Decentralized Pool Visualization ")
    host.set_xlabel("Blocks")
    host.set_ylabel("Adjusted Normalized Revenue:\n(R / max(E[R], 1))")
    host.set_ylim(0.8,1.2)
    for (i,col) in enumerate(chart):
        # Show pooled miners as dotted, not pooled as unbroken
        earnings = (np.array(range(len(blocks)))*miner_hashrate[i]*BLOCK_REWARD).clip(1)
        if miner_shares[i]:
            host.plot(np.array(range(10000)), ((col/earnings)- 0.1)[-10001:-1], 'k')
        else:
            host.plot(range(10000), ((col/earnings)+0.1)[-10001:-1], 'r')
    plt.show()


plt.rcParams["font.size"] = "30"
sim(100, 0.5, 100000, 144*3, 1.0, 2)
```
