### PR TITLE
Add fee_sats_per_tx

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Follow this quickstart guide to get going.
 1.  Get the [wasm-pack](https://rustwasm.github.io/wasm-pack/) tool.
 1.  Clone this repo: `git clone git@github.com:sapio-lang/sapio.git && cd sapio`
 1.  Build the plugin `cd plugin-example && wasm-pack build && cd ..`
-1.  Instantiate a contract from the plugin: `cargo run --bin sapio-cli -- contract create 9.99 "{\"participants\": [{\"amount\": 9.99, \"address\": \"bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw\"}], \"radix\": 2}" --file="plugin-example/pkg/sapio_wasm_plugin_example_bg.wasm"` to see some magic!
+1.  Instantiate a contract from the plugin: `cargo run --bin sapio-cli -- contract create 9.99 "{\"participants\": [{\"amount\": 9.99, \"address\": \"bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw\"}], \"radix\": 2, \"fee_sats_per_tx\": "0"}" --file="plugin-example/pkg/sapio_wasm_plugin_example_bg.wasm"` to see some magic!
 
 You can use `cargo run --bin sapio-cli -- help` to learn more about what a the CLI can do! and `cargo run --bin sapio-cli -- <subcommand> help` to learn about subcommands like `contract`.
 


### PR DESCRIPTION
Fixes this error

```
Running `target/debug/sapio-cli contract create 9.99 '{"participants": [{"amount": 9.99, "address": "bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw"}], "radix": 2}' --file=plugin-example/pkg/sapio_wasm_plugin_example_bg.wasm`
Error: Required properties "fee_sats_per_tx" are missing
At instance path /:
  {
    "participants": [
      {
        "address": "bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw",
        "amount": 9.99
      }
    ],
    "radix": 2
  }

At schema path /required:
  [
    "fee_sats_per_tx",
    "participants",
    "radix"
  ]
```