### PR TITLE
Make WASM Modules readable from a particular workspace

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -261,6 +261,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     use bitcoin::network::constants::Network;
     use rand::prelude::*;
     use std::str::FromStr;
+    let module_path = util::get_path("org", "judica", "sapio-cli");
     match matches.subcommand() {
         Some(("signer", sign_matches)) => match sign_matches.subcommand() {
             Some(("sign", args)) => {
@@ -377,9 +378,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Some(("contract", matches)) => match matches.subcommand() {
             Some(("list", _args)) => {
                 let plugins = WasmPluginHandle::load_all_keys(
-                    "org".into(),
-                    "judica".into(),
-                    "sapio-cli".into(),
+                    module_path,
                     emulator,
                     config.network,
                     plugin_map,
@@ -524,9 +523,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             Some(("create", args)) => {
                 let sph = WasmPluginHandle::new_async(
-                    "org".into(),
-                    "judica".into(),
-                    "sapio-cli".into(),
+                    module_path,
                     &emulator,
                     args.value_of("key"),
                     args.value_of_os("file"),
@@ -559,9 +556,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             Some(("api", args)) => {
                 let sph = WasmPluginHandle::new_async(
-                    "org".into(),
-                    "judica".into(),
-                    "sapio-cli".into(),
+                    module_path,
                     &emulator,
                     args.value_of("key"),
                     args.value_of_os("file"),
@@ -573,9 +568,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             Some(("logo", args)) => {
                 let sph = WasmPluginHandle::new_async(
-                    "org".into(),
-                    "judica".into(),
-                    "sapio-cli".into(),
+                    module_path,
                     &emulator,
                     args.value_of("key"),
                     args.value_of_os("file"),
@@ -587,9 +580,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             Some(("info", args)) => {
                 let sph = WasmPluginHandle::new_async(
-                    "org".into(),
-                    "judica".into(),
-                    "sapio-cli".into(),
+                    module_path,
                     &emulator,
                     args.value_of("key"),
                     args.value_of_os("file"),
@@ -617,9 +608,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             Some(("load", args)) => {
                 let sph = WasmPluginHandle::new_async(
-                    "org".into(),
-                    "judica".into(),
-                    "sapio-cli".into(),
+                    module_path,
                     &emulator,
                     None,
                     args.value_of_os("file"),

--- a/cli/src/util.rs
+++ b/cli/src/util.rs
@@ -6,7 +6,7 @@
 
 use bitcoin::consensus::deserialize;
 use bitcoin::util::psbt::PartiallySignedTransaction;
-
+use std::path::PathBuf;
 /// Checks that a file exists during argument parsing
 ///
 /// **Race Conditions** if file is deleted after this call
@@ -94,4 +94,13 @@ pub fn sign_psbt(
 
 fn input_err(s: &str) -> std::io::Error {
     std::io::Error::new(std::io::ErrorKind::InvalidInput, s)
+}
+
+/// get the path for the compiled modules
+pub(crate) fn get_path(typ: &str, org: &str, proj: &str) -> PathBuf {
+    let proj =
+        directories::ProjectDirs::from(typ, org, proj).expect("Failed to find config directory");
+    let mut path: PathBuf = proj.data_dir().clone().into();
+    path.push("modules");
+    path
 }

--- a/cli/src/util.rs
+++ b/cli/src/util.rs
@@ -97,10 +97,9 @@ fn input_err(s: &str) -> std::io::Error {
 }
 
 /// get the path for the compiled modules
-pub(crate) fn get_path(typ: &str, org: &str, proj: &str) -> PathBuf {
+pub(crate) fn get_data_dir(typ: &str, org: &str, proj: &str) -> PathBuf {
     let proj =
         directories::ProjectDirs::from(typ, org, proj).expect("Failed to find config directory");
     let mut path: PathBuf = proj.data_dir().clone().into();
-    path.push("modules");
     path
 }

--- a/plugins/Cargo.toml
+++ b/plugins/Cargo.toml
@@ -12,7 +12,7 @@ description = "Libarary for building client/host sapio plugin bindings"
 
 [features]
 default = ["client"]
-host = ["wasmer", "wasmer-cache", "tokio", "directories"]
+host = ["wasmer", "wasmer-cache", "tokio"]
 client = ["miniscript"]
 
 [dependencies]
@@ -26,10 +26,6 @@ hex = "0.4.3"
 [dependencies.sapio-trait]
 version = "0.2.0"
 path = "../sapio-trait"
-
-[dependencies.directories]
-version = "3.0.1"
-optional = true
 
 [dependencies.wasmer]
 version = "1"

--- a/plugins/src/host/mod.rs
+++ b/plugins/src/host/mod.rs
@@ -14,6 +14,7 @@ use sapio_ctv_emulator_trait::CTVEmulator;
 use std::cell::Cell;
 use std::collections::BTreeMap;
 use std::io::Write;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use wasmer::*;
 
@@ -24,9 +25,7 @@ pub mod wasm_cache;
 /// Also handles the imports of plugin-side functions
 #[derive(WasmerEnv, Clone)]
 pub struct HostEnvironmentInner {
-    pub typ: String,
-    pub org: String,
-    pub proj: String,
+    pub path: PathBuf,
     pub this: [u8; 32],
     pub module_map: BTreeMap<Vec<u8>, [u8; 32]>,
     pub store: Arc<Mutex<Store>>,
@@ -202,12 +201,10 @@ mod exports {
         };
         let emulator = env.emulator.clone();
         let mmap = env.module_map.clone();
-        let typ = env.typ.clone();
-        let org = env.org.clone();
-        let proj = env.proj.clone();
+        let path = env.path.clone();
         let net = env.net;
 
-        match WasmPluginHandle::new(typ, org, proj, &emulator, Some(&h), None, net, Some(mmap)) {
+        match WasmPluginHandle::new(path, &emulator, Some(&h), None, net, Some(mmap)) {
             Ok(sph) => {
                 let comp_s = (move || -> Result<serde_json::Value, CompilationError> {
                     let value = match action_to_take {

--- a/plugins/src/host/wasm_cache.rs
+++ b/plugins/src/host/wasm_cache.rs
@@ -9,22 +9,11 @@ use std::path::PathBuf;
 use wasmer::{DeserializeError, Module, SerializeError, Store};
 use wasmer_cache::{Cache, FileSystemCache, Hash};
 
-/// get the path for the compiled modules
-fn get_path(typ: &str, org: &str, proj: &str) -> impl Into<PathBuf> {
-    let proj =
-        directories::ProjectDirs::from(typ, org, proj).expect("Failed to find config directory");
-    let mut path: PathBuf = proj.data_dir().clone().into();
-    path.push("modules");
-    path
-}
-
 /// look at the cache and get all of the keys (as Strings) for plugins
-pub fn get_all_keys_from_fs(
-    typ: &str,
-    org: &str,
-    proj: &str,
+pub fn get_all_keys_from_fs<I: Into<PathBuf>>(
+    path: I,
 ) -> Result<Vec<String>, Box<dyn std::error::Error>> {
-    std::fs::read_dir(get_path(typ, org, proj).into())?
+    std::fs::read_dir(path.into())?
         .map(|entry| {
             match entry.map(|x| {
                 x.path()
@@ -41,41 +30,32 @@ pub fn get_all_keys_from_fs(
 }
 
 /// load a module given the bytes of the module, may consult cache if available
-pub fn load_module(
-    typ: &str,
-    org: &str,
-    proj: &str,
+pub fn load_module<I: Into<PathBuf>>(
+    path: I,
     store: &Store,
     bytes: &[u8],
 ) -> Result<(Module, Hash), DeserializeError> {
-    let path = get_path(typ, org, proj);
     let key = Hash::generate(bytes);
     let f = FileSystemCache::new(path)?;
     unsafe { f.load(store, key) }.map(|m| (m, key))
 }
 
 /// load a module from the cache
-pub fn load_module_key(
-    typ: &str,
-    org: &str,
-    proj: &str,
+pub fn load_module_key<I: Into<PathBuf>>(
+    path: I,
     store: &Store,
     key: Hash,
 ) -> Result<(Module, Hash), DeserializeError> {
-    let path = get_path(typ, org, proj);
     let f = FileSystemCache::new(path)?;
     unsafe { f.load(store, key) }.map(|m| (m, key))
 }
 
 /// store a module into the cache
-pub fn store_module(
-    typ: &str,
-    org: &str,
-    proj: &str,
+pub fn store_module<I: Into<PathBuf>>(
+    path: I,
     module: &Module,
     bytes: &[u8],
 ) -> Result<Hash, SerializeError> {
-    let path = get_path(typ, org, proj);
     let mut cache = FileSystemCache::new(path)?;
     #[cfg(target_os = "windows")]
     {


### PR DESCRIPTION
This PR refactors the Plugin handle to recieve a generic path, and not use the projectdirs library.

It then changes the CLI to accept, on certain commands, a workspace parameter which overrides the location that modules are searched for from default.