### PR TITLE
Fixing M1 mac install instructions

### DIFF
--- a/docs/learn-sapio/src/ch01-01-installation.md
+++ b/docs/learn-sapio/src/ch01-01-installation.md
@@ -23,7 +23,7 @@ rustup target add wasm32-unknown-unknown
 > export PATH="/opt/homebrew/opt/llvm/bin:$PATH".
 > export CC=/opt/homebrew/opt/llvm/bin/clang
 > export AR=/opt/homebrew/opt/llvm/bin/llvm-ar
-> rustup toolchain default nightly
+> rustup default nightly
 > ```
 
 1.  Clone this repo: 


### PR DESCRIPTION
The syntax used in the rustup instructions here is incorrect, it will error if you include "toolchain" 

From the man pages:

```
    The `rustup default` command may be used to both install and set
    the desired toolchain as default in a single command:

        $ rustup default stable-msvc

```

I tested this locally and `rustup defaultly nightly` worked w/o error