### PR TITLE
SIMP Interface Cleanup

### DIFF
--- a/plugin-example/clause-module-trampoline/src/plugin.rs
+++ b/plugin-example/clause-module-trampoline/src/plugin.rs
@@ -3,6 +3,8 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 //  License, v. 2.0. If a copy of the MPL was not distributed with this
 //  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+//! Clause Module Example
 
 #![deny(missing_docs)]
 use sapio_wasm_plugin::plugin_handle::PluginHandle;
@@ -23,6 +25,7 @@ use serde::Serialize;
 use bitcoin::XOnlyPublicKey;
 use std::str::FromStr;
 
+/// Same Inner type as the wrapped module
 #[derive(JsonSchema, Deserialize, Serialize, Clone)]
 pub struct GetClause {
     // TODO: Taproot Fix Encoding
@@ -32,6 +35,8 @@ pub struct GetClause {
     #[schemars(with = "bitcoin::hashes::sha256::Hash")]
     bob: bitcoin::XOnlyPublicKey,
 }
+
+/// Wrapper to find the ClauseModule remotely
 #[derive(JsonSchema, Deserialize)]
 pub struct Wrapper {
     g: GetClause,

--- a/plugin-example/clause-module/src/plugin.rs
+++ b/plugin-example/clause-module/src/plugin.rs
@@ -4,6 +4,9 @@
 //  License, v. 2.0. If a copy of the MPL was not distributed with this
 //  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+//! Clause Module for showing non-sapio compiled object types
+
+
 #![deny(missing_docs)]
 use sapio_wasm_plugin::client::*;
 use sapio_wasm_plugin::*;
@@ -17,6 +20,7 @@ use serde::Deserialize;
 use std::convert::{TryFrom, TryInto};
 use sapio_wasm_plugin::client::plugin::Callable;
 
+/// Get a Clause for two parties to OR together
 #[derive(JsonSchema, Deserialize)]
 pub struct GetClause {
     // TODO: Taproot Fix Encoding

--- a/plugin-example/coin_pool/src/plugin.rs
+++ b/plugin-example/coin_pool/src/plugin.rs
@@ -3,9 +3,11 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 //  License, v. 2.0. If a copy of the MPL was not distributed with this
 //  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Coin Pool
+
 #![deny(missing_docs)]
 use crate::sapio_base::Clause;
-
 use sapio::contract::*;
 use sapio::util::amountrange::AmountF64;
 use sapio::*;

--- a/plugin-example/fedpeg/src/plugin.rs
+++ b/plugin-example/fedpeg/src/plugin.rs
@@ -4,6 +4,7 @@
 //  License, v. 2.0. If a copy of the MPL was not distributed with this
 //  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+//! Federated Peg Contract
 #![deny(missing_docs)]
 use sapio_wasm_plugin::client::*;
 use sapio_wasm_plugin::*;

--- a/plugin-example/hanukkiah/src/plugin.rs
+++ b/plugin-example/hanukkiah/src/plugin.rs
@@ -4,6 +4,7 @@
 //  License, v. 2.0. If a copy of the MPL was not distributed with this
 //  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+//! Hanukkiah Contract
 #![deny(missing_docs)]
 use sapio_wasm_plugin::client::*;
 use sapio_wasm_plugin::*;

--- a/plugin-example/helloworld/src/plugin.rs
+++ b/plugin-example/helloworld/src/plugin.rs
@@ -4,6 +4,9 @@
 //  License, v. 2.0. If a copy of the MPL was not distributed with this
 //  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+
+//! Hello World Contract
+
 #![deny(missing_docs)]
 use sapio_wasm_plugin::client::*;
 use sapio_wasm_plugin::*;
@@ -17,6 +20,7 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use std::convert::{TryFrom, TryInto};
 
+/// Trustless Escrow Contract
 #[derive(JsonSchema, Deserialize)]
 pub struct TrustlessEscrow {
     // TODO: Taproot Fix Encoding

--- a/plugin-example/jamesob-vault/src/plugin.rs
+++ b/plugin-example/jamesob-vault/src/plugin.rs
@@ -1,11 +1,14 @@
-use bitcoin::util::bip32::ExtendedPubKey;
-use bitcoin::Amount;
-#![deny(missing_docs)]
 // Copyright Judica, Inc 2021
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 //  License, v. 2.0. If a copy of the MPL was not distributed with this
 //  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! James O'Beirne's Vault Demo
+
+#![deny(missing_docs)]
+use bitcoin::util::bip32::ExtendedPubKey;
+use bitcoin::Amount;
 use sapio::contract::actions::conditional_compile::ConditionalCompileType;
 use sapio::contract::*;
 use sapio::util::amountrange::{AmountF64, AmountU64};

--- a/plugin-example/nft-auction/src/plugin.rs
+++ b/plugin-example/nft-auction/src/plugin.rs
@@ -1,3 +1,12 @@
+// Copyright Judica, Inc 2021
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+//  License, v. 2.0. If a copy of the MPL was not distributed with this
+//  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#![deny(missing_docs)]
+
+//! NFT Auction
+
 use bitcoin::util::amount::Amount;
 use sapio::contract::CompilationError;
 use sapio::contract::Contract;
@@ -12,12 +21,8 @@ use sapio_wasm_plugin::*;
 use schemars::*;
 use serde::*;
 use std::convert::TryFrom;
-#![deny(missing_docs)]
-// Copyright Judica, Inc 2021
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-//  License, v. 2.0. If a copy of the MPL was not distributed with this
-//  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+
 use std::sync::Arc;
 
 /// # Dutch Auction Data
@@ -68,6 +73,7 @@ impl DutchAuctionData {
     }
 }
 
+/// NFT Dutch Auction Contract
 #[derive(JsonSchema, Serialize, Deserialize)]
 pub struct NFTDutchAuction {
     /// This data can be specified directly, or default derived from main

--- a/plugin-example/nft-sale/src/plugin.rs
+++ b/plugin-example/nft-sale/src/plugin.rs
@@ -4,6 +4,9 @@
 //  License, v. 2.0. If a copy of the MPL was not distributed with this
 //  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #![deny(missing_docs)]
+
+//! NFT Sale Contract
+
 use bitcoin::Amount;
 use sapio::contract::CompilationError;
 use sapio::contract::Contract;

--- a/plugin-example/op_return_chain/src/plugin.rs
+++ b/plugin-example/op_return_chain/src/plugin.rs
@@ -4,6 +4,9 @@
 //  License, v. 2.0. If a copy of the MPL was not distributed with this
 //  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #![deny(missing_docs)]
+
+//! Op Return Chain
+
 use sapio::*;
 use sapio_contrib::contracts::op_return_chain::ChainReturn;
 use sapio_wasm_plugin::client::*;

--- a/plugin-example/payment_pool/src/payment_pool.rs
+++ b/plugin-example/payment_pool/src/payment_pool.rs
@@ -5,6 +5,9 @@
 //  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //! Payment Pool Contract for Sapio Studio Advent Calendar Entry
 #![deny(missing_docs)]
+
+//! Payment Pool Contract
+
 use crate::sapio_base::Clause;
 
 use bitcoin::hashes::sha256;

--- a/plugin-example/staker/src/plugin.rs
+++ b/plugin-example/staker/src/plugin.rs
@@ -5,6 +5,9 @@
 //  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #![deny(missing_docs)]
+
+//! Staker Contract
+
 use sapio_wasm_plugin::client::*;
 use sapio_wasm_plugin::*;
 use schemars::*;

--- a/plugin-example/trampolinepay/src/plugin.rs
+++ b/plugin-example/trampolinepay/src/plugin.rs
@@ -5,6 +5,9 @@
 //  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #![deny(missing_docs)]
+
+//! Trampoline Payment (basic congestion control)
+
 use batching_trait::{BatchingModule, BatchingTraitVersion0_1_1};
 
 use sapio::contract::*;

--- a/plugin-example/treepay/src/plugin.rs
+++ b/plugin-example/treepay/src/plugin.rs
@@ -3,9 +3,11 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 //  License, v. 2.0. If a copy of the MPL was not distributed with this
 //  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#![deny(missing_docs)]
+
+//! TreePay is a basic congestion controlled payment
 
 use batching_trait::{BatchingTraitVersion0_1_1, Payment};
-#![deny(missing_docs)]
 use sapio::contract::*;
 use sapio::util::amountrange::*;
 use sapio::*;

--- a/plugin-example/vault/src/plugin.rs
+++ b/plugin-example/vault/src/plugin.rs
@@ -4,6 +4,8 @@
 //  License, v. 2.0. If a copy of the MPL was not distributed with this
 //  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+//! Vault Contract
+
 #![deny(missing_docs)]
 use sapio::contract::*;
 

--- a/sapio-base/src/simp/mod.rs
+++ b/sapio-base/src/simp/mod.rs
@@ -6,6 +6,12 @@
 
 //! Utilities for working with SIMPs (Sapio Interactive Metadata Protocols)
 
+use std::{
+    collections::BTreeMap,
+    marker::PhantomData,
+    ops::{Index, Shl, ShlAssign, Shr},
+};
+
 use serde_json::Value;
 
 /// Errors that may come up when working with SIMPs
@@ -38,6 +44,15 @@ impl From<serde_json::Error> for SIMPError {
 pub trait SIMP {
     /// Get a protocol number, which should be one that is assigned through the
     /// SIMP repo. Proprietary SIMPs can safely use negative numbers.
+    fn static_get_protocol_number() -> i64
+    where
+        Self: Sized;
+    /// Get a protocol number, which should be one that is assigned through the
+    /// SIMP repo. Proprietary SIMPs can safely use negative numbers.
+    ///
+    /// Should be implementd as a pass throught to
+    /// [`Self::static_get_protocol_number`], but the  trait system can't
+    /// express that
     fn get_protocol_number(&self) -> i64;
     /// Conver a SIMP to a JSON. Concretely typed so that SIMP can be a trait object.
     fn to_json(&self) -> Result<Value, serde_json::Error>;
@@ -71,4 +86,89 @@ pub trait SIMPAttachableAt<T: LocationTag>
 where
     Self: SIMP,
 {
+}
+
+/// Trait Type Wrapper for Indexing with a SIMP.
+///
+/// Given a BTreeMap of SIMPs b, you can index it with the following syntax:
+///
+/// ```
+/// use sapio_base::simp::SIMP;
+/// use serde_json::Value;
+/// use sapio_base::simp::by_simp;
+/// use sapio_base::simp::simp_value;
+/// use std::collections::BTreeMap;
+/// struct MySimp(Value);
+/// impl SIMP for MySimp {
+/// fn static_get_protocol_number() -> i64
+/// where
+///     Self: Sized,
+/// {
+///     1234
+/// }
+/// fn get_protocol_number(&self) -> i64 {
+///     Self::static_get_protocol_number()
+/// }
+/// fn to_json(&self) -> Result<Value, serde_json::Error> {
+///     Ok(self.0.clone())
+/// }
+/// fn from_json(value: Value) -> Result<Self, serde_json::Error>
+/// where
+///     Self: Sized,
+/// {
+///     Ok(Self(value))
+/// }
+/// }
+/// let mut b : BTreeMap<i64, Box<dyn SIMP>> = BTreeMap::new();
+/// b <<= Box::new(MySimp("Howdy".into()));
+/// if let Some(simp) = &b >> by_simp::<MySimp>() {
+/// } else {
+///     panic!();
+/// }
+/// let mut c : BTreeMap<i64, Value> = BTreeMap::new();
+/// c <<= simp_value(MySimp("Howdy 2".into()));
+/// if let Some(simp) = &c >> by_simp::<MySimp>() {
+/// } else {
+///     panic!();
+/// }
+/// ```
+pub struct BySIMP<T>(pub PhantomData<T>);
+/// Helper for indexing BySimp
+pub fn by_simp<T>() -> BySIMP<T> {
+    BySIMP(Default::default())
+}
+
+/// Wrapper to write to simp
+pub struct SimpValue<T>(pub T);
+/// Wrapper helper to write to simp
+pub fn simp_value<T: SIMP>(v: T) -> SimpValue<T> {
+    SimpValue(v)
+}
+
+impl<T: SIMP> ShlAssign<SimpValue<T>> for BTreeMap<i64, Value> {
+    fn shl_assign(&mut self, rhs: SimpValue<T>) {
+        if let Ok(js) = rhs.0.to_json() {
+            self.insert(T::static_get_protocol_number(), js);
+        }
+    }
+}
+
+impl ShlAssign<Box<dyn SIMP>> for BTreeMap<i64, Box<dyn SIMP>> {
+    fn shl_assign(&mut self, rhs: Box<dyn SIMP>) {
+        self.insert(rhs.get_protocol_number(), rhs);
+    }
+}
+
+impl<'a, T: SIMP, V> Shr<BySIMP<T>> for &'a BTreeMap<i64, V> {
+    type Output = Option<&'a V>;
+    fn shr(self, rhs: BySIMP<T>) -> Self::Output {
+        self.get(&T::static_get_protocol_number())
+    }
+}
+
+impl<'a, T: SIMP, V> Shr<BySIMP<T>> for &'a mut BTreeMap<i64, V> {
+    type Output = Option<&'a mut V>;
+    fn shr(self, rhs: BySIMP<T>) -> Self::Output {
+        self.get_mut(&T::static_get_protocol_number())
+    }
 }

--- a/simp-pack/src/lib.rs
+++ b/simp-pack/src/lib.rs
@@ -65,7 +65,7 @@ impl IpfsNFT {
 }
 impl SIMP for IpfsNFT {
     fn get_protocol_number(&self) -> i64 {
-        -12345
+        Self::static_get_protocol_number()
     }
 
     fn to_json(&self) -> Result<serde_json::Value, serde_json::Error> {
@@ -77,6 +77,10 @@ impl SIMP for IpfsNFT {
         Self: Sized,
     {
         serde_json::from_value(value)
+    }
+
+    fn static_get_protocol_number() -> i64 {
+        -12345
     }
 }
 


### PR DESCRIPTION
@ProofOfKeags I think this does what you wanted -- we have to use shlassign / shr because the standard indexing interfaces can't return an option from get dues to the use of temporary issue (unless you do something wild...)