### PR TITLE
Validate compiled artifacts and PSBTs before binding or signing

### DIFF
--- a/cli/src/contracts/request.rs
+++ b/cli/src/contracts/request.rs
@@ -275,6 +275,7 @@ impl Bind {
             outpoint,
             ordinals_info,
         } = self;
+        compiled.validate()?;
         let use_txn = use_txn
             .map(|buf| base64::decode(buf.as_bytes()))
             .transpose()?

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -351,7 +351,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let psbt_str = args.value_of("psbt");
 
                 let psbt = get_psbt_from(psbt_str).await?;
-                let js = sapio_psbt::external_api::finalize_psbt_format_api(psbt);
+                let js = sapio_psbt::external_api::finalize_psbt_format_api(psbt)?;
                 println!("{}", serde_json::to_string_pretty(&js)?);
             }
             _ => unreachable!(),

--- a/docs/CTV_FORK_AUDIT.md
+++ b/docs/CTV_FORK_AUDIT.md
@@ -1,0 +1,105 @@
+# CTV hashing and finalization in the Miniscript fork
+
+This audit records the remaining CTV boundary work after Sapio's local hash fix.
+It is based on the dependency source used by the lockfiles, inspected on
+2026-09-07. It does not establish which chains enforce CTV.
+
+## Audited dependency
+
+- Package: `sapio-miniscript 7.0.2-alpha.0`.
+- Source revision: `3f23950459f3424ccfeecc0bb14579ec2aec9820`, recorded in the
+  published crate's `.cargo_vcs_info.json`.
+- Repository: [sapio-lang/rust-miniscript][fork].
+- Hashing and public PSBT extension: [`src/psbt/mod.rs`][psbt].
+- Finalization and interpreter checks: [`src/psbt/finalizer.rs`][finalizer].
+
+The findings concern this pinned source. A later fork release must be reviewed
+and tested before replacing it.
+
+## Findings and affected paths
+
+1. **The private hash helper omits scriptSigs.** `psbt::get_ctv_hash` at line 368
+   serializes version and locktime immediately followed by input count. BIP-119
+   requires an intervening hash of every serialized scriptSig when any is
+   nonempty. Sapio's corrected `CTVHash` implementation does not change this
+   dependency function.
+2. **Satisfaction uses the incomplete helper.** The public
+   `PsbtInputSatisfier::check_tx_template` implementation at line 362 extracts
+   the transaction, including `final_script_sig` fields, but then calls that
+   helper. A correct BIP-119 commitment for nonempty scriptSigs will not match.
+3. **Interpreter checks hash the unsigned transaction.**
+   `interpreter_inp_check` in `finalizer.rs`, line 320, passes
+   `psbt.unsigned_tx` to the helper. Fixing only the helper still excludes
+   finalized scriptSigs. This affects `PsbtExt` finalization, the public
+   `psbt::interpreter_check`, and `PsbtExt::extract`.
+4. **Sequential finalization does not recheck the complete result.**
+   `PsbtExt::finalize_mut` at line 605 verifies and finalizes one input at a
+   time. A later input can add a scriptSig and change the commitment of an
+   earlier CTV input. Per-input verification alone cannot establish that the
+   final transaction satisfies all CTV commitments. Correct positive-case
+   behavior also needs a defined order for obtaining committed scriptSigs.
+5. **Modern finalization bypasses the fork's PSBT sanity check.**
+   `finalize_mut` and `finalize_mall_mut` do not call `sanity_check`; the
+   deprecated helper does. Callers must validate transaction/metadata lengths
+   before these public paths reach indexed accesses. Sapio's
+   `finalize_psbt_format_api` calls the modern `PsbtExt::finalize` path.
+
+The [BIP-119 specification][bip119] describes the scriptSig commitment and the
+case of a CTV input combined with a legacy input whose exact scriptSig is known.
+That mixed-input case exposes the difference between hashing a template and
+checking the fully satisfied transaction.
+
+## Current supported domain and evidence
+
+The maintained Sapio builder emits templates with empty scriptSigs. Keep that
+restriction explicit at artifact boundaries while the fork repair is pending.
+Empty unsigned scriptSigs alone do not establish that an arbitrary external
+PSBT will retain empty scriptSigs when finalized.
+
+Sapio's [hash test](../sapio-base/tests/ctv_hash.rs) checks sixteen expected
+hashes from four official vectors against its local implementation. The fork's
+interpreter test supplies a hash directly, which cannot detect these defects.
+The [integration test](../integration_tests/tests/integration_test.rs) verifies
+two signer-emulated steps with empty scriptSigs; it does not exercise native CTV
+with mixed input types. General mixed-input CTV finalization remains unsupported.
+
+## Owned repair sequence
+
+1. Patch the maintained fork in its own repository, preserving the current
+   Bitcoin data model for this change. Add the missing scriptSig commitment and
+   validate the shared helper against the complete official hash corpus.
+2. Make interpreter checks use the candidate transaction's actual scriptSigs,
+   including the current candidate satisfaction. Define how finalization obtains
+   all required scriptSigs before deciding whether a CTV branch is satisfiable.
+3. Validate PSBT structure at the modern entry points. Check all inputs against
+   the complete finalized transaction before reporting successful finalization;
+   keep partial-finalization behavior explicit when a required scriptSig is
+   unavailable.
+4. Publish a reviewed release or pin its exact revision in both Sapio
+   workspaces. Run native and WASM checks before updating support claims.
+
+A local satisfier can override `check_tx_template`, and the public interpreter
+accepts a caller-supplied hash. Neither replaces the private helper and finalizer
+used by `PsbtExt`. Reimplementing finalization locally would duplicate substantial
+fork logic; keep this repair in the owned dependency.
+
+## Required regression evidence
+
+- Run the [full official corpus][vectors] against Sapio's hash and the fork's
+  helper, preserving every supplied index and expected result. The JSON starts
+  with a descriptive string before its vector objects.
+- Exercise the fork through `PsbtInputSatisfier::check_tx_template`, putting the
+  vector scriptSigs in PSBT `final_script_sig` fields rather than the unsigned
+  transaction. This checks the public satisfaction path as well as hash bytes.
+- Finalize native CTV alongside a fixed legacy scriptSig in either input
+  position. Require the permitted transaction to succeed and altered scriptSigs
+  or outputs to fail, including when another input is finalized later.
+- Check finalized transactions through `interpreter_check` and `PsbtExt::extract`,
+  and retain empty-scriptSig coverage. Malformed PSBT metadata must return errors
+  before indexing. These tests establish library behavior, not chain deployment.
+
+[fork]: https://github.com/sapio-lang/rust-miniscript
+[psbt]: https://github.com/sapio-lang/rust-miniscript/blob/3f23950459f3424ccfeecc0bb14579ec2aec9820/src/psbt/mod.rs
+[finalizer]: https://github.com/sapio-lang/rust-miniscript/blob/3f23950459f3424ccfeecc0bb14579ec2aec9820/src/psbt/finalizer.rs
+[bip119]: https://github.com/bitcoin/bips/blob/master/bip-0119.mediawiki
+[vectors]: https://github.com/bitcoin/bips/blob/master/bip-0119/vectors/ctvhash.json

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -109,6 +109,27 @@ reload the original `.wasm` files before referring to their cached keys:
 sapio-cli contract load --workspace PATH --file MODULE.wasm
 ```
 
+## Artifact boundaries
+
+Compiled artifacts have public fields and can be deserialized from JSON. Call
+`Object::validate()` before consuming one directly. `bind_psbt` validates the
+whole graph before requesting signatures or updating the transaction index;
+the CLI also validates before requesting a funding transaction. Errors identify
+the contract path and, when applicable, its template hash.
+
+Binding currently supports unsigned templates whose contract input is index
+zero. Template map keys and cached hashes must match the transaction, and output
+amounts/scripts must match the receiving-contract metadata. Optional input
+mappings contain one entry per input; entry zero must be `None` because the
+graph determines the contract input. Unknown template keys are rejected.
+
+Signing and finalization reject malformed PSBT maps before processing inputs.
+`finalize_psbt_format_api` returns `Result<PSBTApi, PSBTValidationError>`:
+structural errors are distinct from a valid PSBT still missing signatures.
+These checks establish structural consistency, not policy satisfaction, funding
+availability, chain enforcement, or general mixed-input CTV support. See the
+[CTV fork audit](CTV_FORK_AUDIT.md) for the remaining dependency work.
+
 ## Contributions
 
 Keep behavioral changes in small commits with focused regression coverage. Keep

--- a/docs/MODERNIZATION.md
+++ b/docs/MODERNIZATION.md
@@ -38,13 +38,15 @@ Wasmer 4, a Clap 3 beta, and an old JSON Schema validator. The forks implement
 CTV-specific policy/compiler/interpreter behavior. Replacing their package names
 with upstream crates would remove semantics, not complete a migration.
 
-### Implemented in this modernization branch
+### Implemented
 
 | Area | Change and evidence |
 | --- | --- |
 | Stable builds | Rust 1.98.1 pin, explicit compiler minimum, both dependency locks, resolver 2, removal of the nightly associated-type default |
 | Linux runtime compatibility | Upgrade Wasmer and its cache to 6.1.0, which provides the stack probe removed from Rust's x86 runtime; remove unused direct CLI runtime dependencies |
 | PSBT signing | Use the selected input index for key and script paths; reject sighash errors; verify signatures independently on a two-input transaction |
+| Artifact binding | Validate the complete object graph before signing or indexing: unsigned input-zero templates, matching commitments, descriptors, output metadata and funding totals; reject invalid auxiliary-input mappings |
+| PSBT structure | Reject empty-input transactions, mismatched input/output maps and populated unsigned scriptSigs/witnesses before signing or finalization; preserve the PSBT on structural rejection |
 | CTV hashing | Include nonempty scriptSig commitments; match 16 hash results from four unmodified BIP-119 vectors covering scriptSig and witness combinations |
 | Compiler termination | Advance duplicate-action suffixes; compile a contract registering one action three times |
 | Fees | Enforce the strongest requested minimum in virtual bytes against that template's reserved fees; reject overflow and unknown extra-input weights |
@@ -119,14 +121,17 @@ another. Never infer mainnet safety from a successful compilation or a unit test
 
 This is the next release blocker, before a broad dependency migration.
 
-- Audit the Sapio Miniscript fork's duplicate CTV-hash implementation. The local
-  Sapio hash fix does not patch registry source; the fork still needs equivalent
-  nonempty-scriptSig behavior. The maintained builder currently emits empty
-  scriptSigs. Run the full official hash corpus and finalization tests on both
-  implementations before claiming general transaction support.
-- Audit deserialized `Object`/`Template` and PSBT invariants before indexing input
-  zero or using caller-supplied output maps. Constructors should establish the
-  required invariant once. Add malformed-artifact tests at the public boundary.
+- Repair the Sapio Miniscript fork's CTV paths following the
+  [dependency audit](CTV_FORK_AUDIT.md). The local Sapio hash fix does not patch
+  registry source. The fork needs nonempty-scriptSig hashing, checks against the
+  fully finalized transaction, and defined scriptSig finalization ordering.
+  Keep the builder's empty-scriptSig domain explicit; run the full official hash
+  corpus and finalization tests before claiming general transaction support.
+- Extend artifact boundary checks to funding UTXO identity and emulator responses.
+  Structural graph and PSBT validation now run before binding, signing and
+  finalization. Resolve graph path collisions without rejecting valid reused
+  leaf objects; preserve transaction-index errors instead of treating every
+  failed lookup as missing funding data.
 - Replace the no-op `SapioJSONTrait` compatibility check. An example accepted by a
   schema is only a compatibility probe, not a proof of schema inclusion. Specify
   versioned interfaces and validate actual calls on both sides. Use an offline

--- a/sapio-psbt/src/external_api.rs
+++ b/sapio-psbt/src/external_api.rs
@@ -3,6 +3,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 //  License, v. 2.0. If a copy of the MPL was not distributed with this
 //  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+use crate::{validate_psbt, PSBTValidationError};
 use bitcoin::consensus::serialize;
 use miniscript::psbt::PsbtExt;
 use serde::{Deserialize, Serialize};
@@ -26,9 +27,15 @@ pub enum PSBTApi {
     },
 }
 
-pub fn finalize_psbt_format_api(psbt: PartiallySignedTransaction) -> PSBTApi {
+/// Finalize a structurally valid PSBT, retaining incomplete signing results.
+/// Malformed transaction and metadata fields return a validation error.
+pub fn finalize_psbt_format_api(
+    psbt: PartiallySignedTransaction,
+) -> Result<PSBTApi, PSBTValidationError> {
+    validate_psbt(&psbt)?;
     let secp = Secp256k1::new();
-    psbt.finalize(&secp)
+    Ok(psbt
+        .finalize(&secp)
         .map(|tx| {
             let hex = bitcoin::consensus::encode::serialize_hex(&tx.extract_tx());
             PSBTApi::Finished {
@@ -45,5 +52,5 @@ pub fn finalize_psbt_format_api(psbt: PartiallySignedTransaction) -> PSBTApi {
                 error: "Could not fully finalize psbt".into(),
                 errors,
             }
-        })
+        }))
 }

--- a/sapio-psbt/src/lib.rs
+++ b/sapio-psbt/src/lib.rs
@@ -70,9 +70,10 @@ impl SigningKey {
         secp: &Secp256k1<C>,
         hash_ty: bitcoin::SchnorrSighashType,
     ) -> Result<(), PSBTSigningError> {
+        validate_psbt(psbt)?;
         let l = psbt.inputs.len();
         for idx in 0..l {
-            self.sign_psbt_input_mut(psbt, secp, idx, hash_ty)?;
+            self.sign_validated_psbt_input_mut(psbt, secp, idx, hash_ty)?;
         }
         Ok(())
     }
@@ -89,6 +90,17 @@ impl SigningKey {
         }
     }
     pub fn sign_psbt_input_mut<C: Signing + Verification>(
+        &self,
+        psbt: &mut PartiallySignedTransaction,
+        secp: &Secp256k1<C>,
+        idx: usize,
+        hash_ty: bitcoin::SchnorrSighashType,
+    ) -> Result<(), PSBTSigningError> {
+        validate_psbt(psbt)?;
+        self.sign_validated_psbt_input_mut(psbt, secp, idx, hash_ty)
+    }
+
+    fn sign_validated_psbt_input_mut<C: Signing + Verification>(
         &self,
         psbt: &mut PartiallySignedTransaction,
         secp: &Secp256k1<C>,
@@ -274,6 +286,7 @@ impl SigningKey {
 
 #[derive(Debug, Clone)]
 pub enum PSBTSigningError {
+    InvalidPSBT(PSBTValidationError),
     NoUTXOAtIndex(usize),
     NoInputAtIndex(usize),
     Sighash(bitcoin::util::sighash::Error),
@@ -282,6 +295,7 @@ pub enum PSBTSigningError {
 impl Display for PSBTSigningError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::InvalidPSBT(error) => Display::fmt(error, f),
             Self::NoUTXOAtIndex(index) => write!(f, "missing witness UTXO for input {index}"),
             Self::NoInputAtIndex(index) => write!(f, "no input at index {index}"),
             Self::Sighash(error) => write!(f, "cannot compute signature hash: {error}"),
@@ -291,10 +305,80 @@ impl Display for PSBTSigningError {
 impl Error for PSBTSigningError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
+            Self::InvalidPSBT(error) => Some(error),
             Self::Sighash(error) => Some(error),
             _ => None,
         }
     }
+}
+
+impl From<PSBTValidationError> for PSBTSigningError {
+    fn from(error: PSBTValidationError) -> Self {
+        Self::InvalidPSBT(error)
+    }
+}
+
+/// A PSBT whose public fields violate the signing and finalization boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PSBTValidationError {
+    NoInputs,
+    InputMapCount { transaction: usize, maps: usize },
+    OutputMapCount { transaction: usize, maps: usize },
+    UnsignedTxHasScriptSig(usize),
+    UnsignedTxHasWitness(usize),
+}
+
+impl Display for PSBTValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoInputs => write!(f, "PSBT unsigned transaction has no inputs"),
+            Self::InputMapCount { transaction, maps } => write!(
+                f,
+                "PSBT has {maps} input maps for {transaction} transaction inputs"
+            ),
+            Self::OutputMapCount { transaction, maps } => write!(
+                f,
+                "PSBT has {maps} output maps for {transaction} transaction outputs"
+            ),
+            Self::UnsignedTxHasScriptSig(index) => {
+                write!(f, "PSBT unsigned transaction input {index} has a scriptSig")
+            }
+            Self::UnsignedTxHasWitness(index) => {
+                write!(f, "PSBT unsigned transaction input {index} has a witness")
+            }
+        }
+    }
+}
+
+impl Error for PSBTValidationError {}
+
+// Public PSBT fields can bypass the checks performed during deserialization.
+// Validate the complete shape before signing or entering the fork's finalizer.
+pub(crate) fn validate_psbt(psbt: &PartiallySignedTransaction) -> Result<(), PSBTValidationError> {
+    if psbt.unsigned_tx.input.is_empty() {
+        return Err(PSBTValidationError::NoInputs);
+    }
+    if psbt.inputs.len() != psbt.unsigned_tx.input.len() {
+        return Err(PSBTValidationError::InputMapCount {
+            transaction: psbt.unsigned_tx.input.len(),
+            maps: psbt.inputs.len(),
+        });
+    }
+    if psbt.outputs.len() != psbt.unsigned_tx.output.len() {
+        return Err(PSBTValidationError::OutputMapCount {
+            transaction: psbt.unsigned_tx.output.len(),
+            maps: psbt.outputs.len(),
+        });
+    }
+    for (index, input) in psbt.unsigned_tx.input.iter().enumerate() {
+        if !input.script_sig.is_empty() {
+            return Err(PSBTValidationError::UnsignedTxHasScriptSig(index));
+        }
+        if !input.witness.is_empty() {
+            return Err(PSBTValidationError::UnsignedTxHasWitness(index));
+        }
+    }
+    Ok(())
 }
 
 const DEFAULT_CODESEP: u32 = 0xffff_ffff;

--- a/sapio-psbt/tests/signing.rs
+++ b/sapio-psbt/tests/signing.rs
@@ -6,7 +6,8 @@ use bitcoin::util::psbt::PartiallySignedTransaction;
 use bitcoin::util::sighash::{Error as SighashError, Prevouts, SighashCache};
 use bitcoin::util::taproot::{LeafVersion, TapLeafHash, TaprootBuilder};
 use bitcoin::{Network, OutPoint, SchnorrSighashType, Script, Transaction, TxIn, TxOut};
-use sapio_psbt::{PSBTSigningError, SigningKey};
+use sapio_psbt::external_api::{finalize_psbt_format_api, PSBTApi};
+use sapio_psbt::{PSBTSigningError, PSBTValidationError, SigningKey};
 
 fn two_input_psbt() -> (SigningKey, PartiallySignedTransaction, Vec<TxOut>) {
     let secp = Secp256k1::new();
@@ -123,4 +124,114 @@ fn rejects_single_without_a_corresponding_output() {
     ));
     assert!(psbt.inputs[1].tap_key_sig.is_none());
     assert!(psbt.inputs[1].tap_script_sigs.is_empty());
+}
+
+fn assert_rejected_before_signing_or_finalizing(
+    keys: &SigningKey,
+    psbt: PartiallySignedTransaction,
+    expected: PSBTValidationError,
+) {
+    let secp = Secp256k1::new();
+    for selected_input in [None, Some(0)] {
+        let mut candidate = psbt.clone();
+        let error = match selected_input {
+            None => keys.sign_psbt_mut(&mut candidate, &secp, SchnorrSighashType::All),
+            Some(index) => {
+                keys.sign_psbt_input_mut(&mut candidate, &secp, index, SchnorrSighashType::All)
+            }
+        }
+        .unwrap_err();
+        assert!(
+            matches!(error, PSBTSigningError::InvalidPSBT(ref actual) if *actual == expected),
+            "unexpected signing error: {error}"
+        );
+        assert_eq!(candidate, psbt, "rejection must not add any signatures");
+    }
+    let Err(error) = finalize_psbt_format_api(psbt) else {
+        panic!("finalizer accepted a malformed PSBT");
+    };
+    assert_eq!(error, expected);
+}
+
+#[test]
+fn rejects_empty_transactions_before_signing_or_finalizing() {
+    let (keys, mut psbt, _) = two_input_psbt();
+    psbt.unsigned_tx.input.clear();
+    psbt.inputs.clear();
+    assert_rejected_before_signing_or_finalizing(&keys, psbt, PSBTValidationError::NoInputs);
+}
+
+#[test]
+fn rejects_missing_and_extra_input_maps_before_signing() {
+    for map_count in [0, 1, 3] {
+        let (keys, mut psbt, _) = two_input_psbt();
+        psbt.inputs.resize_with(map_count, Default::default);
+        assert_rejected_before_signing_or_finalizing(
+            &keys,
+            psbt,
+            PSBTValidationError::InputMapCount {
+                transaction: 2,
+                maps: map_count,
+            },
+        );
+    }
+}
+
+#[test]
+fn rejects_missing_and_extra_output_maps_before_signing() {
+    for map_count in [0, 2] {
+        let (keys, mut psbt, _) = two_input_psbt();
+        psbt.outputs.resize_with(map_count, Default::default);
+        assert_rejected_before_signing_or_finalizing(
+            &keys,
+            psbt,
+            PSBTValidationError::OutputMapCount {
+                transaction: 1,
+                maps: map_count,
+            },
+        );
+    }
+}
+
+#[test]
+fn rejects_scriptsig_in_unsigned_transaction_before_signing() {
+    let (keys, mut psbt, _) = two_input_psbt();
+    psbt.unsigned_tx.input[1].script_sig = Builder::new().push_int(1).into_script();
+    assert_rejected_before_signing_or_finalizing(
+        &keys,
+        psbt,
+        PSBTValidationError::UnsignedTxHasScriptSig(1),
+    );
+}
+
+#[test]
+fn rejects_witness_in_unsigned_transaction_before_signing() {
+    let (keys, mut psbt, _) = two_input_psbt();
+    psbt.unsigned_tx.input[1].witness.push([1]);
+    assert_rejected_before_signing_or_finalizing(
+        &keys,
+        psbt,
+        PSBTValidationError::UnsignedTxHasWitness(1),
+    );
+}
+
+#[test]
+fn finalizer_distinguishes_missing_signatures_from_complete_psbts() {
+    let (keys, mut psbt, _) = two_input_psbt();
+    assert!(matches!(
+        finalize_psbt_format_api(psbt.clone()).unwrap(),
+        PSBTApi::NotFinished {
+            completed: false,
+            ..
+        }
+    ));
+    keys.sign_psbt_mut(&mut psbt, &Secp256k1::new(), SchnorrSighashType::All)
+        .unwrap();
+    assert!(matches!(
+        finalize_psbt_format_api(psbt).unwrap(),
+        PSBTApi::Finished {
+            completed: true,
+            ..
+        }
+    ));
 }

--- a/sapio/src/contract/abi/object/bind.rs
+++ b/sapio/src/contract/abi/object/bind.rs
@@ -21,7 +21,7 @@ use sapio_base::miniscript;
 use sapio_base::serialization_helpers::SArc;
 use sapio_base::txindex::TxIndex;
 use sapio_ctv_emulator_trait::CTVEmulator;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -30,7 +30,13 @@ impl Object {
     /// Vector of PSBTs and transaction metadata.
     ///
     /// `bind_psbt` accepts a CTVEmulator, a txindex, and a map of outputs to be
-    /// bound to specific template hashes.
+    /// bound to specific template hashes. Each supplied vector must contain
+    /// one entry per transaction input. Entry zero must be `None`, since
+    /// `out_in` and the parent transaction outputs determine contract inputs.
+    /// Omitted mappings and `None` entries leave auxiliary inputs unresolved.
+    ///
+    /// The entire artifact and all mappings are validated before signing or
+    /// adding transactions to the index.
     pub fn bind_psbt(
         &self,
         out_in: bitcoin::OutPoint,
@@ -38,6 +44,40 @@ impl Object {
         blockdata: Rc<dyn TxIndex>,
         emulator: &dyn CTVEmulator,
     ) -> Result<Program, ObjectError> {
+        self.validate()?;
+        if !output_map.is_empty() {
+            let mut remaining: BTreeSet<_> = output_map.keys().collect();
+            let mut pending = vec![self];
+            while let Some(object) = pending.pop() {
+                for (hash, template) in object.ctv_to_tx.iter().chain(&object.suggested_txs) {
+                    if let Some(inputs) = output_map.get(hash) {
+                        let reason = if inputs.len() != template.tx.input.len() {
+                            Some("expected one entry per transaction input")
+                        } else if inputs[0].is_some() {
+                            Some(
+                                "entry zero must be None; the contract input is bound by the graph",
+                            )
+                        } else {
+                            None
+                        };
+                        if let Some(reason) = reason {
+                            return Err(ObjectError::InvalidInputMapping {
+                                template: *hash,
+                                reason,
+                            });
+                        }
+                        remaining.remove(hash);
+                    }
+                    pending.extend(template.outputs.iter().map(|output| &output.contract));
+                }
+            }
+            if let Some(hash) = remaining.first() {
+                return Err(ObjectError::InvalidInputMapping {
+                    template: **hash,
+                    reason: "template does not exist in the artifact",
+                });
+            }
+        }
         let mut result = BTreeMap::<SArc<EffectPath>, SapioStudioObject>::new();
         // Could use a queue instead to do BFS linking, but order doesn't matter and stack is
         // faster.
@@ -91,8 +131,7 @@ impl Object {
                                     }
                                 }
                                 let mut psbtx =
-                                    PartiallySignedTransaction::from_unsigned_tx(tx.clone())
-                                        .unwrap();
+                                    PartiallySignedTransaction::from_unsigned_tx(tx.clone())?;
                                 for (psbt_in, tx_in) in psbtx.inputs.iter_mut().zip(tx.input.iter())
                                 {
                                     psbt_in.witness_utxo =

--- a/sapio/src/contract/abi/object/error.rs
+++ b/sapio/src/contract/abi/object/error.rs
@@ -15,6 +15,17 @@ use sapio_ctv_emulator_trait::EmulatorError;
 /// Error types that can arise when constructing an Object
 #[derive(Debug)]
 pub enum ObjectError {
+    /// An artifact violates the transaction binding invariants.
+    InvalidArtifact(super::ArtifactError),
+    /// An auxiliary-input mapping does not match its template.
+    InvalidInputMapping {
+        /// The template whose input mapping is invalid.
+        template: bitcoin::hashes::sha256::Hash,
+        /// Explanation of the mapping error.
+        reason: &'static str,
+    },
+    /// The transaction cannot be represented as an unsigned PSBT.
+    Psbt(bitcoin::util::psbt::Error),
     /// The Error was due to Miniscript Policy
     MiniscriptPolicy(miniscript::policy::compiler::CompilerError),
     /// The Error was due to Miniscript
@@ -28,7 +39,25 @@ pub enum ObjectError {
     /// The Error was for an unknown/unhandled reason
     Custom(Box<dyn std::error::Error>),
 }
-impl std::error::Error for ObjectError {}
+impl std::error::Error for ObjectError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::InvalidArtifact(error) => Some(error),
+            Self::Psbt(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+impl From<super::ArtifactError> for ObjectError {
+    fn from(error: super::ArtifactError) -> Self {
+        Self::InvalidArtifact(error)
+    }
+}
+impl From<bitcoin::util::psbt::Error> for ObjectError {
+    fn from(error: bitcoin::util::psbt::Error) -> Self {
+        Self::Psbt(error)
+    }
+}
 impl From<TaprootBuilderError> for ObjectError {
     fn from(e: TaprootBuilderError) -> ObjectError {
         ObjectError::TaprootBulderError(e)
@@ -59,6 +88,13 @@ impl From<miniscript::Error> for ObjectError {
 
 impl std::fmt::Display for ObjectError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        match self {
+            Self::InvalidArtifact(error) => error.fmt(f),
+            Self::InvalidInputMapping { template, reason } => {
+                write!(f, "invalid input mapping for template {template}: {reason}")
+            }
+            Self::Psbt(error) => write!(f, "invalid unsigned transaction: {error}"),
+            _ => write!(f, "{:?}", self),
+        }
     }
 }

--- a/sapio/src/contract/abi/object/mod.rs
+++ b/sapio/src/contract/abi/object/mod.rs
@@ -10,6 +10,7 @@ pub mod error;
 pub use error::*;
 pub mod bind;
 pub mod descriptors;
+mod validation;
 use crate::contract::abi::continuation::ContinuationPoint;
 use crate::contract::CompilationError;
 use crate::template::Template;
@@ -31,6 +32,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::BTreeMap;
 use std::sync::Arc;
+pub use validation::{ArtifactError, ArtifactErrorKind};
 
 /// Metadata for Object, arbitrary KV set.
 #[derive(Serialize, Deserialize, Clone, JsonSchema, Debug, PartialEq, Eq, Default)]
@@ -100,8 +102,8 @@ impl ObjectMetadata {
 }
 
 /// Object holds a contract's complete context required post-compilation
-/// There is no guarantee that Object is properly constructed presently.
-//TODO: Make type immutable and correct by construction...
+/// Public fields and deserialization can produce inconsistent objects. Call
+/// [`Object::validate`] before using an artifact; binding performs this check.
 #[derive(Serialize, Deserialize, JsonSchema, Clone, Debug)]
 pub struct Object {
     /// a map of template hashes to the corresponding template, that in the

--- a/sapio/src/contract/abi/object/validation.rs
+++ b/sapio/src/contract/abi/object/validation.rs
@@ -1,0 +1,162 @@
+// Copyright Judica, Inc 2022
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use super::Object;
+use bitcoin::hashes::sha256::Hash;
+use sapio_base::effects::EffectPath;
+use sapio_base::serialization_helpers::SArc;
+use sapio_base::util::CTVHash;
+use std::fmt;
+
+/// The location and cause of an inconsistent compiled artifact.
+#[derive(Debug)]
+pub struct ArtifactError {
+    /// The affected contract's compilation path.
+    pub path: SArc<EffectPath>,
+    /// The template map key, when the error concerns a template.
+    pub template: Option<Hash>,
+    /// The violated invariant.
+    pub kind: ArtifactErrorKind,
+}
+
+/// Invariants required to bind a compiled artifact to transaction inputs.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ArtifactErrorKind {
+    /// The descriptor and advertised address describe different scripts.
+    DescriptorMismatch,
+    /// Binding requires a contract input at index zero.
+    MissingInput,
+    /// Only index zero is supported by the binder.
+    UnsupportedInputIndex(u32),
+    /// Input metadata must describe every transaction input exactly once.
+    InputMetadataCount,
+    /// Output metadata must describe every transaction output exactly once.
+    OutputMetadataCount,
+    /// A template must be unsigned, with empty scriptSigs and witnesses.
+    SignedInput(usize),
+    /// The map key, cached hash and transaction commitment must agree.
+    TemplateHashMismatch,
+    /// An output's amount or receiving script differs from its metadata.
+    OutputMismatch(usize),
+    /// The total output amount is not representable in satoshis.
+    OutputAmountOverflow,
+    /// The declared funding requirement is smaller than the output total.
+    InsufficientAmount,
+}
+
+impl fmt::Display for ArtifactErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DescriptorMismatch => write!(f, "descriptor does not match the address script"),
+            Self::MissingInput => write!(f, "missing contract input zero"),
+            Self::UnsupportedInputIndex(index) => {
+                write!(f, "unsupported contract input index {index}; expected zero")
+            }
+            Self::InputMetadataCount => {
+                write!(f, "input metadata count does not match the transaction")
+            }
+            Self::OutputMetadataCount => {
+                write!(f, "output metadata count does not match the transaction")
+            }
+            Self::SignedInput(index) => {
+                write!(f, "template input {index} has a scriptSig or witness")
+            }
+            Self::TemplateHashMismatch => write!(
+                f,
+                "template map key, cached hash and transaction commitment disagree"
+            ),
+            Self::OutputMismatch(index) => write!(
+                f,
+                "output {index} amount or script does not match its metadata"
+            ),
+            Self::OutputAmountOverflow => write!(f, "output amount total overflows"),
+            Self::InsufficientAmount => {
+                write!(f, "declared funding amount is below the output total")
+            }
+        }
+    }
+}
+
+impl fmt::Display for ArtifactError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "invalid artifact at {}",
+            String::from(self.path.0.as_ref().clone())
+        )?;
+        if let Some(template) = self.template {
+            write!(f, ", template {template}")?;
+        }
+        write!(f, ": {}", self.kind)
+    }
+}
+
+impl std::error::Error for ArtifactError {}
+
+impl Object {
+    /// Validate the entire graph before binding or requesting funding.
+    ///
+    /// Checks structural consistency and transaction commitments, including
+    /// suggested transactions. This does not prove policy satisfaction, chain
+    /// enforcement, funding availability, or the advertised fee rate.
+    pub fn validate(&self) -> Result<(), ArtifactError> {
+        let mut pending = vec![self];
+        while let Some(object) = pending.pop() {
+            let error = |template, kind| ArtifactError {
+                path: object.root_path.clone(),
+                template,
+                kind,
+            };
+            if let Some(descriptor) = &object.descriptor {
+                if descriptor.script_pubkey() != bitcoin::Script::from(&object.address) {
+                    return Err(error(None, ArtifactErrorKind::DescriptorMismatch));
+                }
+            }
+            for (key, template) in object.ctv_to_tx.iter().chain(&object.suggested_txs) {
+                let error = |kind| error(Some(*key), kind);
+                let tx = &template.tx;
+                if tx.input.is_empty() {
+                    return Err(error(ArtifactErrorKind::MissingInput));
+                }
+                if template.ctv_index != 0 {
+                    return Err(error(ArtifactErrorKind::UnsupportedInputIndex(
+                        template.ctv_index,
+                    )));
+                }
+                if tx.input.len() != template.inputs.len() {
+                    return Err(error(ArtifactErrorKind::InputMetadataCount));
+                }
+                if tx.output.len() != template.outputs.len() {
+                    return Err(error(ArtifactErrorKind::OutputMetadataCount));
+                }
+                for (index, input) in tx.input.iter().enumerate() {
+                    if !input.script_sig.is_empty() || !input.witness.is_empty() {
+                        return Err(error(ArtifactErrorKind::SignedInput(index)));
+                    }
+                }
+                if *key != template.ctv || template.ctv != tx.get_ctv_hash(0) {
+                    return Err(error(ArtifactErrorKind::TemplateHashMismatch));
+                }
+                let mut total = 0u64;
+                for (index, (output, info)) in tx.output.iter().zip(&template.outputs).enumerate() {
+                    if output.value != info.amount.as_sat()
+                        || output.script_pubkey != bitcoin::Script::from(&info.contract.address)
+                    {
+                        return Err(error(ArtifactErrorKind::OutputMismatch(index)));
+                    }
+                    total = total
+                        .checked_add(output.value)
+                        .ok_or_else(|| error(ArtifactErrorKind::OutputAmountOverflow))?;
+                    pending.push(&info.contract);
+                }
+                if total > template.max.as_sat() {
+                    return Err(error(ArtifactErrorKind::InsufficientAmount));
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/sapio/tests/artifact_validation.rs
+++ b/sapio/tests/artifact_validation.rs
@@ -1,0 +1,260 @@
+use bitcoin::hashes::{sha256, Hash};
+use bitcoin::psbt::PartiallySignedTransaction;
+use bitcoin::{Address, Amount, Network, OutPoint, Script, Transaction, Txid, Witness};
+use sapio::contract::abi::object::{ArtifactErrorKind, ObjectError};
+use sapio::contract::abi::studio::SapioStudioFormat;
+use sapio::contract::{Compilable, Compiled, Context, Contract};
+use sapio::template::Template;
+use sapio::{declare, then};
+use sapio_base::txindex::{TxIndex, TxIndexError, TxIndexLogger};
+use sapio_base::util::CTVHash;
+use sapio_base::Clause;
+use sapio_ctv_emulator_trait::{CTVAvailable, CTVEmulator, EmulatorError};
+use std::collections::BTreeMap;
+use std::rc::Rc;
+use std::str::FromStr;
+use std::sync::Arc;
+
+struct Payment {
+    destination: Compiled,
+    extra_input: bool,
+}
+
+impl Payment {
+    #[then]
+    fn pay(self, ctx: Context) {
+        let mut builder =
+            ctx.template()
+                .add_output(Amount::from_sat(1_000), &self.destination, None)?;
+        if self.extra_input {
+            builder = builder.add_sequence();
+        }
+        builder.into()
+    }
+}
+
+impl Contract for Payment {
+    declare! {then, Self::pay}
+    declare! {non updatable}
+}
+
+fn payment(destination: Compiled, extra_input: bool, path: &str) -> Compiled {
+    Payment {
+        destination,
+        extra_input,
+    }
+    .compile(Context::new(
+        Network::Regtest,
+        Amount::from_sat(1_000),
+        Arc::new(CTVAvailable),
+        path.try_into().unwrap(),
+        Arc::new(Default::default()),
+        None,
+    ))
+    .unwrap()
+}
+
+fn leaf() -> Compiled {
+    Compiled::from_address(
+        Address::from_str("bcrt1qumrrqgt7e3a7damzm8x97m6sjs20u8hjw2hcjj").unwrap(),
+        None,
+    )
+}
+
+fn wire_roundtrip(object: Compiled) -> Compiled {
+    serde_json::from_slice(&serde_json::to_vec(&object).unwrap()).unwrap()
+}
+
+fn template(object: &mut Compiled) -> &mut Template {
+    object.ctv_to_tx.values_mut().next().unwrap()
+}
+
+// A malformed graph must fail before even looking up a UTXO or asking a signer.
+struct NoEffects;
+
+impl TxIndex for NoEffects {
+    fn lookup_tx(&self, _: &Txid) -> Result<Arc<Transaction>, TxIndexError> {
+        panic!("invalid artifact reached transaction lookup");
+    }
+    fn add_tx(&self, _: Arc<Transaction>) -> Result<Txid, TxIndexError> {
+        panic!("invalid artifact reached transaction insertion");
+    }
+}
+
+impl CTVEmulator for NoEffects {
+    fn get_signer_for(&self, _: sha256::Hash) -> Result<Clause, EmulatorError> {
+        panic!("invalid artifact requested a signer");
+    }
+    fn sign(
+        &self,
+        _: PartiallySignedTransaction,
+    ) -> Result<PartiallySignedTransaction, EmulatorError> {
+        panic!("invalid artifact reached signing");
+    }
+}
+
+fn reject_artifact(object: Compiled, expected: ArtifactErrorKind) {
+    let object = wire_roundtrip(object);
+    let error = object
+        .bind_psbt(
+            OutPoint::default(),
+            BTreeMap::new(),
+            Rc::new(NoEffects),
+            &NoEffects,
+        )
+        .expect_err("malformed artifact was accepted");
+    let ObjectError::InvalidArtifact(error) = error else {
+        panic!("unexpected error: {error}");
+    };
+    assert_eq!(error.kind, expected);
+}
+
+#[test]
+fn rejects_malformed_unsigned_templates_at_the_binding_boundary() {
+    type Mutation = fn(&mut Template);
+    let cases: [(Mutation, ArtifactErrorKind); 11] = [
+        (|t| t.tx.input.clear(), ArtifactErrorKind::MissingInput),
+        (
+            |t| t.ctv_index = 1,
+            ArtifactErrorKind::UnsupportedInputIndex(1),
+        ),
+        (|t| t.inputs.clear(), ArtifactErrorKind::InputMetadataCount),
+        (
+            |t| t.outputs.clear(),
+            ArtifactErrorKind::OutputMetadataCount,
+        ),
+        (
+            |t| t.tx.input[0].script_sig = Script::from(vec![0x51]),
+            ArtifactErrorKind::SignedInput(0),
+        ),
+        (
+            |t| t.tx.input[0].witness = Witness::from_vec(vec![vec![1]]),
+            ArtifactErrorKind::SignedInput(0),
+        ),
+        (
+            |t| t.ctv = sha256::Hash::from_slice(&[0; 32]).unwrap(),
+            ArtifactErrorKind::TemplateHashMismatch,
+        ),
+        (
+            |t| t.tx.lock_time += 1,
+            ArtifactErrorKind::TemplateHashMismatch,
+        ),
+        (
+            |t| t.outputs[0].amount = Amount::from_sat(999),
+            ArtifactErrorKind::OutputMismatch(0),
+        ),
+        (
+            |t| {
+                t.outputs[0].contract.address =
+                    sapio::util::extended_address::ExtendedAddress::Unknown(Script::new())
+            },
+            ArtifactErrorKind::OutputMismatch(0),
+        ),
+        (
+            |t| t.max = Amount::from_sat(999),
+            ArtifactErrorKind::InsufficientAmount,
+        ),
+    ];
+    for (mutate, expected) in cases {
+        let mut object = payment(leaf(), false, "payment");
+        mutate(template(&mut object));
+        reject_artifact(object, expected);
+    }
+}
+
+#[test]
+fn rejects_inconsistent_map_keys_and_descriptors() {
+    let mut object = payment(leaf(), false, "payment");
+    let (_, t) = object.ctv_to_tx.pop_first().unwrap();
+    object
+        .ctv_to_tx
+        .insert(sha256::Hash::from_slice(&[0; 32]).unwrap(), t);
+    reject_artifact(object, ArtifactErrorKind::TemplateHashMismatch);
+
+    let mut object = payment(leaf(), false, "payment");
+    object.address = sapio::util::extended_address::ExtendedAddress::Unknown(Script::new());
+    reject_artifact(object, ArtifactErrorKind::DescriptorMismatch);
+}
+
+#[test]
+fn rejects_overflow_even_when_output_metadata_and_hashes_agree() {
+    let mut object = payment(leaf(), false, "payment");
+    let (_, mut t) = object.ctv_to_tx.pop_first().unwrap();
+    t.tx.output[0].value = u64::MAX;
+    t.outputs[0].amount = Amount::from_sat(u64::MAX);
+    t.tx.output.push(t.tx.output[0].clone());
+    t.outputs.push(t.outputs[0].clone());
+    t.max = Amount::from_sat(u64::MAX);
+    t.ctv = t.tx.get_ctv_hash(0);
+    object.ctv_to_tx.insert(t.ctv, t);
+    reject_artifact(object, ArtifactErrorKind::OutputAmountOverflow);
+}
+
+#[test]
+fn checks_nested_and_suggested_templates_before_any_side_effect() {
+    let inner = payment(leaf(), false, "inner");
+    let mut outer = payment(inner, false, "outer");
+    let inner = &mut template(&mut outer).outputs[0].contract;
+    let expected_path = inner.root_path.clone();
+    template(inner).tx.input.clear();
+    let error = outer.validate().unwrap_err();
+    assert_eq!(error.path, expected_path);
+    assert!(error.template.is_some());
+    reject_artifact(outer, ArtifactErrorKind::MissingInput);
+
+    let mut object = payment(leaf(), false, "suggested");
+    object.suggested_txs = std::mem::take(&mut object.ctv_to_tx);
+    object
+        .suggested_txs
+        .values_mut()
+        .next()
+        .unwrap()
+        .tx
+        .input
+        .clear();
+    reject_artifact(object, ArtifactErrorKind::MissingInput);
+}
+
+#[test]
+fn rejects_invalid_input_mappings_before_binding() {
+    let child = payment(leaf(), true, "child");
+    let child_hash = *child.ctv_to_tx.keys().next().unwrap();
+    let object = payment(child, false, "parent");
+    for mapping in [
+        BTreeMap::from([(child_hash, vec![None])]),
+        BTreeMap::from([(child_hash, vec![None, None, None])]),
+        BTreeMap::from([(child_hash, vec![Some(OutPoint::default()), None])]),
+        BTreeMap::from([(sha256::Hash::from_slice(&[0; 32]).unwrap(), vec![None])]),
+    ] {
+        assert!(matches!(
+            object.bind_psbt(OutPoint::default(), mapping, Rc::new(NoEffects), &NoEffects),
+            Err(ObjectError::InvalidInputMapping { .. })
+        ));
+    }
+}
+
+#[test]
+fn binds_roundtripped_artifacts_with_explicit_auxiliary_inputs() {
+    let object = wire_roundtrip(payment(leaf(), true, "payment"));
+    object.validate().unwrap();
+    let hash = *object.ctv_to_tx.keys().next().unwrap();
+    let contract_input = OutPoint::new(Txid::from_slice(&[0; 32]).unwrap(), 2);
+    let auxiliary_input = OutPoint::new(Txid::from_slice(&[0; 32]).unwrap(), 3);
+    let program = object
+        .bind_psbt(
+            contract_input,
+            BTreeMap::from([(hash, vec![None, Some(auxiliary_input)])]),
+            Rc::new(TxIndexLogger::new()),
+            &CTVAvailable,
+        )
+        .unwrap();
+    let txs = &program.program.get(&object.root_path).unwrap().txs;
+    assert_eq!(txs.len(), 1);
+    let SapioStudioFormat::LinkedPSBT { psbt, .. } = &txs[0];
+    let psbt: PartiallySignedTransaction =
+        bitcoin::consensus::deserialize(&base64::decode(psbt).unwrap()).unwrap();
+    assert_eq!(psbt.unsigned_tx.input[0].previous_output, contract_input);
+    assert_eq!(psbt.unsigned_tx.input[1].previous_output, auxiliary_input);
+    assert_eq!(psbt.unsigned_tx.get_ctv_hash(0), hash);
+    assert_eq!(psbt.unsigned_tx.output[0].value, 1_000);
+}


### PR DESCRIPTION
Malformed compiled contracts can currently panic during binding or pair output metadata with a different transaction. Public PSBT fields can also bypass parser invariants and reach unchecked signing/finalization paths.

Validate the complete contract graph before CLI funding requests, signatures, or transaction-index updates. Check unsigned input-zero templates, template commitments, descriptors, metadata counts, output amounts/scripts, and output totals. Validate auxiliary-input mappings before binding and report the affected contract path and template.

Reject structurally malformed PSBTs before signing or finalization, with typed errors and no signatures added on rejection. `finalize_psbt_format_api` now returns `Result<PSBTApi, PSBTValidationError>`; the CLI propagates structural errors while valid incomplete PSBTs retain their existing response.

Validation: 51 workspace tests passed, 8 doctests ignored; six artifact tests also pass with Sapio built independently. Formatting, Clippy, API docs, all WASM example builds, and direct/cross-module CLI smoke tests pass. Regressions cover malformed nested and suggested templates, rejection before any side effects, explicit auxiliary inputs, malformed PSBT maps, and successful finalization.

The three commits separate artifact validation, PSBT validation, and documentation. The included CTV fork audit records the remaining scriptSig hashing and complete-transaction finalization work. Funding UTXO checks, emulator response validation, graph path collisions, and general mixed-input CTV support remain follow-ups.
