### PR TITLE
Update installation docs

### DIFF
--- a/docs/learn-sapio/src/ch01-01-installation.md
+++ b/docs/learn-sapio/src/ch01-01-installation.md
@@ -5,6 +5,11 @@
 Sapio should work on all platforms, but is recommend for use with Linux (Ubuntu preferred).
 Follow this quickstart guide to get going.
 
+1.  Install [clang](https://clang.llvm.org/) if you don't have it already.
+```bash
+sudo apt-get install clang
+```
+
 1.  Get [rust](https://rustup.rs/) if you don't have it already.
 1.  Add the wasm target by running the below command in your terminal:
 ```bash
@@ -25,11 +30,11 @@ cd plugin-example && wasm-pack build && cd ..
 ```
 1.  Instantiate a contract from the plugin:
 ```
-cargo run --bin sapio-cli -- contract create 9.99 "{\"participants\": [{\"amount\": 9.99, \"address\": \"bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw\"}], \"radix\": 2}" --file="plugin-example/pkg/sapio_wasm_plugin_example_bg.wasm"
+cargo run --bin cli -- contract create 9.99 "{\"participants\": [{\"amount\": 9.99, \"address\": \"bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw\"}], \"radix\": 2}" --file="plugin-example/pkg/sapio_wasm_plugin_example_bg.wasm"
 ```
 
-You can use `cargo run --bin sapio-cli -- help` to learn more about what a the CLI
-can do! and `cargo run --bin sapio-cli -- <subcommand> help` to learn about
+You can use `cargo run --bin cli -- help` to learn more about what a the CLI
+can do! and `cargo run --bin cli -- <subcommand> help` to learn about
 subcommands like `contract`.
 
 


### PR DESCRIPTION
Having `clang` installed is a prerequisite, so I've added that to the installation docs.

Also `cargo run --bin sapio-cli` yielded the following error:

```bash
error: no bin target named `sapio-cli`

Did you mean `sapio-ws`?
```

I think the bin target should just be plain `cli`. That made it work for me.