### PR TITLE
Add editable MapEffectDB struct

### DIFF
--- a/sapio-base/src/effects/mod.rs
+++ b/sapio-base/src/effects/mod.rs
@@ -52,6 +52,23 @@ pub struct MapEffectDB {
     #[serde(skip, default)]
     empty: BTreeMap<SArc<String>, serde_json::Value>,
 }
+
+pub struct EditableMapEffectDB {
+    pub effects: BTreeMap<SArc<EffectPath>, BTreeMap<SArc<String>, serde_json::Value>>,
+    pub empty: BTreeMap<SArc<String>, serde_json::Value>,
+}
+
+impl From<MapEffectDB> for EditableMapEffectDB {
+    fn from(MapEffectDB { effects, empty }: MapEffectDB) -> Self {
+        Self { effects, empty }
+    }
+}
+impl From<EditableMapEffectDB> for MapEffectDB {
+    fn from(EditableMapEffectDB { effects, empty }: EditableMapEffectDB) -> Self {
+        Self { effects, empty }
+    }
+}
+
 impl MapEffectDB {
     pub fn skip_serializing(&self) -> bool {
         self.effects.is_empty()


### PR DESCRIPTION
This is not "great" since we want MapEffectDB to be immutable, but it hleps us with being able to build things that modify effect DBs from rust.