### PR TITLE
examples/dcf_mining_pool: fix match on OP_RETURN

### DIFF
--- a/examples/dcf_mining_pool/src/main.rs
+++ b/examples/dcf_mining_pool/src/main.rs
@@ -38,7 +38,7 @@ impl BlockNotes {
             for out in coinbase.output.iter() {
                 if out.script_pubkey.is_op_return() {
                     match out.script_pubkey.as_bytes() {
-                        [OP_RETURN, 123, 45, 67, 89, tail @ ..] => {
+                        [106, 123, 45, 67, 89, tail @ ..] => {
                             if tail.len() == 33 {
                                 key = PublicKey::from_slice(tail).ok();
                                 if key.is_some() {


### PR DESCRIPTION
Turn a wildcard variable match into an explicit match on the OP_RETURN
value. This was caught by an unused variable warning.
