### PR TITLE
WIP: Cleanup Logic of ThenFn / FinishOrFn to be the same

### DIFF
--- a/sapio-contrib/src/contracts/basic_examples.rs
+++ b/sapio-contrib/src/contracts/basic_examples.rs
@@ -60,7 +60,7 @@ impl BState for Finish {
 
 trait ExampleBThen
 where
-    Self: Sized,
+    Self: Sized + Contract,
 {
     decl_then! {begin_contest}
 }

--- a/sapio-contrib/src/contracts/derivatives/exploding.rs
+++ b/sapio-contrib/src/contracts/derivatives/exploding.rs
@@ -9,7 +9,7 @@ use super::*;
 use sapio_base::timelocks::*;
 use sapio_macros::guard;
 /// Generic functionality required for Exploding contracts
-pub trait Explodes: 'static + Sized {
+pub trait Explodes: 'static + Sized + Contract {
     decl_then! {
         /// What to do when the timeout expires
         explodes

--- a/sapio-contrib/src/contracts/dynamic.rs
+++ b/sapio-contrib/src/contracts/dynamic.rs
@@ -62,7 +62,7 @@ impl DynamicExample {
                 Some(sapio::contract::actions::ThenFunc {
                     conditional_compile_if: &[],
                     guard: &[],
-                    func: |_s, _ctx| Err(CompilationError::TerminateCompilation),
+                    func: |_s, _ctx, _t| Err(CompilationError::TerminateCompilation),
                     name: Arc::new("Empty".into()),
                 })
             }],

--- a/sapio-contrib/src/contracts/dynamic.rs
+++ b/sapio-contrib/src/contracts/dynamic.rs
@@ -17,13 +17,15 @@ use std::sync::Arc;
 /// Demonstrates how to make a contract object without known functionality at
 /// (rust) compile time. `D` Binds statically to the AnyContract interface though!
 struct D<'a> {
-    v: Vec<fn() -> Option<actions::ThenFuncAsFinishOrFunc<'a, D<'a>>>>,
+    v: Vec<fn() -> Option<actions::ThenFuncAsFinishOrFunc<'a, D<'a>, ()>>>,
 }
 
 impl AnyContract for D<'static> {
     type StatefulArguments = ();
     type Ref = Self;
