### PR TITLE
hotfix/descriptor

### DIFF
--- a/sapio/src/contract/compiler/mod.rs
+++ b/sapio/src/contract/compiler/mod.rs
@@ -329,7 +329,9 @@ where
         let tree = branches_to_tree(branches);
         let descriptor = Descriptor::Tr(descriptor::Tr::new(some_key, tree)?);
         let estimated_max_size = descriptor.max_satisfaction_weight()?;
-        let address = descriptor.address(ctx.network)?.into();
+        // TODO: Convert into an address instead of keeping descriptor,
+        // hot-fix workaround
+        let address = descriptor.clone().into();
         let descriptor = Some(descriptor.into());
         let root_path = SArc(ctx.path().clone());
 


### PR DESCRIPTION
computing the address was panicking only in WASM, this PR rips out computing the address and punts it up the stack for out of wasm consumers.