-    fn then_fns<'a>(&'a self) -> &'a [fn() -> Option<actions::ThenFuncAsFinishOrFunc<'a, Self>>]
+    fn then_fns<'a>(
+        &'a self,
+    ) -> &'a [fn() -> Option<actions::ThenFuncAsFinishOrFunc<'a, Self, Self::StatefulArguments>>]
     where
         Self::Ref: 'a,
     {
@@ -54,7 +56,8 @@ pub struct DynamicExample;
 impl DynamicExample {
     #[then]
     fn next(self, ctx: sapio::Context) {
-        let v: Vec<fn() -> Option<actions::ThenFuncAsFinishOrFunc<'static, D<'static>>>> = vec![];
+        let v: Vec<fn() -> Option<actions::ThenFuncAsFinishOrFunc<'static, D<'static>, ()>>> =
+            vec![];
         let d: D<'_> = D { v };
 
         let d2 = DynamicContract::<(), String> {

--- a/sapio-contrib/src/contracts/dynamic.rs
+++ b/sapio-contrib/src/contracts/dynamic.rs
@@ -17,13 +17,13 @@ use std::sync::Arc;
 /// Demonstrates how to make a contract object without known functionality at
 /// (rust) compile time. `D` Binds statically to the AnyContract interface though!
 struct D<'a> {
-    v: Vec<fn() -> Option<actions::ThenFunc<'a, D<'a>>>>,
+    v: Vec<fn() -> Option<actions::ThenFuncAsFinishOrFunc<'a, D<'a>>>>,
 }
 
 impl AnyContract for D<'static> {
     type StatefulArguments = ();
     type Ref = Self;
-    fn then_fns<'a>(&'a self) -> &'a [fn() -> Option<actions::ThenFunc<'a, Self>>]
+    fn then_fns<'a>(&'a self) -> &'a [fn() -> Option<actions::ThenFuncAsFinishOrFunc<'a, Self>>]
     where
         Self::Ref: 'a,
     {
@@ -54,17 +54,20 @@ pub struct DynamicExample;
 impl DynamicExample {
     #[then]
     fn next(self, ctx: sapio::Context) {
-        let v: Vec<fn() -> Option<actions::ThenFunc<'static, D<'static>>>> = vec![];
+        let v: Vec<fn() -> Option<actions::ThenFuncAsFinishOrFunc<'static, D<'static>>>> = vec![];
         let d: D<'_> = D { v };
 
         let d2 = DynamicContract::<(), String> {
             then: vec![|| None, || {
-                Some(sapio::contract::actions::ThenFunc {
-                    conditional_compile_if: &[],
-                    guard: &[],
-                    func: |_s, _ctx, _t| Err(CompilationError::TerminateCompilation),
-                    name: Arc::new("Empty".into()),
-                })
+                Some(
+                    sapio::contract::actions::ThenFunc {
+                        conditional_compile_if: &[],
+                        guard: &[],
+                        func: |_s, _ctx, _t| Err(CompilationError::TerminateCompilation),
+                        name: Arc::new("Empty".into()),
+                    }
+                    .into(),
+                )
             }],
             finish: vec![],
             finish_or: vec![],

--- a/sapio-contrib/src/contracts/federated_sidechain.rs
+++ b/sapio-contrib/src/contracts/federated_sidechain.rs
@@ -52,7 +52,7 @@ pub struct FederatedPegIn<T: RecoveryState> {
 /// Actions that will be specialized depending on the exact state.
 pub trait StateDependentActions
 where
-    Self: Sized,
+    Self: Sized + Contract,
 {
     decl_guard! {
     /// Should only be defined when RecoveryState is in CanFinishRecovery

--- a/sapio-contrib/src/contracts/staked_signer.rs
+++ b/sapio-contrib/src/contracts/staked_signer.rs
@@ -60,7 +60,7 @@ pub struct Staker<T: StakingState> {
 /// Functional Interface for Staking Contracts
 pub trait StakerInterface
 where
-    Self: Sized,
+    Self: Sized + Contract,
 {
     decl_guard!(
         /// The key used to sign messages

--- a/sapio/src/contract/actions/then.rs
+++ b/sapio/src/contract/actions/then.rs
@@ -5,11 +5,28 @@
 //  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 //! Functionality for a function that uses CTV
+use super::CompilationError;
 use super::Context;
 use super::TxTmplIt;
 use crate::contract::actions::ConditionallyCompileIfList;
 use crate::contract::actions::GuardList;
+use crate::contract::actions::{FinishOrFunc, WebAPIDisabled};
+use std::marker::PhantomData;
 use std::sync::Arc;
+
+/// ThenFuncTypeTag is used as the args type of a ThenFunc
+pub struct ThenFuncTypeTag(pub(crate) ());
+
+impl ThenFuncTypeTag {
+    /// coerce of Self maps onto Self
+    pub fn coerce_args(f: Self) -> Result<Self, CompilationError> {
+        Ok(f)
+    }
+}
+
+/// Alias for representation of ThenFunc as FinishOrFunc
+pub type ThenFuncAsFinishOrFunc<'a, ContractSelf> =
+    FinishOrFunc<'a, ContractSelf, ThenFuncTypeTag, ThenFuncTypeTag, WebAPIDisabled>;
 
 /// A ThenFunc takes a list of Guards and a TxTmplIt generator.  Each TxTmpl returned from the
 /// ThenFunc is Covenant Permitted only if the AND of all guards is satisfied.
@@ -23,7 +40,23 @@ pub struct ThenFunc<'a, ContractSelf> {
     /// func returns an iterator of possible transactions
     /// Implementors should aim to return as few `TxTmpl`s as possible for enhanced
     /// semantics, preferring to split across multiple `ThenFunc`'s
-    pub func: fn(&ContractSelf, Context) -> TxTmplIt,
+    pub func: fn(&ContractSelf, Context, ThenFuncTypeTag) -> TxTmplIt,
     /// name derived from Function Name.
     pub name: Arc<String>,
+}
+
+impl<'a, ContractSelf> From<ThenFunc<'a, ContractSelf>>
+    for ThenFuncAsFinishOrFunc<'a, ContractSelf>
+{
+    fn from(f: ThenFunc<'a, ContractSelf>) -> Self {
+        FinishOrFunc {
+            guard: f.guard,
+            conditional_compile_if: f.conditional_compile_if,
+            func: f.func,
+            name: f.name,
+            coerce_args: ThenFuncTypeTag::coerce_args,
+            schema: None,
+            f: PhantomData::default(),
+        }
+    }
 }

--- a/sapio/src/contract/actions/then.rs
+++ b/sapio/src/contract/actions/then.rs
@@ -19,14 +19,14 @@ pub struct ThenFuncTypeTag(pub(crate) ());
 
 impl ThenFuncTypeTag {
     /// coerce of Self maps onto Self
-    pub fn coerce_args(f: Self) -> Result<Self, CompilationError> {
-        Ok(f)
+    pub fn coerce_args<StatefulArguments>(f: StatefulArguments) -> Result<Self, CompilationError> {
+        Ok(ThenFuncTypeTag(()))
     }
 }
 
 /// Alias for representation of ThenFunc as FinishOrFunc
-pub type ThenFuncAsFinishOrFunc<'a, ContractSelf> =
-    FinishOrFunc<'a, ContractSelf, ThenFuncTypeTag, ThenFuncTypeTag, WebAPIDisabled>;
+pub type ThenFuncAsFinishOrFunc<'a, ContractSelf, StatefulArguments> =
+    FinishOrFunc<'a, ContractSelf, StatefulArguments, ThenFuncTypeTag, WebAPIDisabled>;
 
 /// A ThenFunc takes a list of Guards and a TxTmplIt generator.  Each TxTmpl returned from the
 /// ThenFunc is Covenant Permitted only if the AND of all guards is satisfied.
@@ -45,8 +45,8 @@ pub struct ThenFunc<'a, ContractSelf> {
     pub name: Arc<String>,
 }
 
-impl<'a, ContractSelf> From<ThenFunc<'a, ContractSelf>>
-    for ThenFuncAsFinishOrFunc<'a, ContractSelf>
+impl<'a, ContractSelf, StatefulArgs> From<ThenFunc<'a, ContractSelf>>
+    for ThenFuncAsFinishOrFunc<'a, ContractSelf, StatefulArgs>
 {
     fn from(f: ThenFunc<'a, ContractSelf>) -> Self {
         FinishOrFunc {

--- a/sapio/src/contract/compiler/mod.rs
+++ b/sapio/src/contract/compiler/mod.rs
@@ -13,6 +13,7 @@ use super::Context;
 use crate::contract::abi::continuation::ContinuationPoint;
 use crate::contract::actions::conditional_compile::CCILWrapper;
 use crate::contract::actions::CallableAsFoF;
+use crate::contract::actions::ThenFuncTypeTag;
 use crate::contract::TxTmplIt;
 use crate::util::amountrange::AmountRange;
 use ::miniscript::descriptor::TapTree;
@@ -179,7 +180,7 @@ where
                             UseCTV::Yes,
                             guards,
                             if errors.is_empty() {
-                                (func.func)(self_ref, ntx_ctx)
+                                (func.func)(self_ref, ntx_ctx, ThenFuncTypeTag(()))
                             } else {
                                 Err(CompilationError::ConditionalCompilationFailed(errors))
                             },

--- a/sapio/src/contract/compiler/mod.rs
+++ b/sapio/src/contract/compiler/mod.rs
@@ -21,8 +21,8 @@ use ::miniscript::*;
 use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::hashes::Hash;
 use bitcoin::schnorr::TweakedPublicKey;
-use std::collections::BinaryHeap;
 use sapio_base::reverse_path::ReversePath;
+use std::collections::BinaryHeap;
 
 use bitcoin::XOnlyPublicKey;
 use sapio_base::effects::EffectDB;
@@ -130,112 +130,7 @@ where
 
         let guard_clauses = std::cell::RefCell::new(GuardCache::new());
 
-
         let dummy_root = Arc::new(ReversePath::from(PathFragment::Root));
-        // The code for then_fns and finish_or_fns is very similar, differing
-        // only in that then_fns have a CTV enforcing the contract and
-        // finish_or_fns do not. We can lazily chain iterators to process them
-        // in a row.
-        let (mut continue_apis, then_fns): (
-            BTreeMap<SArc<EffectPath>, ContinuationPoint>,
-            Vec<(Nullable, UseCTV, Clause, TxTmplIt)>,
-        ) = {
-            let mut then_fn_ctx = ctx.derive(PathFragment::ThenFn)?;
-            let mut finish_or_fns_ctx = ctx.derive(PathFragment::FinishOrFn)?;
-            self.then_fns()
-                .iter()
-                .filter_map(|func| func())
-                // TODO: Without allocations?
-                .map(|x| -> Box<dyn CallableAsFoF<_, _>> { Box::new(x) })
-                // TOOD: What is flat map doing here?
-                .flat_map(|x| {
-                    let name = PathFragment::Named(SArc(x.get_name().clone()));
-                    then_fn_ctx.derive(name).map(|p| (p, x))
-                })
-                .map(|x| (UseCTV::Yes, x))
-                .chain(
-                    self.finish_or_fns()
-                        .iter()
-                        .filter_map(|func| func())
-                        .flat_map(|x| {
-                            let name = PathFragment::Named(SArc(x.get_name().clone()));
-                            finish_or_fns_ctx.derive(name).map(|p| (p, x))
-                        })
-                        .map(|x| (UseCTV::No, x)),
-                )
-                .flat_map(|(ctv, (mut f_ctx, func))| {
-                    f_ctx
-                        .derive(PathFragment::CondCompIf)
-                        .map(|mut this_ctx| {
-                            // TODO: Merge logic?
-                            match CCILWrapper(func.get_conditional_compile_if())
-                                .assemble(self_ref, &mut this_ctx)
-                            {
-                                ConditionalCompileType::Fail(errors) => {
-                                    Some((f_ctx, func, errors, Nullable::No, ctv))
-                                }
-                                ConditionalCompileType::Required
-                                | ConditionalCompileType::NoConstraint => {
-                                    Some((f_ctx, func, LinkedList::new(), Nullable::No, ctv))
-                                }
-                                ConditionalCompileType::Nullable => {
-                                    Some((f_ctx, func, LinkedList::new(), Nullable::Yes, ctv))
-                                }
-                                ConditionalCompileType::Skippable
-                                | ConditionalCompileType::Never => None,
-                            }
-                        })
-                        .transpose()
-                })
-                .map(|r| {
-                    r.and_then(|(mut f_ctx, func, errors, nullability, ctv)| {
-                        let gctx = f_ctx.derive(PathFragment::Guard)?;
-                        // TODO: Suggested path frag?
-                        let ntx_ctx = f_ctx.derive(PathFragment::Next)?;
-                        let guards = create_guards(
-                            self_ref,
-                            gctx,
-                            func.get_guard(),
-                            &mut guard_clauses.borrow_mut(),
-                        );
-                        let effect_ctx = f_ctx.derive(PathFragment::Suggested)?;
-                        let cont = if ctv == UseCTV::Yes {
-                            (SArc(dummy_root.clone()), ContinuationPoint::at(None, dummy_root.clone()))
-                        } else {
-                            (
-                                SArc(effect_ctx.path().clone()),
-                                ContinuationPoint::at(
-                                    func.get_schema().clone(),
-                                    effect_ctx.path().clone(),
-                                ),
-                            )
-                        };
-                        let transactions = if errors.is_empty() {
-                            if ctv == UseCTV::Yes {
-                                func.call(self_ref, ntx_ctx, Default::default())
-                            } else {
-                                // finish_or_fns may be used to compute additional transactions with
-                                // a given argument, but for building the ABI we only precompute with
-                                // the default argument.
-                                compute_all_effects(effect_ctx, self_ref, func.as_ref())
-                            }
-                        } else {
-                            Err(CompilationError::ConditionalCompilationFailed(errors))
-                        };
-                        Ok((cont, (nullability, ctv, guards, transactions)))
-                    })
-                })
-                .collect::<Result<
-                    Vec<(
-                        (SArc<EffectPath>, ContinuationPoint),
-                        (Nullable, UseCTV, Clause, TxTmplIt),
-                    )>,
-                    CompilationError,
-                >>()?
-                .into_iter()
-                .unzip()
-        };
-        continue_apis.remove(&SArc(dummy_root.clone()));
 
         let mut ctv_to_tx = BTreeMap::new();
         let mut suggested_txs = BTreeMap::new();
@@ -244,76 +139,183 @@ where
         let mut amount_range_ctx = ctx.derive(PathFragment::Cloned)?;
         amount_range.update_range(self.ensure_amount(amount_range_ctx)?);
 
-        // If no guards and not CTV, then nothing gets added (not interpreted as Trivial True)
-        // If CTV and no guards, just CTV added.
-        // If CTV and guards, CTV & guards added.
-        let clause_accumulator = then_fns
-            .into_iter()
-            .map(|(nullability, uses_ctv, guards, r_txtmpls)| {
-                // it would be an error if any of r_txtmpls is an error instead of just an empty
-                // iterator.
-                let txtmpl_clauses = r_txtmpls?
-                    .map(|r_txtmpl| {
-                        let txtmpl = r_txtmpl?;
-                        let h = txtmpl.hash();
-                        amount_range.update_range(txtmpl.max);
-                        // Add the addition guards to these clauses
-                        if uses_ctv == UseCTV::Yes {
-                            let txtmpl = ctv_to_tx.entry(h).or_insert(txtmpl);
-                            if txtmpl.guards.len() == 0 {
-                                ctx.ctv_emulator(h).map(Some)
-                            } else {
-                                let mut g = txtmpl.guards.clone();
-                                g.push(ctx.ctv_emulator(h)?);
-                                Ok(Some(Clause::And(g)))
+        // The code for then_fns and finish_or_fns is very similar, differing
+        // only in that then_fns have a CTV enforcing the contract and
+        // finish_or_fns do not. We can lazily chain iterators to process them
+        // in a row.
+        let mut finish_or_fns_ctx = ctx.derive(PathFragment::FinishOrFn)?;
+        let mut then_fn_ctx = ctx.derive(PathFragment::ThenFn)?;
+        let (mut continue_apis, clause_accumulator): (
+            BTreeMap<SArc<EffectPath>, ContinuationPoint>,
+            Vec<Vec<Clause>>
+        ) = self
+            .then_fns()
+            .iter()
+            .filter_map(|func| func())
+            // TODO: Without allocations?
+            .map(|x| -> Box<dyn CallableAsFoF<_, _>> { Box::new(x) })
+            // TOOD: What is flat map doing here?
+            .flat_map(|x| {
+                let name = PathFragment::Named(SArc(x.get_name().clone()));
+                then_fn_ctx.derive(name).map(|p| (p, x))
+            })
+            .map(|x| (UseCTV::Yes, x))
+            .chain(
+                self.finish_or_fns()
+                    .iter()
+                    .filter_map(|func| func())
+                    .flat_map(|x| {
+                        let name = PathFragment::Named(SArc(x.get_name().clone()));
+                        finish_or_fns_ctx.derive(name).map(|p| (p, x))
+                    })
+                    .map(|x| (UseCTV::No, x)),
+            )
+            .flat_map(|(ctv, (mut f_ctx, func))| {
+                f_ctx
+                    .derive(PathFragment::CondCompIf)
+                    .map(|mut this_ctx| {
+                        // TODO: Merge logic?
+                        match CCILWrapper(func.get_conditional_compile_if())
+                            .assemble(self_ref, &mut this_ctx)
+                        {
+                            ConditionalCompileType::Fail(errors) => {
+                                Some((f_ctx, func, errors, Nullable::No, ctv))
                             }
-                        } else {
-                            let txtmpl = suggested_txs.entry(h).or_insert(txtmpl);
-                            // Don't return or use the extra guards here because we're within a
-                            // non-CTV context... if we did, then it would destabilize compilation
-                            // with effect arguments.
-                            if txtmpl.guards.len() != 0 {
-                                // todo: In theory, the *default* effect could pass up something here.
-                                Err(CompilationError::AdditionalGuardsNotAllowedHere)
-                            } else {
-                                // Don't add anything...
-                                Ok(None)
+                            ConditionalCompileType::Required
+                            | ConditionalCompileType::NoConstraint => {
+                                Some((f_ctx, func, LinkedList::new(), Nullable::No, ctv))
+                            }
+                            ConditionalCompileType::Nullable => {
+                                Some((f_ctx, func, LinkedList::new(), Nullable::Yes, ctv))
+                            }
+                            ConditionalCompileType::Skippable | ConditionalCompileType::Never => {
+                                None
                             }
                         }
                     })
-                    // Drop None values
-                    .filter_map(|s| s.transpose())
-                    // Forces any error to abort the whole thing
-                    .collect::<Result<Vec<Clause>, CompilationError>>()?;
-
-                match (uses_ctv, nullability, txtmpl_clauses.len(), guards) {
-                    // Mark this branch dead.
-                    // Nullable branch without anything
-                    (UseCTV::Yes, Nullable::Yes, 0, _) => Ok(vec![]),
-                    // Error if we expect CTV, returned some templates, but our guard
-                    // was unsatisfiable, irrespective of nullability. This is because
-                    // the behavior should be captured through a compile_if if it is
-                    // intended.
-                    (UseCTV::Yes, _, n, Clause::Unsatisfiable) if n > 0 => {
-                        // TODO: Turn into a warning that the intended behavior should be to compile_if
-                        Err(CompilationError::MissingTemplates)
-                    }
-                    // Error if 0 templates return and we don't want to be nullable
-                    (UseCTV::Yes, Nullable::No, 0, _) => Err(CompilationError::MissingTemplates),
-                    // If the guard is trivial, return the hashes standalone
-                    (UseCTV::Yes, _, _, Clause::Trivial) => Ok(txtmpl_clauses),
-                    // If the guard is non-trivial, zip it to each hash
-                    // TODO: Arc in miniscript to dedup memory?
-                    //       This could be Clause::Shared(x) or something...
-                    (UseCTV::Yes, _, _, guards) => Ok(txtmpl_clauses
-                        .into_iter()
-                        // extra_guards will contain any CTV
-                        .map(|extra_guards| Clause::And(vec![guards.clone(), extra_guards]))
-                        .collect()),
-                    (UseCTV::No, _, _, guards) => Ok(vec![guards]),
-                }
+                    .transpose()
             })
-            .collect::<Result<Vec<Vec<Clause>>, CompilationError>>()?;
+            .map(|r| {
+                r.and_then(|(mut f_ctx, func, errors, nullability, ctv)| {
+                    let gctx = f_ctx.derive(PathFragment::Guard)?;
+                    // TODO: Suggested path frag?
+                    let ntx_ctx = f_ctx.derive(PathFragment::Next)?;
+                    let guards = create_guards(
+                        self_ref,
+                        gctx,
+                        func.get_guard(),
+                        &mut guard_clauses.borrow_mut(),
+                    );
+                    let effect_ctx = f_ctx.derive(PathFragment::Suggested)?;
+                    let cont = if ctv == UseCTV::Yes {
+                        (
+                            SArc(dummy_root.clone()),
+                            ContinuationPoint::at(None, dummy_root.clone()),
+                        )
+                    } else {
+                        (
+                            SArc(effect_ctx.path().clone()),
+                            ContinuationPoint::at(
+                                func.get_schema().clone(),
+                                effect_ctx.path().clone(),
+                            ),
+                        )
+                    };
+                    let transactions = if errors.is_empty() {
+                        if ctv == UseCTV::Yes {
+                            func.call(self_ref, ntx_ctx, Default::default())
+                        } else {
+                            // finish_or_fns may be used to compute additional transactions with
+                            // a given argument, but for building the ABI we only precompute with
+                            // the default argument.
+                            compute_all_effects(effect_ctx, self_ref, func.as_ref())
+                        }
+                    } else {
+                        Err(CompilationError::ConditionalCompilationFailed(errors))
+                    };
+                    Ok((cont, (nullability, ctv, guards, transactions)))
+                })
+            })
+            // If no guards and not CTV, then nothing gets added (not interpreted as Trivial True)
+            // If CTV and no guards, just CTV added.
+            // If CTV and guards, CTV & guards added.
+
+            // TODO: What does flat_map do here?
+            .flat_map(|r| {
+                r.map(|(cont, (nullability, uses_ctv, guards, r_txtmpls))| {
+                    // it would be an error if any of r_txtmpls is an error instead of just an empty
+                    // iterator.
+                    let txtmpl_clauses = r_txtmpls?
+                        .map(|r_txtmpl| {
+                            let txtmpl = r_txtmpl?;
+                            let h = txtmpl.hash();
+                            amount_range.update_range(txtmpl.max);
+                            // Add the addition guards to these clauses
+                            if uses_ctv == UseCTV::Yes {
+                                let txtmpl = ctv_to_tx.entry(h).or_insert(txtmpl);
+                                if txtmpl.guards.len() == 0 {
+                                    ctx.ctv_emulator(h).map(Some)
+                                } else {
+                                    let mut g = txtmpl.guards.clone();
+                                    g.push(ctx.ctv_emulator(h)?);
+                                    Ok(Some(Clause::And(g)))
+                                }
+                            } else {
+                                let txtmpl = suggested_txs.entry(h).or_insert(txtmpl);
+                                // Don't return or use the extra guards here because we're within a
+                                // non-CTV context... if we did, then it would destabilize compilation
+                                // with effect arguments.
+                                if txtmpl.guards.len() != 0 {
+                                    // todo: In theory, the *default* effect could pass up something here.
+                                    Err(CompilationError::AdditionalGuardsNotAllowedHere)
+                                } else {
+                                    // Don't add anything...
+                                    Ok(None)
+                                }
+                            }
+                        })
+                        // Drop None values
+                        .filter_map(|s| s.transpose())
+                        // Forces any error to abort the whole thing
+                        .collect::<Result<Vec<Clause>, CompilationError>>()?;
+
+                    match (uses_ctv, nullability, txtmpl_clauses.len(), guards) {
+                        // Mark this branch dead.
+                        // Nullable branch without anything
+                        (UseCTV::Yes, Nullable::Yes, 0, _) => Ok((cont, vec![])),
+                        // Error if we expect CTV, returned some templates, but our guard
+                        // was unsatisfiable, irrespective of nullability. This is because
+                        // the behavior should be captured through a compile_if if it is
+                        // intended.
+                        (UseCTV::Yes, _, n, Clause::Unsatisfiable) if n > 0 => {
+                            // TODO: Turn into a warning that the intended behavior should be to compile_if
+                            Err(CompilationError::MissingTemplates)
+                        }
+                        // Error if 0 templates return and we don't want to be nullable
+                        (UseCTV::Yes, Nullable::No, 0, _) => {
+                            Err(CompilationError::MissingTemplates)
+                        }
+                        // If the guard is trivial, return the hashes standalone
+                        (UseCTV::Yes, _, _, Clause::Trivial) => Ok((cont, txtmpl_clauses)),
+                        // If the guard is non-trivial, zip it to each hash
+                        // TODO: Arc in miniscript to dedup memory?
+                        //       This could be Clause::Shared(x) or something...
+                        (UseCTV::Yes, _, _, guards) => Ok((
+                            cont,
+                            txtmpl_clauses
+                                .into_iter()
+                                // extra_guards will contain any CTV
+                                .map(|extra_guards| Clause::And(vec![guards.clone(), extra_guards]))
+                                .collect(),
+                        )),
+                        (UseCTV::No, _, _, guards) => Ok((cont, vec![guards])),
+                    }
+                })
+            })
+            .collect::<Result<Vec<((SArc<EffectPath>, ContinuationPoint), Vec<Clause>)>, CompilationError>>()?
+            .into_iter()
+            .unzip();
+        continue_apis.remove(&SArc(dummy_root.clone()));
         let finish_fns: Vec<_> = {
             let mut finish_fns_ctx = ctx.derive(PathFragment::FinishFn)?;
             // Compute all finish_functions at this level, caching if requested.

--- a/sapio/src/contract/macros.rs
+++ b/sapio/src/contract/macros.rs
@@ -30,7 +30,7 @@ macro_rules! declare {
     {then $(,$a:expr)*} => {
         /// binds the list of `ThenFunc`'s to this impl.
         /// Any fn() which returns None is ignored (useful for type-level state machines)
-        const THEN_FNS: &'static [fn() -> Option<$crate::contract::actions::ThenFunc<'static, Self>>] = &[$($a,)*];
+        const THEN_FNS: &'static [fn() -> Option<$crate::contract::actions::ThenFuncAsFinishOrFunc<'static, Self>>] = &[$($a,)*];
     };
     [state $i:ty]  => {
         type StatefulArguments = $i;
@@ -95,7 +95,7 @@ macro_rules! decl_then {
                 unimplemented!();
             }
             $(#[$meta])*
-            fn $name<'a>() -> Option<$crate::contract::actions::ThenFunc<'a, Self>> {None}
+            fn $name<'a>() -> Option<$crate::contract::actions::ThenFuncAsFinishOrFunc<'a, Self>> {None}
         }
     };
 }

--- a/sapio/src/contract/macros.rs
+++ b/sapio/src/contract/macros.rs
@@ -90,7 +90,7 @@ macro_rules! decl_then {
         $crate::contract::macros::paste!{
 
             $(#[$meta])*
-            fn [<then_ $name>](&self, _ctx:$crate::contract::Context)-> $crate::contract::TxTmplIt
+            fn [<then_ $name>](&self, _ctx:$crate::contract::Context, _:$crate::contract::actions::ThenFuncTypeTag)-> $crate::contract::TxTmplIt
             {
                 unimplemented!();
             }

--- a/sapio/src/contract/macros.rs
+++ b/sapio/src/contract/macros.rs
@@ -30,7 +30,7 @@ macro_rules! declare {
     {then $(,$a:expr)*} => {
         /// binds the list of `ThenFunc`'s to this impl.
         /// Any fn() which returns None is ignored (useful for type-level state machines)
-        const THEN_FNS: &'static [fn() -> Option<$crate::contract::actions::ThenFuncAsFinishOrFunc<'static, Self>>] = &[$($a,)*];
+        const THEN_FNS: &'static [fn() -> Option<$crate::contract::actions::ThenFuncAsFinishOrFunc<'static, Self, Self::StatefulArguments>>] = &[$($a,)*];
     };
     [state $i:ty]  => {
         type StatefulArguments = $i;
@@ -95,7 +95,7 @@ macro_rules! decl_then {
                 unimplemented!();
             }
             $(#[$meta])*
-            fn $name<'a>() -> Option<$crate::contract::actions::ThenFuncAsFinishOrFunc<'a, Self>> {None}
+            fn $name<'a>() -> Option<$crate::contract::actions::ThenFuncAsFinishOrFunc<'a, Self, <Self as sapio::contract::Contract>::StatefulArguments>> {None}
         }
     };
 }

--- a/sapio/src/contract/mod.rs
+++ b/sapio/src/contract/mod.rs
@@ -61,8 +61,8 @@ where
 /// DynamicContract wraps a struct S with a set of methods (that can be constructed dynamically)
 /// to form a contract. DynamicContract owns all its methods.
 pub struct DynamicContract<'a, T, S> {
-    /// the list of `ThenFunc` for this contract.
-    pub then: Vec<fn() -> Option<actions::ThenFunc<'a, S>>>,
+    /// the list of `ThenFuncAsFinishOrFunc` for this contract.
+    pub then: Vec<fn() -> Option<actions::ThenFuncAsFinishOrFunc<'a, S>>>,
     /// the list of `FinishOrFunc` for this contract.
     pub finish_or: Vec<fn() -> Option<Box<dyn actions::CallableAsFoF<S, T>>>>,
     /// the list of `Guard` for this contract to finish.
@@ -82,7 +82,7 @@ where
 {
     type StatefulArguments = T;
     type Ref = S;
-    fn then_fns<'a>(&'a self) -> &'a [fn() -> Option<actions::ThenFunc<'a, S>>]
+    fn then_fns<'a>(&'a self) -> &'a [fn() -> Option<actions::ThenFuncAsFinishOrFunc<'a, S>>]
     where
         Self::Ref: 'a,
     {
@@ -129,8 +129,10 @@ where
     /// This enables `DynamicContract` and `Contract` to impl `AnyContract`, as well
     /// as more exotic types.
     type Ref;
-    /// obtain a reference to the `ThenFunc` list.
-    fn then_fns<'a>(&'a self) -> &'a [fn() -> Option<actions::ThenFunc<'a, Self::Ref>>]
+    /// obtain a reference to the `ThenFuncAsFinishOrFunc` list.
+    fn then_fns<'a>(
+        &'a self,
+    ) -> &'a [fn() -> Option<actions::ThenFuncAsFinishOrFunc<'a, Self::Ref>>]
     where
         Self::Ref: 'a;
 
@@ -155,7 +157,9 @@ where
 {
     type StatefulArguments = C::StatefulArguments;
     type Ref = Self;
-    fn then_fns<'a>(&'a self) -> &'a [fn() -> Option<actions::ThenFunc<'a, Self::Ref>>]
+    fn then_fns<'a>(
+        &'a self,
+    ) -> &'a [fn() -> Option<actions::ThenFuncAsFinishOrFunc<'a, Self::Ref>>]
     where
         Self::Ref: 'a,
     {

--- a/sapio/src/contract/mod.rs
+++ b/sapio/src/contract/mod.rs
@@ -62,7 +62,7 @@ where
 /// to form a contract. DynamicContract owns all its methods.
 pub struct DynamicContract<'a, T, S> {
     /// the list of `ThenFuncAsFinishOrFunc` for this contract.
-    pub then: Vec<fn() -> Option<actions::ThenFuncAsFinishOrFunc<'a, S>>>,
+    pub then: Vec<fn() -> Option<actions::ThenFuncAsFinishOrFunc<'a, S, T>>>,
     /// the list of `FinishOrFunc` for this contract.
     pub finish_or: Vec<fn() -> Option<Box<dyn actions::CallableAsFoF<S, T>>>>,
     /// the list of `Guard` for this contract to finish.
@@ -82,7 +82,9 @@ where
 {
     type StatefulArguments = T;
     type Ref = S;
-    fn then_fns<'a>(&'a self) -> &'a [fn() -> Option<actions::ThenFuncAsFinishOrFunc<'a, S>>]
+    fn then_fns<'a>(
+        &'a self,
+    ) -> &'a [fn() -> Option<actions::ThenFuncAsFinishOrFunc<'a, S, Self::StatefulArguments>>]
     where
         Self::Ref: 'a,
     {
@@ -132,7 +134,9 @@ where
     /// obtain a reference to the `ThenFuncAsFinishOrFunc` list.
     fn then_fns<'a>(
         &'a self,
-    ) -> &'a [fn() -> Option<actions::ThenFuncAsFinishOrFunc<'a, Self::Ref>>]
+    ) -> &'a [fn() -> Option<
+        actions::ThenFuncAsFinishOrFunc<'a, Self::Ref, Self::StatefulArguments>,
+    >]
     where
         Self::Ref: 'a;
 
@@ -159,7 +163,9 @@ where
     type Ref = Self;
     fn then_fns<'a>(
         &'a self,
-    ) -> &'a [fn() -> Option<actions::ThenFuncAsFinishOrFunc<'a, Self::Ref>>]
+    ) -> &'a [fn() -> Option<
+        actions::ThenFuncAsFinishOrFunc<'a, Self::Ref, Self::StatefulArguments>,
+    >]
     where
         Self::Ref: 'a,
     {

--- a/sapio_macros/src/lib.rs
+++ b/sapio_macros/src/lib.rs
@@ -152,7 +152,7 @@ pub fn then(args: TokenStream, input: TokenStream) -> TokenStream {
                 })
             }
             /// (missing docs fix)
-            fn #then_fn_name(&self, #context_arg) -> sapio::contract::TxTmplIt
+            fn #then_fn_name(&self, #context_arg, _: sapio::contract::actions::ThenFuncTypeTag) -> sapio::contract::TxTmplIt
             #block
     })
 }

--- a/sapio_macros/src/lib.rs
+++ b/sapio_macros/src/lib.rs
@@ -143,13 +143,13 @@ pub fn then(args: TokenStream, input: TokenStream) -> TokenStream {
     let (cia, gba) = get_arrays(&args);
     proc_macro::TokenStream::from(quote! {
             /// (missing docs fix)
-            fn #name<'a>() -> Option<sapio::contract::actions::ThenFunc<'a, Self>>{
+            fn #name<'a>() -> Option<sapio::contract::actions::ThenFuncAsFinishOrFunc<'a, Self>>{
                 Some(sapio::contract::actions::ThenFunc{
                     guard: &#gba,
                     conditional_compile_if: &#cia,
                     func: Self::#then_fn_name,
                     name: std::sync::Arc::new(std::stringify!(#name).into()),
-                })
+                }.into())
             }
             /// (missing docs fix)
             fn #then_fn_name(&self, #context_arg, _: sapio::contract::actions::ThenFuncTypeTag) -> sapio::contract::TxTmplIt

--- a/sapio_macros/src/lib.rs
+++ b/sapio_macros/src/lib.rs
@@ -143,7 +143,7 @@ pub fn then(args: TokenStream, input: TokenStream) -> TokenStream {
     let (cia, gba) = get_arrays(&args);
     proc_macro::TokenStream::from(quote! {
             /// (missing docs fix)
-            fn #name<'a>() -> Option<sapio::contract::actions::ThenFuncAsFinishOrFunc<'a, Self>>{
+            fn #name<'a>() -> Option<sapio::contract::actions::ThenFuncAsFinishOrFunc<'a, Self, <Self as sapio::contract::Contract>::StatefulArguments>>{
                 Some(sapio::contract::actions::ThenFunc{
                     guard: &#gba,
                     conditional_compile_if: &#cia,


### PR DESCRIPTION
Needs testing to check that the compiled results do not differ (much!) after this change.

It does change the order of path derivations.