### PR TITLE
Validate funding and signer integrity in bound contract graphs

### DIFF
--- a/cli/src/contracts/request.rs
+++ b/cli/src/contracts/request.rs
@@ -3,7 +3,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 //  License, v. 2.0. If a copy of the MPL was not distributed with this
 //  file, You can obtain one at https://mozilla.org/MPL/2.0/.
-use bitcoin::{consensus::Decodable, psbt::PartiallySignedTransaction, OutPoint};
+use bitcoin::{consensus::deserialize, psbt::PartiallySignedTransaction, OutPoint};
 use bitcoincore_rpc_async as rpc;
 use bitcoincore_rpc_async::RpcApi;
 use emulator_connect::{CTVAvailable, CTVEmulator};
@@ -19,7 +19,7 @@ use sapio::{
 use sapio_base::{
     effects::{MapEffectDB, PathFragment},
     serialization_helpers::SArc,
-    txindex::{TxIndex, TxIndexLogger},
+    txindex::{TxIndex, TxIndexError, TxIndexLogger},
 };
 use sapio_wasm_plugin::{
     host::{plugin_handle::ModuleLocator, PluginHandle, WasmPluginHandle},
@@ -279,10 +279,13 @@ impl Bind {
         let use_txn = use_txn
             .map(|buf| base64::decode(buf.as_bytes()))
             .transpose()?
-            .map(|b| PartiallySignedTransaction::consensus_decode(&b[..]))
+            .map(|b| deserialize::<PartiallySignedTransaction>(&b))
             .transpose()?;
+        if let Some(psbt) = &use_txn {
+            sapio_psbt::validate_psbt(psbt)?;
+        }
         let client = rpc::Client::new(client_url, client_auth).await?;
-        let (tx, vout) = if use_mock {
+        let (tx, vout, funding_psbt) = if use_mock {
             let ctx = Context::new(
                 net,
                 compiled.amount_range.max(),
@@ -296,43 +299,33 @@ impl Bind {
                 .add_output(compiled.amount_range.max(), &compiled, None)?
                 .get_tx();
             tx.input[0].previous_output = create_mock_output();
-            (tx, 0)
+            let psbt = if outpoint.is_none() {
+                Some(PartiallySignedTransaction::from_unsigned_tx(tx.clone())?)
+            } else {
+                None
+            };
+            (tx, 0, psbt)
         } else if let Some(outpoint) = outpoint {
             let res = client.get_raw_transaction(&outpoint.txid, None).await?;
-            (res, outpoint.vout)
+            validate_funding_outpoint(&res, outpoint)?;
+            (res, outpoint.vout, None)
         } else {
             let mut spends = HashMap::new();
             if let ExtendedAddress::Address(ref a) = compiled.address {
                 spends.insert(format!("{}", a), compiled.amount_range.max());
 
-                if let Some(psbt) = use_txn {
-                    let script = a.script_pubkey();
-                    if let Some(pos) = psbt
-                        .unsigned_tx
-                        .output
-                        .iter()
-                        .enumerate()
-                        .find(|(_, o)| o.script_pubkey == script)
-                        .map(|(i, _)| i)
-                    {
-                        (psbt.extract_tx(), pos as u32)
-                    } else {
-                        return Err(Err(RequestError(
-                            format!("No Output found {:?} {:?}", psbt.unsigned_tx, a).into(),
-                        ))?);
-                    }
+                let psbt = if let Some(psbt) = use_txn {
+                    psbt
                 } else {
                     let res = client
                         .wallet_create_funded_psbt(&[], &spends, None, None, None)
                         .await?;
-                    let psbt = PartiallySignedTransaction::consensus_decode(
-                        &base64::decode(&res.psbt)?[..],
-                    )?;
-                    let tx = psbt.extract_tx();
-                    // if change pos is -1, then +1%len == 0. if it is 0, then 1. if 1, then 2 % len == 0.
-                    let vout = ((res.change_position + 1) as usize) % tx.output.len();
-                    (tx, vout as u32)
-                }
+                    deserialize(&base64::decode(&res.psbt)?)?
+                };
+                let vout = funding_output(&psbt, &a.script_pubkey())?;
+                // Final scriptSigs can change the TXID. Bind the extracted
+                // transaction while retaining the complete PSBT for signing.
+                (psbt.clone().extract_tx(), vout, Some(psbt))
             } else {
                 return Err(Err(RequestError("Must have a valid address".into()))?);
             }
@@ -340,16 +333,15 @@ impl Bind {
         let logger = Rc::new(TxIndexLogger::new());
         (*logger).add_tx(Arc::new(tx.clone()))?;
         let mut bound = compiled.bind_psbt(
-            OutPoint::new(tx.txid(), vout as u32),
+            OutPoint::new(tx.txid(), vout),
             BTreeMap::new(),
             logger,
             emulator.as_ref(),
         )?;
-        if outpoint.is_none() {
+        if let Some(psbt) = funding_psbt {
             let added_output_metadata = vec![OutputMeta::default(); tx.output.len()];
             let output_metadata = vec![ObjectMetadata::default(); tx.output.len()];
             let out = tx.input[0].previous_output;
-            let psbt = PartiallySignedTransaction::from_unsigned_tx(tx)?;
             bound.program.insert(
                 SArc(Arc::new("funding".try_into()?)),
                 SapioStudioObject {
@@ -374,3 +366,36 @@ impl Bind {
         Ok(bound)
     }
 }
+
+fn funding_output(psbt: &PartiallySignedTransaction, script: &bitcoin::Script) -> ResultT<u32> {
+    sapio_psbt::validate_psbt(psbt)?;
+    let index = psbt
+        .unsigned_tx
+        .output
+        .iter()
+        .position(|output| output.script_pubkey == *script)
+        .ok_or_else(|| {
+            RequestError("Funding transaction has no output paying the contract".into())
+        })?;
+    Ok(index.try_into()?)
+}
+
+fn validate_funding_outpoint(
+    tx: &bitcoin::Transaction,
+    outpoint: OutPoint,
+) -> Result<(), TxIndexError> {
+    let actual = tx.txid();
+    if actual != outpoint.txid {
+        return Err(TxIndexError::TxidMismatch {
+            expected: outpoint.txid,
+            actual,
+        });
+    }
+    if outpoint.vout as usize >= tx.output.len() {
+        return Err(TxIndexError::IndexTooHigh(outpoint.vout));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/cli/src/contracts/request.rs
+++ b/cli/src/contracts/request.rs
@@ -17,7 +17,7 @@ use sapio::{
     Context,
 };
 use sapio_base::{
-    effects::{MapEffectDB, PathFragment},
+    effects::{EffectPath, MapEffectDB, PathFragment},
     serialization_helpers::SArc,
     txindex::{TxIndex, TxIndexError, TxIndexLogger},
 };
@@ -343,8 +343,12 @@ impl Bind {
             let output_metadata = vec![ObjectMetadata::default(); tx.output.len()];
             let out = tx.input[0].previous_output;
             bound.program.insert(
-                SArc(Arc::new("funding".try_into()?)),
+                SArc(EffectPath::push(
+                    Some(compiled.root_path.0.clone()),
+                    PathFragment::Funding,
+                )),
                 SapioStudioObject {
+                    source_path: None,
                     metadata: Default::default(),
                     out,
                     continue_apis: Default::default(),

--- a/cli/src/contracts/request/tests.rs
+++ b/cli/src/contracts/request/tests.rs
@@ -1,0 +1,249 @@
+use super::*;
+use bitcoin::consensus::{deserialize, encode::serialize_hex, serialize};
+use bitcoin::psbt::raw::Key;
+use bitcoin::secp256k1::{Message, Secp256k1, SecretKey};
+use bitcoin::{
+    Address, EcdsaSig, EcdsaSighashType, Network, PublicKey, Script, Transaction, TxIn, TxOut,
+};
+use sapio::contract::abi::studio::SapioStudioFormat;
+use std::str::FromStr;
+
+fn contract() -> Compiled {
+    Compiled::from_address(
+        Address::from_str("bcrt1qumrrqgt7e3a7damzm8x97m6sjs20u8hjw2hcjj").unwrap(),
+        None,
+    )
+}
+
+fn funding_psbt(compiled: &Compiled) -> PartiallySignedTransaction {
+    let tx = Transaction {
+        version: 2,
+        lock_time: 0,
+        input: vec![TxIn::default()],
+        output: vec![
+            TxOut {
+                value: 500,
+                script_pubkey: Script::new(),
+            },
+            TxOut {
+                value: 1_000,
+                script_pubkey: (&compiled.address).into(),
+            },
+        ],
+    };
+    let mut psbt = PartiallySignedTransaction::from_unsigned_tx(tx).unwrap();
+    let unknown = |key| Key {
+        type_value: 0xfa,
+        key: vec![key],
+    };
+    psbt.unknown.insert(unknown(1), vec![2]);
+    psbt.inputs[0].unknown.insert(unknown(3), vec![4]);
+    psbt.outputs[1].unknown.insert(unknown(5), vec![6]);
+    psbt
+}
+
+fn request(compiled: Compiled, psbt: &[u8]) -> Bind {
+    Bind {
+        client_url: "http://127.0.0.1:1".into(),
+        client_auth: rpc::Auth::None,
+        use_base64: true,
+        use_mock: false,
+        outpoint: None,
+        use_txn: Some(base64::encode(psbt)),
+        compiled,
+        ordinals_info: None,
+    }
+}
+
+fn assert_preserved_funding(
+    bound: &Program,
+    compiled: &Compiled,
+    expected: &PartiallySignedTransaction,
+) {
+    let expected_tx = expected.clone().extract_tx();
+    assert_eq!(
+        bound.program.get(&compiled.root_path).unwrap().out,
+        OutPoint::new(expected_tx.txid(), 1)
+    );
+    let funding = bound
+        .program
+        .values()
+        .flat_map(|object| &object.txs)
+        .find(|entry| {
+            let SapioStudioFormat::LinkedPSBT { metadata, .. } = entry;
+            metadata.label.as_deref() == Some("funding")
+        })
+        .unwrap();
+    let SapioStudioFormat::LinkedPSBT { psbt, hex, .. } = funding;
+    let restored: PartiallySignedTransaction = deserialize(&base64::decode(psbt).unwrap()).unwrap();
+    assert_eq!(restored, *expected);
+    assert_eq!(*hex, serialize_hex(&expected_tx));
+}
+
+#[tokio::test]
+async fn supplied_funding_keeps_partial_signatures_and_all_psbt_maps() {
+    let compiled = contract();
+    let mut psbt = funding_psbt(&compiled);
+    let secp = Secp256k1::new();
+    let secret = SecretKey::from_slice(&[1; 32]).unwrap();
+    let key = PublicKey::new(bitcoin::secp256k1::PublicKey::from_secret_key(
+        &secp, &secret,
+    ));
+    let sig = EcdsaSig {
+        sig: secp.sign_ecdsa(&Message::from_digest_slice(&[2; 32]).unwrap(), &secret),
+        hash_ty: EcdsaSighashType::All,
+    };
+    psbt.inputs[0].partial_sigs.insert(key, sig);
+    let bound = request(compiled.clone(), &serialize(&psbt))
+        .call(Network::Regtest, Arc::new(CTVAvailable))
+        .await
+        .unwrap();
+    assert_preserved_funding(&bound, &compiled, &psbt);
+}
+
+#[tokio::test]
+async fn finalized_legacy_funding_keeps_its_psbt_and_binds_the_extracted_txid() {
+    let compiled = contract();
+    let mut psbt = funding_psbt(&compiled);
+    psbt.inputs[0].final_script_sig = Some(Script::from(vec![1, 0x42]));
+    assert_ne!(psbt.unsigned_tx.txid(), psbt.clone().extract_tx().txid());
+    let bound = request(compiled.clone(), &serialize(&psbt))
+        .call(Network::Regtest, Arc::new(CTVAvailable))
+        .await
+        .unwrap();
+    assert_preserved_funding(&bound, &compiled, &psbt);
+}
+
+#[tokio::test]
+async fn zero_input_funding_psbt_returns_a_validation_error() {
+    let compiled = contract();
+    let mut psbt = funding_psbt(&compiled);
+    psbt.unsigned_tx.input.clear();
+    psbt.inputs.clear();
+    let error = request(compiled, &serialize(&psbt))
+        .call(Network::Regtest, Arc::new(CTVAvailable))
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        error.downcast_ref::<sapio_psbt::PSBTValidationError>(),
+        Some(sapio_psbt::PSBTValidationError::NoInputs)
+    ));
+}
+
+#[tokio::test]
+async fn supplied_funding_rejects_trailing_psbt_bytes() {
+    let compiled = contract();
+    let mut bytes = serialize(&funding_psbt(&compiled));
+    bytes.push(0);
+    assert!(request(compiled, &bytes)
+        .call(Network::Regtest, Arc::new(CTVAvailable))
+        .await
+        .is_err());
+}
+
+#[test]
+fn funding_output_uses_the_contract_script_and_rejects_missing_outputs() {
+    let compiled = contract();
+    let script = bitcoin::Script::from(&compiled.address);
+    let mut psbt = funding_psbt(&compiled);
+    assert_eq!(funding_output(&psbt, &script).unwrap(), 1);
+    psbt.unsigned_tx.output.swap(0, 1);
+    psbt.outputs.swap(0, 1);
+    assert_eq!(funding_output(&psbt, &script).unwrap(), 0);
+
+    psbt.unsigned_tx.output[0].script_pubkey = Script::new();
+    assert!(funding_output(&psbt, &script)
+        .unwrap_err()
+        .is::<RequestError>());
+    psbt.unsigned_tx.output.clear();
+    psbt.outputs.clear();
+    assert!(funding_output(&psbt, &script)
+        .unwrap_err()
+        .is::<RequestError>());
+}
+
+#[test]
+fn funding_output_validates_psbt_maps_before_extraction() {
+    use sapio_psbt::PSBTValidationError;
+
+    let compiled = contract();
+    let script = bitcoin::Script::from(&compiled.address);
+    let mut psbt = funding_psbt(&compiled);
+    psbt.inputs.clear();
+    assert_eq!(
+        funding_output(&psbt, &script)
+            .unwrap_err()
+            .downcast_ref::<PSBTValidationError>(),
+        Some(&PSBTValidationError::InputMapCount {
+            transaction: 1,
+            maps: 0,
+        })
+    );
+
+    let mut psbt = funding_psbt(&compiled);
+    psbt.outputs.pop();
+    assert_eq!(
+        funding_output(&psbt, &script)
+            .unwrap_err()
+            .downcast_ref::<PSBTValidationError>(),
+        Some(&PSBTValidationError::OutputMapCount {
+            transaction: 2,
+            maps: 1,
+        })
+    );
+}
+
+#[test]
+fn rpc_funding_must_match_the_requested_txid_and_output_index() {
+    let tx = funding_psbt(&contract()).extract_tx();
+    let requested = OutPoint::new(tx.txid(), 1);
+    validate_funding_outpoint(&tx, requested).unwrap();
+    assert!(matches!(
+        validate_funding_outpoint(&tx, OutPoint::new(tx.txid(), 2)),
+        Err(TxIndexError::IndexTooHigh(2))
+    ));
+
+    let mut wrong = tx;
+    wrong.output[1].value += 1;
+    for vout in [1, 2] {
+        assert!(matches!(
+            validate_funding_outpoint(&wrong, OutPoint { vout, ..requested }),
+            Err(TxIndexError::TxidMismatch { expected, actual })
+                if expected == requested.txid && actual == wrong.txid()
+        ));
+    }
+}
+
+#[tokio::test]
+async fn mock_funding_still_includes_a_funding_psbt() {
+    let compiled = contract();
+    let mut bind = request(compiled.clone(), &serialize(&funding_psbt(&compiled)));
+    bind.use_txn = None;
+    bind.use_mock = true;
+    let bound = bind
+        .call(Network::Regtest, Arc::new(CTVAvailable))
+        .await
+        .unwrap();
+    let funding = bound
+        .program
+        .values()
+        .flat_map(|object| &object.txs)
+        .next()
+        .unwrap();
+    let SapioStudioFormat::LinkedPSBT { psbt, .. } = funding;
+    let psbt: PartiallySignedTransaction = deserialize(&base64::decode(psbt).unwrap()).unwrap();
+    sapio_psbt::validate_psbt(&psbt).unwrap();
+    assert_eq!(
+        psbt.unsigned_tx.input[0].previous_output,
+        create_mock_output()
+    );
+    assert_eq!(psbt.unsigned_tx.output.len(), 1);
+    assert_eq!(
+        psbt.unsigned_tx.output[0].script_pubkey,
+        bitcoin::Script::from(&compiled.address)
+    );
+    assert_eq!(
+        bound.program.get(&compiled.root_path).unwrap().out,
+        OutPoint::new(psbt.unsigned_tx.txid(), 0)
+    );
+}

--- a/cli/src/contracts/request/tests.rs
+++ b/cli/src/contracts/request/tests.rs
@@ -247,3 +247,34 @@ async fn mock_funding_still_includes_a_funding_psbt() {
         OutPoint::new(psbt.unsigned_tx.txid(), 0)
     );
 }
+
+#[tokio::test]
+async fn funding_entry_cannot_overwrite_a_contract_named_funding() {
+    for root in ["funding", "funding/@funding"] {
+        let mut compiled = contract();
+        compiled.root_path = SArc(Arc::new(root.try_into().unwrap()));
+        let psbt = funding_psbt(&compiled);
+        let bound = request(compiled.clone(), &serialize(&psbt))
+            .call(Network::Regtest, Arc::new(CTVAvailable))
+            .await
+            .unwrap();
+        assert_eq!(bound.program.len(), 2);
+        assert_preserved_funding(&bound, &compiled, &psbt);
+        let contract_node = bound.program.get(&compiled.root_path).unwrap();
+        assert_eq!(
+            contract_node.source_path.as_ref(),
+            Some(&compiled.root_path)
+        );
+        let funding_path = SArc(Arc::new(format!("{root}/@funding").try_into().unwrap()));
+        let funding = bound.program.get(&funding_path).unwrap();
+        assert!(funding.source_path.is_none());
+        let restored: Program =
+            serde_json::from_value(serde_json::to_value(&bound).unwrap()).unwrap();
+        assert!(restored
+            .program
+            .get(&funding_path)
+            .unwrap()
+            .source_path
+            .is_none());
+    }
+}

--- a/contrib/check_wasm.py
+++ b/contrib/check_wasm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Check direct, cross-module, and inscription compilation through CLI/WASM."""
+"""Check compilation and mock funding through the real CLI/WASM workflow."""
 
 import json
 from pathlib import Path
@@ -13,11 +13,14 @@ modules = Path(sys.argv[2]).resolve()
 vectors = ROOT / "contrib" / "vectors"
 
 with tempfile.TemporaryDirectory(prefix="sapio-wasm-") as workspace:
-    def request(command, module, parameters=None):
+    def request(command, module=None, parameters=None, extra_args=()):
+        args = [str(cli), "--config", str(vectors / "basic_config.json"),
+                "contract", command]
+        if module is not None:
+            args.extend(["--workspace", workspace, "--file", str(modules / module)])
+        args.extend(extra_args)
         result = subprocess.run(
-            [str(cli), "--config", str(vectors / "basic_config.json"),
-             "contract", command, "--workspace", workspace,
-             "--file", str(modules / module)],
+            args,
             input=json.dumps(parameters) if parameters is not None else "",
             text=True, capture_output=True, check=True, timeout=60,
         )
@@ -68,4 +71,12 @@ with tempfile.TemporaryDirectory(prefix="sapio-wasm-") as workspace:
     assert len(templates) == 1, templates
     outputs = templates[0]["transaction_literal"]["output"]
     assert len(outputs) == 1 and outputs[0]["value"] == 9_500, outputs
-    print("WASM direct, cross-module, and inscription compilation passed")
+    bound = request("bind", parameters=inscription, extra_args=["--mock"])["Bind"]["program"]
+    root = inscription["root_path"]
+    template_hash = next(iter(inscription["suggested_template_hash_to_template_map"]))
+    child = f"{root}/@suggested/{template_hash}/#0"
+    assert set(bound) == {root, f"{root}/@funding", child}, bound
+    assert bound[root]["source_path"] == root, bound[root]
+    assert "source_path" not in bound[f"{root}/@funding"], bound
+    assert len(bound[root]["txs"]) == 1 and not bound[child]["txs"], bound
+    print("WASM direct, cross-module, inscription compilation and mock binding passed")

--- a/ctv_emulators/src/connections/federated.rs
+++ b/ctv_emulators/src/connections/federated.rs
@@ -38,7 +38,7 @@ impl CTVEmulator for FederatedEmulatorConnection {
         mut b: PartiallySignedTransaction,
     ) -> Result<PartiallySignedTransaction, EmulatorError> {
         for emulator in self.emulators.iter() {
-            b = emulator.sign(b)?;
+            b = sapio_ctv_emulator_trait::sign_checked(emulator.as_ref(), b)?;
         }
         Ok(b)
     }

--- a/ctv_emulators/src/connections/hd.rs
+++ b/ctv_emulators/src/connections/hd.rs
@@ -84,7 +84,7 @@ impl CTVEmulator for HDOracleEmulatorConnection {
     }
     fn sign(
         &self,
-        mut b: PartiallySignedTransaction,
+        b: PartiallySignedTransaction,
     ) -> Result<PartiallySignedTransaction, EmulatorError> {
         let inp: Result<PartiallySignedTransaction, std::io::Error> =
             tokio::task::block_in_place(|| {
@@ -107,8 +107,8 @@ impl CTVEmulator for HDOracleEmulatorConnection {
                 })
             });
 
-        b.combine(inp?)
-            .or_else(|_e| input_error("Fault Signed PSBT"))?;
-        Ok(b)
+        let response = inp?;
+        sapio_ctv_emulator_trait::validate_signing_response(&b, &response)?;
+        Ok(response)
     }
 }

--- a/ctv_emulators/src/connections/mod.rs
+++ b/ctv_emulators/src/connections/mod.rs
@@ -9,3 +9,5 @@
 use super::*;
 pub mod federated;
 pub mod hd;
+#[cfg(test)]
+mod tests;

--- a/ctv_emulators/src/connections/tests.rs
+++ b/ctv_emulators/src/connections/tests.rs
@@ -13,6 +13,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use tokio::net::TcpListener;
 
+type Mutation = fn(&mut Psbt);
+
 fn request() -> Psbt {
     let mut psbt = Psbt::from_unsigned_tx(Transaction {
         version: 2,
@@ -136,7 +138,7 @@ fn federation_accumulates_signatures_and_preserves_prior_participant_entries() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn hd_rejects_raw_metadata_changes_instead_of_hiding_them_in_a_merge() {
-    let mutations: [(fn(&mut Psbt), bool); 5] = [
+    let mutations: [(Mutation, bool); 5] = [
         (|psbt| psbt.inputs[0].unknown.clear(), false),
         (
             |psbt| psbt.inputs[0].witness_utxo.as_mut().unwrap().value -= 1,

--- a/ctv_emulators/src/connections/tests.rs
+++ b/ctv_emulators/src/connections/tests.rs
@@ -1,0 +1,182 @@
+use super::federated::FederatedEmulatorConnection;
+use super::hd::HDOracleEmulatorConnection;
+use crate::{msgs, wire, CTVEmulator, Clause, EmulatorError};
+use bitcoin::hashes::sha256;
+use bitcoin::secp256k1::Secp256k1;
+use bitcoin::secp256k1::{Keypair, Message, SecretKey};
+use bitcoin::util::bip32::{ExtendedPrivKey, ExtendedPubKey};
+use bitcoin::util::psbt::{raw, PartiallySignedTransaction as Psbt};
+use bitcoin::util::taproot::{LeafVersion, TapLeafHash};
+use bitcoin::{Network, Script, Transaction, TxIn, TxOut};
+use bitcoin::{SchnorrSig, SchnorrSighashType};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use tokio::net::TcpListener;
+
+fn request() -> Psbt {
+    let mut psbt = Psbt::from_unsigned_tx(Transaction {
+        version: 2,
+        lock_time: 0,
+        input: vec![TxIn::default()],
+        output: vec![TxOut {
+            value: 9_000,
+            script_pubkey: Script::new(),
+        }],
+    })
+    .unwrap();
+    psbt.inputs[0].witness_utxo = Some(TxOut {
+        value: 10_000,
+        script_pubkey: Script::new(),
+    });
+    psbt.inputs[0].unknown.insert(
+        raw::Key {
+            type_value: 0x80,
+            key: vec![1],
+        },
+        vec![2],
+    );
+    psbt
+}
+
+struct ChangeResponse(fn(&mut Psbt));
+
+impl CTVEmulator for ChangeResponse {
+    fn get_signer_for(&self, _: sha256::Hash) -> Result<Clause, EmulatorError> {
+        Ok(Clause::Trivial)
+    }
+
+    fn sign(&self, mut psbt: Psbt) -> Result<Psbt, EmulatorError> {
+        (self.0)(&mut psbt);
+        Ok(psbt)
+    }
+}
+
+struct ObserveResponse(Arc<AtomicUsize>);
+
+impl CTVEmulator for ObserveResponse {
+    fn get_signer_for(&self, _: sha256::Hash) -> Result<Clause, EmulatorError> {
+        Ok(Clause::Trivial)
+    }
+
+    fn sign(&self, psbt: Psbt) -> Result<Psbt, EmulatorError> {
+        self.0.fetch_add(1, Ordering::SeqCst);
+        Ok(psbt)
+    }
+}
+
+#[test]
+fn federation_rejects_changed_metadata_before_calling_another_participant() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let federation = FederatedEmulatorConnection::new(
+        vec![
+            Arc::new(ChangeResponse(|psbt| psbt.inputs[0].unknown.clear())),
+            Arc::new(ObserveResponse(calls.clone())),
+        ],
+        2,
+    );
+    assert!(matches!(
+        federation.sign(request()),
+        Err(EmulatorError::InvalidResponse)
+    ));
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+}
+
+fn add_signature(psbt: &mut Psbt, byte: u8) {
+    let secp = Secp256k1::new();
+    let keypair = Keypair::from_secret_key(&secp, &SecretKey::from_slice(&[byte; 32]).unwrap());
+    psbt.inputs[0].tap_script_sigs.insert(
+        (
+            keypair.x_only_public_key().0,
+            TapLeafHash::from_script(&Script::from(vec![0x51]), LeafVersion::TapScript),
+        ),
+        SchnorrSig {
+            sig: secp.sign_schnorr_no_aux_rand(
+                &Message::from_digest_slice(&[byte; 32]).unwrap(),
+                &keypair,
+            ),
+            hash_ty: SchnorrSighashType::All,
+        },
+    );
+}
+
+#[test]
+fn federation_accumulates_signatures_and_preserves_prior_participant_entries() {
+    let original = request();
+    let federation = FederatedEmulatorConnection::new(
+        vec![
+            Arc::new(ChangeResponse(|psbt| add_signature(psbt, 1))),
+            Arc::new(ChangeResponse(|psbt| {
+                assert_eq!(psbt.inputs[0].tap_script_sigs.len(), 1);
+                add_signature(psbt, 2);
+            })),
+        ],
+        2,
+    );
+    let response = federation.sign(original.clone()).unwrap();
+    assert_eq!(response.inputs[0].tap_script_sigs.len(), 2);
+    sapio_ctv_emulator_trait::validate_signing_response(&original, &response).unwrap();
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let invalid = FederatedEmulatorConnection::new(
+        vec![
+            Arc::new(ChangeResponse(|psbt| add_signature(psbt, 1))),
+            Arc::new(ChangeResponse(|psbt| {
+                psbt.inputs[0].tap_script_sigs.clear()
+            })),
+            Arc::new(ObserveResponse(calls.clone())),
+        ],
+        2,
+    );
+    assert!(matches!(
+        invalid.sign(original),
+        Err(EmulatorError::InvalidResponse)
+    ));
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn hd_rejects_raw_metadata_changes_instead_of_hiding_them_in_a_merge() {
+    let mutations: [(fn(&mut Psbt), bool); 5] = [
+        (|psbt| psbt.inputs[0].unknown.clear(), false),
+        (
+            |psbt| psbt.inputs[0].witness_utxo.as_mut().unwrap().value -= 1,
+            false,
+        ),
+        (
+            |psbt| psbt.outputs[0].witness_script = Some(Script::from(vec![0x51])),
+            false,
+        ),
+        (|_| {}, true),
+        (|psbt| add_signature(psbt, 1), true),
+    ];
+    for (mutate, accepted) in mutations {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let peer = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let msgs::Request::SignPSBT(msgs::PSBT(mut response)) =
+                wire::read_message(&mut stream).await.unwrap();
+            mutate(&mut response);
+            wire::write_message(&mut stream, &msgs::PSBT(response))
+                .await
+                .unwrap();
+        });
+        let secp = Arc::new(Secp256k1::new());
+        let root = ExtendedPubKey::from_priv(
+            &secp,
+            &ExtendedPrivKey::new_master(Network::Regtest, &[7; 32]).unwrap(),
+        );
+        let connection = HDOracleEmulatorConnection::new(address, root, None, secp)
+            .await
+            .unwrap();
+        let response = connection.sign(request());
+        peer.await.unwrap();
+        if accepted {
+            let mut expected = request();
+            mutate(&mut expected);
+            assert_eq!(response.unwrap(), expected);
+        } else {
+            assert!(matches!(response, Err(EmulatorError::InvalidResponse)));
+        }
+    }
+}

--- a/ctv_emulators/src/servers/hd.rs
+++ b/ctv_emulators/src/servers/hd.rs
@@ -124,7 +124,7 @@ impl HDOracleEmulator {
                 )
         }) {
             let sig = get_sig(None, &tweaked)?;
-            input_zero.tap_key_sig = Some(sig);
+            input_zero.tap_key_sig.get_or_insert(sig);
         }
         for tlh in input_zero
             .tap_scripts
@@ -132,7 +132,7 @@ impl HDOracleEmulator {
             .map(|(script, ver)| TapLeafHash::from_script(script, *ver))
         {
             let sig = get_sig(Some((tlh, 0xffffffff)), &untweaked)?;
-            input_zero.tap_script_sigs.insert((pk.0, tlh), sig);
+            input_zero.tap_script_sigs.entry((pk.0, tlh)).or_insert(sig);
         }
         Ok(b)
     }
@@ -154,6 +154,8 @@ impl HDOracleEmulator {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bitcoin::util::taproot::{LeafVersion, TaprootBuilder};
+    use sapio_ctv_emulator_trait::validate_signing_response;
 
     #[test]
     fn rejects_psbts_without_an_input_to_sign() {
@@ -171,5 +173,58 @@ mod tests {
             oracle.sign(psbt, &secp).unwrap_err().kind(),
             std::io::ErrorKind::InvalidInput
         );
+    }
+
+    #[test]
+    fn signing_adds_both_taproot_signature_forms_without_replacing_existing_entries() {
+        let secp = Secp256k1::new();
+        let root = ExtendedPrivKey::new_master(bitcoin::Network::Regtest, &[44; 32]).unwrap();
+        let oracle = HDOracleEmulator::new(root, false);
+        let mut request = PartiallySignedTransaction::from_unsigned_tx(bitcoin::Transaction {
+            version: 2,
+            lock_time: 0,
+            input: vec![bitcoin::TxIn::default()],
+            output: vec![TxOut {
+                value: 9_000,
+                script_pubkey: Script::new(),
+            }],
+        })
+        .unwrap();
+        let derived = oracle
+            .derive(request.clone().extract_tx().get_ctv_hash(0), &secp)
+            .unwrap();
+        let internal = derived.to_keypair(&secp).x_only_public_key().0;
+        let leaf = (Script::from(vec![0x51]), LeafVersion::TapScript);
+        let spend = TaprootBuilder::new()
+            .add_leaf(0, leaf.0.clone())
+            .unwrap()
+            .finalize(&secp, internal)
+            .unwrap();
+        request.inputs[0].witness_utxo = Some(TxOut {
+            value: 10_000,
+            script_pubkey: Script::new_v1_p2tr_tweaked(spend.output_key()),
+        });
+        request.inputs[0].tap_merkle_root = spend.merkle_root();
+        request.inputs[0]
+            .tap_scripts
+            .insert(spend.control_block(&leaf).unwrap(), leaf);
+        let response = oracle.sign(request.clone(), &secp).unwrap();
+        validate_signing_response(&request, &response).unwrap();
+        assert!(response.inputs[0].tap_key_sig.is_some());
+        assert_eq!(response.inputs[0].tap_script_sigs.len(), 1);
+
+        // Existing entries belong to the caller, even if their validity has
+        // not been established. A signer cannot silently replace them.
+        let mut existing = response;
+        existing.inputs[0].tap_key_sig.as_mut().unwrap().hash_ty =
+            bitcoin::SchnorrSighashType::Default;
+        existing.inputs[0]
+            .tap_script_sigs
+            .values_mut()
+            .next()
+            .unwrap()
+            .hash_ty = bitcoin::SchnorrSighashType::Default;
+        let repeated = oracle.sign(existing.clone(), &secp).unwrap();
+        assert_eq!(repeated, existing);
     }
 }

--- a/docs/BINDING.md
+++ b/docs/BINDING.md
@@ -1,0 +1,87 @@
+# Binding contracts to funding
+
+`Object::bind_psbt` turns a compiled contract and an input outpoint into a
+`Program` of PSBTs. Binding checks the complete artifact and input mappings,
+prepares and checks funding throughout the graph, checks every signer response,
+and then adds the resulting transactions to the transaction index.
+
+## Funding checks
+
+For each explicit input, the binder obtains the previous transaction and checks
+its computed txid against the requested outpoint before selecting its output.
+An out-of-range output, an incorrect transaction, or a network/RPC error fails
+binding. Only `UnknownTxid` for the requested transaction leaves an explicit
+input unresolved. Auxiliary inputs without a mapping remain unresolved and get
+distinct placeholder outpoints that avoid explicit mappings and the contract
+input.
+
+Known contract inputs must pay the compiled contract's script. Every transaction
+must use distinct input outpoints, and known input values must sum without
+overflow. When all inputs are known, that total must cover the template's
+outputs and reserved fees. Auxiliary inputs may contribute to that total;
+additional funding is permitted. These checks also apply to suggested
+transactions and descendants, using generated parent transactions directly.
+
+Every known previous transaction is retained as `non_witness_utxo` in the PSBT.
+Native witness outputs also populate `witness_utxo`. This allows a downstream
+signer to authenticate the supplied amounts and scripts against the input's
+txid. Arbitrary legacy or P2SH auxiliary outputs are not labeled as witness
+outputs without evidence of their spending script. See
+[BIP-174's input fields](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#specification).
+
+Unresolved inputs support offline construction; a successful bind does not mean
+that such a transaction is funded or ready to sign. Transaction identity also
+does not establish confirmation or whether an output is still unspent. Those
+checks require an appropriate chain/wallet view.
+
+## Signer and index boundaries
+
+The `CTVEmulator` signing contract returns a complete PSBT. A response may add
+ECDSA partial signatures, Taproot key signatures, or Taproot script signatures.
+It must preserve existing signatures and all other data, including transaction
+fields, UTXOs, sighash declarations, scripts, derivations, final scripts, and
+unknown/proprietary metadata.
+
+Call `sign_checked` when accepting a custom emulator's response. The HD client
+checks the raw response, and a federation checks each participant before
+passing the PSBT onward. These checks establish response integrity; finalization
+still needs to verify the signatures. They do not authenticate a network peer or
+replace a signer's authorization policy.
+
+Invalid funding anywhere in the graph fails before signer calls or
+insertion of generated transactions. An invalid signer response also fails
+before inserting generated transactions. Index insertion
+must acknowledge the locally computed txid; an incorrect acknowledgement or
+write error fails binding. Writes are not atomic: an index failure can leave
+earlier accepted writes in place. Funding lookups may populate an index
+implementation's lookup cache during preparation.
+
+`CachedTxIndex` falls back only on a matching `UnknownTxid`, validates both
+transaction contents and insertion acknowledgements, and forwards transactions
+with changed witnesses even when their txid is unchanged. Identical
+transactions are deduplicated.
+
+## Bound paths and source paths
+
+The root entry retains the compiled root path. Each child entry gets a binding
+path formed from its parent's binding path, `@next` or `@suggested`, the template
+hash, and `#<output index>`. Reusing a compiled object at multiple outputs
+therefore preserves every occurrence, including leaf metadata. Enforced and
+suggested transitions remain distinct even if their transaction hashes match.
+
+`SapioStudioObject.source_path` records the original compilation path.
+Continuation API paths remain compilation paths. Consumers should use the
+program's map keys to identify bound occurrences and `source_path` to relate
+them to the compiled contract. Child keys have deliberately changed from the
+old source-path keys, which could silently overwrite other outputs.
+
+The CLI's synthetic funding entry uses `<root>/@funding` and has no
+`source_path`. It cannot overwrite a contract named `funding` or one of its
+transitions. The funding PSBT retains the wallet's supplied metadata and
+signatures.
+
+These changes do not solve descendant rebinding for legacy inputs whose
+scriptSigs change transaction IDs during finalization, or establish native CTV
+enforcement on a particular chain. The supported signing/finalization domain
+and remaining release boundaries are recorded in [the fork audit](CTV_FORK_AUDIT.md)
+and [the modernization plan](MODERNIZATION.md).

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -146,6 +146,13 @@ amounts/scripts must match the receiving-contract metadata. Optional input
 mappings contain one entry per input; entry zero must be `None` because the
 graph determines the contract input. Unknown template keys are rejected.
 
+Binding authenticates known funding transactions, checks scripts and available
+amounts, and accepts only signature additions from emulators. Matching unknown
+transactions remain unresolved for offline work; other lookup errors propagate.
+Bound graph keys identify individual occurrences, while `source_path` retains
+the original compilation path. See [the binding contract](BINDING.md) for the
+funding checks, path format and limits.
+
 Signing and finalization reject malformed PSBT maps before processing inputs.
 `finalize_psbt_format_api` returns `Result<PSBTApi, PSBTValidationError>`:
 structural errors are distinct from a valid PSBT still missing signatures.
@@ -163,8 +170,8 @@ Whole-transaction finalization can leave partial progress on error. Automatic
 ordering does not solve circular P2SH commitments or expand bare-descriptor
 support, and the builder still requires unsigned input-zero templates.
 
-Script verification uses supplied prevouts; funding UTXO authentication remains
-required at the caller boundary. Backend enforcement and native CTV node
+Script verification uses supplied prevouts; callers outside `bind_psbt` must
+authenticate them as well. Backend enforcement and native CTV node
 execution are separate release requirements. See the
 [CTV fork repair record](CTV_FORK_AUDIT.md) for exact evidence and limits. The
 separate Core inscription checks cover ordinary Taproot; they do not validate

--- a/docs/MODERNIZATION.md
+++ b/docs/MODERNIZATION.md
@@ -46,6 +46,8 @@ with upstream crates would remove semantics, not complete a migration.
 | Linux runtime compatibility | Upgrade Wasmer and its cache to 6.1.0, which provides the stack probe removed from Rust's x86 runtime; remove unused direct CLI runtime dependencies |
 | PSBT signing | Use the selected input index for key and script paths; reject sighash errors; verify signatures independently on a two-input transaction |
 | Artifact binding | Validate the complete object graph before signing or indexing: unsigned input-zero templates, matching commitments, descriptors, output metadata and funding totals; reject invalid auxiliary-input mappings |
+| Funding integrity | Authenticate previous transactions and index acknowledgements; check contract scripts, distinct inputs, checked funding totals and reserved fees before signing; preserve operational lookup errors and authenticated PSBT prevouts |
+| Bound graph identity | Derive child keys from parent bindings and transition/output identities; preserve reused leaves and contracts, original source paths and continuation paths; keep synthetic funding in its own path |
 | PSBT structure | Reject empty-input transactions, mismatched input/output maps and populated unsigned scriptSigs/witnesses before signing or finalization; preserve the PSBT on structural rejection |
 | CTV hashing | Include conditional commitments to every serialized scriptSig in Sapio and the pinned Miniscript fork; both tests cover all 400 expected hashes from the complete official BIP-119 corpus |
 | CTV finalization | Pin fork revision `04b69f69459fe3b043ca61fb649cf546d5a241b6`; establish legacy scriptSigs before native witness inputs, verify candidate scriptSigs and the completed transaction; regressions cover native WSH/Taproot with legacy inputs in either position |
@@ -57,6 +59,7 @@ with upstream crates would remove semantics, not complete a migration.
 | Ordinal allocation | Preserve allocated/remaining range prefixes and suffixes; reject malformed and insufficient ranges |
 | WASM host | Bound ABI messages, validate every memory read/write, bound string scans, propagate errors, and test hostile guests through Wasmer; register guest callbacks once with `OnceLock` |
 | Emulator protocol | Bound both directions of framed JSON, discard failed streams, reject malformed PSBT maps, support prebound listeners |
+| Emulator responses | Accept complete PSBT responses containing only signature additions; preserve existing signatures and every other field, including raw HD responses and each federation participant |
 | Integration | Restore the suite to the workspace; compile, sign and finalize two contract steps and reject a modified output |
 | Developer checks | Formatting, real feature checks, native tests, all WASM example builds, CLI smoke checks, and API documentation |
 
@@ -125,13 +128,13 @@ another. Never infer mainnet safety from a successful compilation or a unit test
 
 This is the next release blocker, before a broad dependency migration.
 
-- Extend artifact boundary checks to funding UTXO identity and emulator responses.
-  Structural graph and PSBT validation now run before binding, signing and
-  finalization. Resolve graph path collisions without rejecting valid reused
-  leaf objects; preserve transaction-index errors instead of treating every
-  failed lookup as missing funding data. The repaired fork still verifies against
-  supplied prevouts; callers must authenticate them and reject conflicting UTXO
-  records.
+- Extend [the binding checks](BINDING.md) with explicit chain/wallet funding
+  policy. Transaction identities, known amounts, scripts, graph paths and
+  emulator response integrity are checked; unresolved offline inputs remain
+  possible. Establish confirmation/unspentness where required and keep that
+  policy separate from artifact validation. The repaired fork verifies against
+  supplied prevouts; callers outside the binder must also authenticate them and
+  reject conflicting UTXO records.
 - Enforce backend capability information before funding and execute the supported
   native CTV cases against a node implementing the intended semantics. The
   [fork repair record](CTV_FORK_AUDIT.md) documents hashing, finalization and

--- a/emulator-trait/src/emulator.rs
+++ b/emulator-trait/src/emulator.rs
@@ -18,10 +18,17 @@ pub enum EmulatorError {
     NetworkIssue(std::io::Error),
     /// Error was caused by BIP32
     BIP32Error(bitcoin::util::bip32::Error),
+    /// A signer changed or removed PSBT data instead of only adding signatures.
+    InvalidResponse,
 }
 impl fmt::Display for EmulatorError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        match self {
+            EmulatorError::InvalidResponse => {
+                f.write_str("Emulator response must preserve the PSBT and only add signatures")
+            }
+            _ => write!(f, "{:?}", self),
+        }
     }
 }
 impl std::error::Error for EmulatorError {}
@@ -44,11 +51,71 @@ pub trait CTVEmulator: Sync + Send {
     /// For a given transaction hash, gets the corresponding Clause that the
     /// Emulator would satisfy.
     fn get_signer_for(&self, h: sha256::Hash) -> Result<Clause, EmulatorError>;
-    /// Adds the Emulators signature to the PSBT, if any.
+    /// Returns the complete PSBT with the emulator's signatures added, if any.
+    /// Existing signatures and all other fields must remain unchanged.
+    /// Call [`sign_checked`] when accepting a response from an emulator.
     fn sign(
         &self,
         b: PartiallySignedTransaction,
     ) -> Result<PartiallySignedTransaction, EmulatorError>;
+}
+
+/// Call an emulator and enforce the complete-response signing contract.
+///
+/// Only additions to ECDSA partial signatures, Taproot key signatures and
+/// Taproot script signatures are permitted. This function checks response
+/// integrity; signature validity must still be checked during finalization.
+pub fn sign_checked(
+    emulator: &dyn CTVEmulator,
+    request: PartiallySignedTransaction,
+) -> Result<PartiallySignedTransaction, EmulatorError> {
+    let response = emulator.sign(request.clone())?;
+    validate_signing_response(&request, &response)?;
+    Ok(response)
+}
+
+/// Check that a complete signer response only adds signatures to a PSBT.
+///
+/// Existing signatures cannot be replaced or removed. Every other field,
+/// including unknown metadata and finalized scripts, must remain unchanged.
+/// This does not verify new signatures or the validity of the original PSBT.
+pub fn validate_signing_response(
+    request: &PartiallySignedTransaction,
+    response: &PartiallySignedTransaction,
+) -> Result<(), EmulatorError> {
+    if request.inputs.len() != response.inputs.len()
+        || request.outputs.len() != response.outputs.len()
+        || response.inputs.len() != response.unsigned_tx.input.len()
+        || response.outputs.len() != response.unsigned_tx.output.len()
+    {
+        return Err(EmulatorError::InvalidResponse);
+    }
+    let mut preserved = response.clone();
+    for (original, changed) in request.inputs.iter().zip(&mut preserved.inputs) {
+        if original
+            .partial_sigs
+            .iter()
+            .any(|(key, signature)| changed.partial_sigs.get(key) != Some(signature))
+            || original
+                .tap_script_sigs
+                .iter()
+                .any(|(key, signature)| changed.tap_script_sigs.get(key) != Some(signature))
+            || (original.tap_key_sig.is_some() && changed.tap_key_sig != original.tap_key_sig)
+        {
+            return Err(EmulatorError::InvalidResponse);
+        }
+        // Compare the whole PSBT after masking only the permitted additions.
+        // New non-signature fields remain protected by structural equality.
+        changed.partial_sigs.clone_from(&original.partial_sigs);
+        changed.tap_key_sig = original.tap_key_sig;
+        changed
+            .tap_script_sigs
+            .clone_from(&original.tap_script_sigs);
+    }
+    if preserved != *request {
+        return Err(EmulatorError::InvalidResponse);
+    }
+    Ok(())
 }
 
 /// A wrapper for an optional internal emulator trait object. If no emulator is

--- a/emulator-trait/tests/signing_response.rs
+++ b/emulator-trait/tests/signing_response.rs
@@ -1,0 +1,217 @@
+use bitcoin::hashes::{sha256, Hash};
+use bitcoin::secp256k1::{Keypair, Message, Secp256k1, SecretKey};
+use bitcoin::util::bip32::{DerivationPath, ExtendedPrivKey, ExtendedPubKey, Fingerprint};
+use bitcoin::util::psbt::{raw, PartiallySignedTransaction as Psbt};
+use bitcoin::util::taproot::{LeafVersion, TapLeafHash};
+use bitcoin::{EcdsaSig, EcdsaSighashType, PublicKey, SchnorrSig, SchnorrSighashType};
+use bitcoin::{Network, Script, Transaction, TxIn, TxOut, Witness};
+use sapio_ctv_emulator_trait::{
+    sign_checked, validate_signing_response, CTVAvailable, CTVEmulator, Clause, EmulatorError,
+};
+
+fn add_signatures(psbt: &mut Psbt, input: usize, byte: u8) {
+    let secp = Secp256k1::new();
+    let secret = SecretKey::from_slice(&[byte; 32]).unwrap();
+    let keypair = Keypair::from_secret_key(&secp, &secret);
+    let message = Message::from_digest_slice(&[byte; 32]).unwrap();
+    let schnorr = SchnorrSig {
+        sig: secp.sign_schnorr_no_aux_rand(&message, &keypair),
+        hash_ty: SchnorrSighashType::Default,
+    };
+    psbt.inputs[input].partial_sigs.insert(
+        PublicKey::new(keypair.public_key()),
+        EcdsaSig {
+            sig: secp.sign_ecdsa(&message, &secret),
+            hash_ty: EcdsaSighashType::All,
+        },
+    );
+    psbt.inputs[input].tap_key_sig.get_or_insert(schnorr);
+    psbt.inputs[input].tap_script_sigs.insert(
+        (
+            keypair.x_only_public_key().0,
+            TapLeafHash::from_script(&Script::from(vec![byte]), LeafVersion::TapScript),
+        ),
+        schnorr,
+    );
+}
+
+fn request() -> Psbt {
+    let mut psbt = Psbt::from_unsigned_tx(Transaction {
+        version: 2,
+        lock_time: 0,
+        input: vec![TxIn::default(), TxIn::default()],
+        output: vec![TxOut {
+            value: 9_000,
+            script_pubkey: Script::from(vec![0x51]),
+        }],
+    })
+    .unwrap();
+    psbt.inputs[0].witness_utxo = Some(TxOut {
+        value: 10_000,
+        script_pubkey: Script::from(vec![0x51]),
+    });
+    psbt.inputs[0].non_witness_utxo = Some(psbt.unsigned_tx.clone());
+    psbt.inputs[0].sighash_type = Some(SchnorrSighashType::Default.into());
+    psbt.inputs[0].witness_script = Some(Script::from(vec![0x51]));
+    psbt.inputs[0].redeem_script = Some(Script::from(vec![0x51]));
+    psbt.inputs[0].final_script_sig = Some(Script::new());
+    psbt.inputs[0].final_script_witness = Some(Witness::from_vec(vec![vec![1]]));
+    let unknown = raw::Key {
+        type_value: 0x80,
+        key: vec![1],
+    };
+    let proprietary = raw::ProprietaryKey {
+        prefix: b"test".to_vec(),
+        subtype: 1,
+        key: vec![2],
+    };
+    psbt.unknown.insert(unknown.clone(), vec![3]);
+    psbt.proprietary.insert(proprietary.clone(), vec![4]);
+    psbt.inputs[0].unknown.insert(unknown.clone(), vec![5]);
+    psbt.inputs[0]
+        .proprietary
+        .insert(proprietary.clone(), vec![6]);
+    psbt.outputs[0].unknown.insert(unknown, vec![7]);
+    psbt.outputs[0].proprietary.insert(proprietary, vec![8]);
+    add_signatures(&mut psbt, 0, 1);
+    psbt
+}
+
+struct Signer(fn(&mut Psbt));
+
+impl CTVEmulator for Signer {
+    fn get_signer_for(&self, _: sha256::Hash) -> Result<Clause, EmulatorError> {
+        Ok(Clause::Trivial)
+    }
+
+    fn sign(&self, mut psbt: Psbt) -> Result<Psbt, EmulatorError> {
+        (self.0)(&mut psbt);
+        Ok(psbt)
+    }
+}
+
+#[test]
+fn checked_signing_preserves_complete_requests_and_accepts_only_signature_additions() {
+    let original = request();
+    assert_eq!(
+        sign_checked(&CTVAvailable, original.clone()).unwrap(),
+        original
+    );
+    let signer = Signer(|psbt| {
+        add_signatures(psbt, 0, 2);
+        add_signatures(psbt, 1, 3);
+    });
+    let response = sign_checked(&signer, original.clone()).unwrap();
+    assert_eq!(response.inputs[0].partial_sigs.len(), 2);
+    assert_eq!(response.inputs[0].tap_script_sigs.len(), 2);
+    assert_eq!(
+        response.inputs[0].tap_key_sig,
+        original.inputs[0].tap_key_sig
+    );
+    assert!(response.inputs[1].tap_key_sig.is_some());
+    validate_signing_response(&original, &response).unwrap();
+}
+
+#[test]
+fn checked_signing_rejects_changes_to_each_protected_psbt_field_family() {
+    let changes: &[(&str, fn(&mut Psbt))] = &[
+        ("transaction", |p| p.unsigned_tx.output[0].value -= 1),
+        ("input count", |p| {
+            p.inputs.pop();
+        }),
+        ("output count", |p| p.outputs.clear()),
+        ("unsigned input count", |p| {
+            p.unsigned_tx.input.pop();
+        }),
+        ("unsigned output count", |p| p.unsigned_tx.output.clear()),
+        ("PSBT version", |p| p.version += 1),
+        ("global xpub", |p| {
+            let secp = Secp256k1::new();
+            let root = ExtendedPrivKey::new_master(Network::Regtest, &[3; 32]).unwrap();
+            p.xpub.insert(
+                ExtendedPubKey::from_priv(&secp, &root),
+                (Fingerprint::default(), DerivationPath::default()),
+            );
+        }),
+        ("witness UTXO", |p| {
+            p.inputs[0].witness_utxo.as_mut().unwrap().value -= 1
+        }),
+        ("nonwitness UTXO", |p| p.inputs[0].non_witness_utxo = None),
+        ("sighash", |p| {
+            p.inputs[0].sighash_type = Some(SchnorrSighashType::None.into())
+        }),
+        ("redeem script", |p| p.inputs[0].redeem_script = None),
+        ("witness script", |p| p.inputs[0].witness_script = None),
+        ("final scriptSig", |p| p.inputs[0].final_script_sig = None),
+        ("final witness", |p| p.inputs[0].final_script_witness = None),
+        ("input derivation", |p| {
+            let key = p.inputs[0].partial_sigs.keys().next().unwrap().inner;
+            p.inputs[0]
+                .bip32_derivation
+                .insert(key, (Fingerprint::default(), DerivationPath::default()));
+        }),
+        ("taproot internal key", |p| {
+            p.inputs[0].tap_internal_key =
+                Some(p.inputs[0].tap_script_sigs.keys().next().unwrap().0)
+        }),
+        ("preimage", |p| {
+            p.inputs[0]
+                .sha256_preimages
+                .insert(sha256::Hash::hash(&[1]), vec![1]);
+        }),
+        ("global unknown", |p| p.unknown.clear()),
+        ("global proprietary", |p| p.proprietary.clear()),
+        ("input unknown", |p| p.inputs[0].unknown.clear()),
+        ("input proprietary", |p| p.inputs[0].proprietary.clear()),
+        ("output unknown", |p| p.outputs[0].unknown.clear()),
+        ("output proprietary", |p| p.outputs[0].proprietary.clear()),
+        ("output script", |p| {
+            p.outputs[0].witness_script = Some(Script::new())
+        }),
+        ("second input", |p| {
+            p.inputs[1].sighash_type = Some(SchnorrSighashType::All.into())
+        }),
+    ];
+    for (name, change) in changes {
+        assert!(
+            matches!(
+                sign_checked(&Signer(*change), request()),
+                Err(EmulatorError::InvalidResponse)
+            ),
+            "{}",
+            name
+        );
+    }
+}
+
+#[test]
+fn checked_signing_rejects_removing_or_replacing_existing_signatures() {
+    let changes: &[fn(&mut Psbt)] = &[
+        |p| p.inputs[0].partial_sigs.clear(),
+        |p| {
+            p.inputs[0]
+                .partial_sigs
+                .values_mut()
+                .next()
+                .unwrap()
+                .hash_ty = EcdsaSighashType::None
+        },
+        |p| p.inputs[0].tap_key_sig = None,
+        |p| p.inputs[0].tap_key_sig.as_mut().unwrap().hash_ty = SchnorrSighashType::All,
+        |p| p.inputs[0].tap_script_sigs.clear(),
+        |p| {
+            p.inputs[0]
+                .tap_script_sigs
+                .values_mut()
+                .next()
+                .unwrap()
+                .hash_ty = SchnorrSighashType::All
+        },
+    ];
+    for change in changes {
+        assert!(matches!(
+            sign_checked(&Signer(*change), request()),
+            Err(EmulatorError::InvalidResponse)
+        ));
+    }
+}

--- a/emulator-trait/tests/signing_response.rs
+++ b/emulator-trait/tests/signing_response.rs
@@ -9,6 +9,8 @@ use sapio_ctv_emulator_trait::{
     sign_checked, validate_signing_response, CTVAvailable, CTVEmulator, Clause, EmulatorError,
 };
 
+type Mutation = fn(&mut Psbt);
+
 fn add_signatures(psbt: &mut Psbt, input: usize, byte: u8) {
     let secp = Secp256k1::new();
     let secret = SecretKey::from_slice(&[byte; 32]).unwrap();
@@ -114,7 +116,7 @@ fn checked_signing_preserves_complete_requests_and_accepts_only_signature_additi
 
 #[test]
 fn checked_signing_rejects_changes_to_each_protected_psbt_field_family() {
-    let changes: &[(&str, fn(&mut Psbt))] = &[
+    let changes: &[(&str, Mutation)] = &[
         ("transaction", |p| p.unsigned_tx.output[0].value -= 1),
         ("input count", |p| {
             p.inputs.pop();

--- a/integration_tests/tests/integration_test.rs
+++ b/integration_tests/tests/integration_test.rs
@@ -93,7 +93,7 @@ async fn compiles_signs_and_finalizes_a_two_step_contract() {
     let tx = bitcoin::Transaction {
         version: 2,
         lock_time: 0,
-        input: vec![],
+        input: vec![bitcoin::TxIn::default()],
         output: vec![TxOut {
             value: Amount::from_btc(1.0).unwrap().as_sat(),
             script_pubkey: compiled.address.clone().into(),

--- a/sapio-base/src/effects/path_fragment.rs
+++ b/sapio-base/src/effects/path_fragment.rs
@@ -37,6 +37,8 @@ pub enum PathFragment {
     Next,
     /// Suggested Transaction
     Suggested,
+    /// The synthetic funding transaction of a bound program.
+    Funding,
     /// The Default Effect passed into a Continuation
     DefaultEffect,
     /// All the Effects for a Coninuation
@@ -65,6 +67,7 @@ impl From<&PathFragment> for String {
             PathFragment::Guard => "@guard".into(),
             PathFragment::Next => "@next".into(),
             PathFragment::Suggested => "@suggested".into(),
+            PathFragment::Funding => "@funding".into(),
             PathFragment::DefaultEffect => "@default_effect".into(),
             PathFragment::Effects => "@effects".into(),
             PathFragment::Metadata => "@metadata".into(),
@@ -116,6 +119,7 @@ impl TryFrom<&str> for PathFragment {
             "@guard" => PathFragment::Guard,
             "@next" => PathFragment::Next,
             "@suggested" => PathFragment::Suggested,
+            "@funding" => PathFragment::Funding,
             "@default_effect" => PathFragment::DefaultEffect,
             "@effects" => PathFragment::Effects,
             "@metadata" => PathFragment::Metadata,

--- a/sapio-base/src/txindex.rs
+++ b/sapio-base/src/txindex.rs
@@ -18,6 +18,13 @@ pub enum TxIndexError {
     UnknownTxid(Txid),
     /// TXID exists, but the vout index was too high
     IndexTooHigh(u32),
+    /// An index returned a transaction or acknowledgement for another TXID.
+    TxidMismatch {
+        /// The requested transaction ID.
+        expected: Txid,
+        /// The transaction ID returned by the index.
+        actual: Txid,
+    },
     /// Error in the Rpc System
     RpcError(Box<dyn std::error::Error>),
 }
@@ -30,19 +37,27 @@ impl std::fmt::Display for TxIndexError {
 }
 type Result<T> = std::result::Result<T, TxIndexError>;
 
+fn check_txid(expected: Txid, actual: Txid) -> Result<()> {
+    if expected != actual {
+        return Err(TxIndexError::TxidMismatch { expected, actual });
+    }
+    Ok(())
+}
+
 /// Generic interface for any txindex
 pub trait TxIndex {
-    /// lookup a tx
+    /// Look up a transaction whose TXID must match the requested ID.
     fn lookup_tx(&self, b: &Txid) -> Result<Arc<bitcoin::Transaction>>;
     /// lookup a particular output
     fn lookup_output(&self, b: &bitcoin::OutPoint) -> Result<bitcoin::TxOut> {
-        self.lookup_tx(&b.txid)?
-            .output
+        let tx = self.lookup_tx(&b.txid)?;
+        check_txid(b.txid, tx.txid())?;
+        tx.output
             .get(b.vout as usize)
             .cloned()
             .ok_or(TxIndexError::IndexTooHigh(b.vout))
     }
-    /// locally add a tx for tracking
+    /// Add a transaction for tracking and return its TXID.
     fn add_tx(&self, tx: Arc<bitcoin::Transaction>) -> Result<Txid>;
 }
 
@@ -81,6 +96,10 @@ impl TxIndex for TxIndexLogger {
 }
 
 /// a cached txindex checks a cache first and then a primary txindex
+///
+/// Only an unknown requested TXID permits fallback. Identical transactions
+/// are deduplicated on insertion; changed witnesses are sent to the primary
+/// before replacing the cached transaction.
 pub struct CachedTxIndex<Cache: TxIndex, Primary: TxIndex> {
     /// the cache txindex
     pub cache: Cache,
@@ -94,21 +113,34 @@ where
     Primary: TxIndex,
 {
     fn lookup_tx(&self, b: &Txid) -> Result<Arc<bitcoin::Transaction>> {
-        if let Ok(ent) = self.cache.lookup_tx(b) {
-            Ok(ent)
-        } else {
-            let ent = self.primary.lookup_tx(b)?;
-            self.cache.add_tx(ent.clone())?;
-            Ok(ent)
+        match self.cache.lookup_tx(b) {
+            Ok(tx) => {
+                check_txid(*b, tx.txid())?;
+                Ok(tx)
+            }
+            Err(TxIndexError::UnknownTxid(txid)) if txid == *b => {
+                let tx = self.primary.lookup_tx(b)?;
+                check_txid(*b, tx.txid())?;
+                check_txid(*b, self.cache.add_tx(tx.clone())?)?;
+                Ok(tx)
+            }
+            Err(error) => Err(error),
         }
     }
     fn add_tx(&self, tx: Arc<bitcoin::Transaction>) -> Result<Txid> {
         let txid = tx.txid();
-        if self.cache.lookup_tx(&txid).is_ok() {
-            Ok(txid)
-        } else {
-            self.primary.add_tx(tx.clone())?;
-            self.cache.add_tx(tx)
+        match self.cache.lookup_tx(&txid) {
+            Ok(cached) => {
+                check_txid(txid, cached.txid())?;
+                if cached == tx {
+                    return Ok(txid);
+                }
+            }
+            Err(TxIndexError::UnknownTxid(missing)) if missing == txid => {}
+            Err(error) => return Err(error),
         }
+        check_txid(txid, self.primary.add_tx(tx.clone())?)?;
+        check_txid(txid, self.cache.add_tx(tx)?)?;
+        Ok(txid)
     }
 }

--- a/sapio-base/tests/txindex.rs
+++ b/sapio-base/tests/txindex.rs
@@ -1,0 +1,330 @@
+use bitcoin::{OutPoint, Script, Transaction, TxIn, TxOut, Txid, Witness};
+use sapio_base::txindex::{CachedTxIndex, TxIndex, TxIndexError, TxIndexLogger};
+use std::cell::RefCell;
+use std::io;
+use std::sync::Arc;
+
+type Lookup = Result<Arc<Transaction>, TxIndexError>;
+
+#[derive(Default)]
+struct StubIndex {
+    lookup: RefCell<Option<Lookup>>,
+    add: RefCell<Option<Result<Txid, TxIndexError>>>,
+    requested: RefCell<Vec<Txid>>,
+    added: RefCell<Vec<Arc<Transaction>>>,
+}
+
+impl StubIndex {
+    fn with_lookup(self, result: Lookup) -> Self {
+        *self.lookup.borrow_mut() = Some(result);
+        self
+    }
+
+    fn with_add(self, result: Result<Txid, TxIndexError>) -> Self {
+        *self.add.borrow_mut() = Some(result);
+        self
+    }
+
+    fn assert_untouched(&self) {
+        assert!(self.requested.borrow().is_empty());
+        assert!(self.added.borrow().is_empty());
+    }
+}
+
+impl TxIndex for StubIndex {
+    fn lookup_tx(&self, txid: &Txid) -> Lookup {
+        self.requested.borrow_mut().push(*txid);
+        self.lookup.borrow_mut().take().expect("unexpected lookup")
+    }
+
+    fn add_tx(&self, tx: Arc<Transaction>) -> Result<Txid, TxIndexError> {
+        self.added.borrow_mut().push(tx);
+        self.add.borrow_mut().take().expect("unexpected add")
+    }
+}
+
+fn transaction(value: u64) -> Arc<Transaction> {
+    Arc::new(Transaction {
+        version: 2,
+        lock_time: 0,
+        input: vec![TxIn::default()],
+        output: vec![TxOut {
+            value,
+            script_pubkey: Script::new(),
+        }],
+    })
+}
+
+fn assert_mismatch(error: TxIndexError, expected: Txid, actual: Txid) {
+    assert!(
+        matches!(error, TxIndexError::TxidMismatch { expected: e, actual: a }
+            if e == expected && a == actual),
+        "{error}"
+    );
+}
+
+fn failures(other: Txid) -> Vec<TxIndexError> {
+    vec![
+        TxIndexError::NetworkError(io::Error::new(io::ErrorKind::TimedOut, "offline")),
+        TxIndexError::RpcError(Box::new(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "RPC unavailable",
+        ))),
+        TxIndexError::UnknownTxid(other),
+    ]
+}
+
+fn assert_same_error(actual: TxIndexError, expected: &str) {
+    assert_eq!(actual.to_string(), expected);
+}
+
+#[test]
+fn output_lookup_checks_identity_before_the_output_index() {
+    let expected = transaction(42).txid();
+    let wrong = transaction(43);
+    for vout in [0, 1] {
+        let index = StubIndex::default().with_lookup(Ok(wrong.clone()));
+        let error = index
+            .lookup_output(&OutPoint {
+                txid: expected,
+                vout,
+            })
+            .unwrap_err();
+        assert_mismatch(error, expected, wrong.txid());
+    }
+
+    let tx = transaction(42);
+    let index = TxIndexLogger::new();
+    assert!(
+        matches!(index.lookup_tx(&expected), Err(TxIndexError::UnknownTxid(id)) if id == expected)
+    );
+    index.add_tx(tx.clone()).unwrap();
+    assert_eq!(
+        index
+            .lookup_output(&OutPoint {
+                txid: expected,
+                vout: 0
+            })
+            .unwrap(),
+        tx.output[0]
+    );
+    assert!(matches!(
+        index.lookup_output(&OutPoint {
+            txid: expected,
+            vout: 1
+        }),
+        Err(TxIndexError::IndexTooHigh(1))
+    ));
+}
+
+#[test]
+fn cache_miss_loads_once_and_subsequent_hit_skips_the_primary() {
+    let tx = transaction(42);
+    let index = CachedTxIndex {
+        cache: TxIndexLogger::new(),
+        primary: StubIndex::default().with_lookup(Ok(tx.clone())),
+    };
+    assert_eq!(index.lookup_tx(&tx.txid()).unwrap(), tx);
+    assert_eq!(index.lookup_tx(&tx.txid()).unwrap(), tx);
+    assert_eq!(*index.primary.requested.borrow(), vec![tx.txid()]);
+    assert!(index.primary.added.borrow().is_empty());
+}
+
+#[test]
+fn cache_errors_do_not_fall_back_during_lookup_or_add() {
+    let tx = transaction(42);
+    for adding in [false, true] {
+        for error in failures(transaction(43).txid()) {
+            let expected = error.to_string();
+            let index = CachedTxIndex {
+                cache: StubIndex::default().with_lookup(Err(error)),
+                primary: StubIndex::default(),
+            };
+            let error = if adding {
+                index.add_tx(tx.clone()).unwrap_err()
+            } else {
+                index.lookup_tx(&tx.txid()).unwrap_err()
+            };
+            assert_same_error(error, &expected);
+            index.primary.assert_untouched();
+            assert!(index.cache.added.borrow().is_empty());
+        }
+    }
+}
+
+#[test]
+fn wrong_cache_transactions_stop_lookup_and_add() {
+    let tx = transaction(42);
+    let wrong = transaction(43);
+    for adding in [false, true] {
+        let index = CachedTxIndex {
+            cache: StubIndex::default().with_lookup(Ok(wrong.clone())),
+            primary: StubIndex::default(),
+        };
+        let error = if adding {
+            index.add_tx(tx.clone()).unwrap_err()
+        } else {
+            index.lookup_tx(&tx.txid()).unwrap_err()
+        };
+        assert_mismatch(error, tx.txid(), wrong.txid());
+        index.primary.assert_untouched();
+        assert!(index.cache.added.borrow().is_empty());
+    }
+}
+
+#[test]
+fn wrong_primary_transactions_never_enter_the_cache() {
+    let expected = transaction(42).txid();
+    let wrong = transaction(43);
+    let index = CachedTxIndex {
+        cache: StubIndex::default().with_lookup(Err(TxIndexError::UnknownTxid(expected))),
+        primary: StubIndex::default().with_lookup(Ok(wrong.clone())),
+    };
+    assert_mismatch(
+        index.lookup_tx(&expected).unwrap_err(),
+        expected,
+        wrong.txid(),
+    );
+    assert!(index.cache.added.borrow().is_empty());
+}
+
+#[test]
+fn primary_lookup_errors_leave_the_cache_untouched() {
+    let txid = transaction(42).txid();
+    for error in failures(txid) {
+        let expected = error.to_string();
+        let index = CachedTxIndex {
+            cache: StubIndex::default().with_lookup(Err(TxIndexError::UnknownTxid(txid))),
+            primary: StubIndex::default().with_lookup(Err(error)),
+        };
+        assert_same_error(index.lookup_tx(&txid).unwrap_err(), &expected);
+        assert!(index.cache.added.borrow().is_empty());
+    }
+}
+
+#[test]
+fn lookup_rejects_an_incorrect_cache_add_acknowledgement() {
+    let tx = transaction(42);
+    let wrong = transaction(43).txid();
+    let index = CachedTxIndex {
+        cache: StubIndex::default()
+            .with_lookup(Err(TxIndexError::UnknownTxid(tx.txid())))
+            .with_add(Ok(wrong)),
+        primary: StubIndex::default().with_lookup(Ok(tx.clone())),
+    };
+    assert_mismatch(index.lookup_tx(&tx.txid()).unwrap_err(), tx.txid(), wrong);
+}
+
+#[test]
+fn add_miss_populates_primary_then_cache() {
+    let tx = transaction(42);
+    let index = CachedTxIndex {
+        cache: TxIndexLogger::new(),
+        primary: StubIndex::default().with_add(Ok(tx.txid())),
+    };
+    assert_eq!(index.add_tx(tx.clone()).unwrap(), tx.txid());
+    assert_eq!(index.lookup_tx(&tx.txid()).unwrap(), tx);
+    assert_eq!(*index.primary.added.borrow(), vec![tx]);
+    assert!(index.primary.requested.borrow().is_empty());
+}
+
+#[test]
+fn incorrect_primary_add_acknowledgements_never_populate_the_cache() {
+    let tx = transaction(42);
+    let wrong = transaction(43).txid();
+    let index = CachedTxIndex {
+        cache: StubIndex::default().with_lookup(Err(TxIndexError::UnknownTxid(tx.txid()))),
+        primary: StubIndex::default().with_add(Ok(wrong)),
+    };
+    assert_mismatch(index.add_tx(tx.clone()).unwrap_err(), tx.txid(), wrong);
+    assert!(index.cache.added.borrow().is_empty());
+}
+
+#[test]
+fn add_rejects_an_incorrect_cache_acknowledgement() {
+    let tx = transaction(42);
+    let wrong = transaction(43).txid();
+    let index = CachedTxIndex {
+        cache: StubIndex::default()
+            .with_lookup(Err(TxIndexError::UnknownTxid(tx.txid())))
+            .with_add(Ok(wrong)),
+        primary: StubIndex::default().with_add(Ok(tx.txid())),
+    };
+    assert_mismatch(index.add_tx(tx.clone()).unwrap_err(), tx.txid(), wrong);
+}
+
+#[test]
+fn primary_add_errors_do_not_populate_the_cache() {
+    let tx = transaction(42);
+    for error in failures(tx.txid()) {
+        let expected = error.to_string();
+        let index = CachedTxIndex {
+            cache: StubIndex::default().with_lookup(Err(TxIndexError::UnknownTxid(tx.txid()))),
+            primary: StubIndex::default().with_add(Err(error)),
+        };
+        assert_same_error(index.add_tx(tx.clone()).unwrap_err(), &expected);
+        assert!(index.cache.added.borrow().is_empty());
+    }
+}
+
+#[test]
+fn cache_add_errors_propagate_during_lookup_and_add() {
+    let tx = transaction(42);
+    for adding in [false, true] {
+        for error in failures(tx.txid()) {
+            let expected = error.to_string();
+            let index = CachedTxIndex {
+                cache: StubIndex::default()
+                    .with_lookup(Err(TxIndexError::UnknownTxid(tx.txid())))
+                    .with_add(Err(error)),
+                primary: StubIndex::default()
+                    .with_lookup(Ok(tx.clone()))
+                    .with_add(Ok(tx.txid())),
+            };
+            let error = if adding {
+                index.add_tx(tx.clone()).unwrap_err()
+            } else {
+                index.lookup_tx(&tx.txid()).unwrap_err()
+            };
+            assert_same_error(error, &expected);
+        }
+    }
+}
+
+#[test]
+fn identical_adds_do_not_rewrite_either_index() {
+    let tx = transaction(42);
+    let index = CachedTxIndex {
+        cache: StubIndex::default().with_lookup(Ok(tx.clone())),
+        primary: StubIndex::default(),
+    };
+    assert_eq!(index.add_tx(tx.clone()).unwrap(), tx.txid());
+    assert!(index.cache.added.borrow().is_empty());
+    index.primary.assert_untouched();
+}
+
+#[test]
+fn changed_witnesses_update_both_indexes_but_identical_adds_are_deduplicated() {
+    let original = transaction(42);
+    let mut signed = (*original).clone();
+    signed.input[0].witness = Witness::from_vec(vec![vec![1; 64]]);
+    let signed = Arc::new(signed);
+    assert_eq!(original.txid(), signed.txid());
+    assert_ne!(original.wtxid(), signed.wtxid());
+
+    let index = CachedTxIndex {
+        cache: TxIndexLogger::new(),
+        primary: StubIndex::default().with_add(Ok(signed.txid())),
+    };
+    index.cache.add_tx(original.clone()).unwrap();
+    assert_eq!(index.add_tx(original.clone()).unwrap(), original.txid());
+    index.primary.assert_untouched();
+
+    assert_eq!(index.add_tx(signed.clone()).unwrap(), signed.txid());
+    assert_eq!(*index.primary.added.borrow(), vec![signed.clone()]);
+    assert_eq!(index.lookup_tx(&signed.txid()).unwrap(), signed);
+
+    assert_eq!(index.add_tx(signed.clone()).unwrap(), signed.txid());
+    assert_eq!(*index.primary.added.borrow(), vec![signed.clone()]);
+    assert_eq!(index.lookup_tx(&signed.txid()).unwrap(), signed);
+}

--- a/sapio-psbt/src/lib.rs
+++ b/sapio-psbt/src/lib.rs
@@ -352,9 +352,12 @@ impl Display for PSBTValidationError {
 
 impl Error for PSBTValidationError {}
 
-// Public PSBT fields can bypass the checks performed during deserialization.
-// Validate the complete shape before signing or entering the fork's finalizer.
-pub(crate) fn validate_psbt(psbt: &PartiallySignedTransaction) -> Result<(), PSBTValidationError> {
+/// Validate transaction and map structure before extracting or signing a PSBT.
+///
+/// Public fields can bypass checks performed during deserialization. This
+/// checks input presence, map counts and unsigned transaction fields; it does
+/// not authenticate previous outputs or verify signatures.
+pub fn validate_psbt(psbt: &PartiallySignedTransaction) -> Result<(), PSBTValidationError> {
     if psbt.unsigned_tx.input.is_empty() {
         return Err(PSBTValidationError::NoInputs);
     }

--- a/sapio/src/contract/abi/object/bind.rs
+++ b/sapio/src/contract/abi/object/bind.rs
@@ -85,7 +85,7 @@ impl Object {
                 });
             }
         }
-        // Prepare the complete graph before invoking signers or index writers.
+        // Prepare the complete graph before signing or inserting generated transactions.
         // Descendants use the actual generated parent, not a second index lookup.
         let mut prepared = Vec::new();
         let mut stack = vec![(

--- a/sapio/src/contract/abi/object/bind.rs
+++ b/sapio/src/contract/abi/object/bind.rs
@@ -9,18 +9,17 @@ use super::descriptors::*;
 pub use crate::contract::abi::studio::*;
 use crate::contract::object::Object;
 use crate::contract::object::ObjectError;
-use crate::template::Template;
 use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::util::psbt::PartiallySignedTransaction;
 use bitcoin::util::taproot::TaprootBuilder;
 use bitcoin::util::taproot::TaprootSpendInfo;
-use bitcoin::OutPoint;
+use bitcoin::{OutPoint, Transaction};
 use miniscript::*;
 use sapio_base::effects::EffectPath;
 use sapio_base::miniscript;
 use sapio_base::serialization_helpers::SArc;
-use sapio_base::txindex::TxIndex;
-use sapio_ctv_emulator_trait::CTVEmulator;
+use sapio_base::txindex::{TxIndex, TxIndexError};
+use sapio_ctv_emulator_trait::{sign_checked, CTVEmulator};
 use std::collections::{BTreeMap, BTreeSet};
 use std::rc::Rc;
 use std::sync::Arc;
@@ -35,8 +34,16 @@ impl Object {
     /// `out_in` and the parent transaction outputs determine contract inputs.
     /// Omitted mappings and `None` entries leave auxiliary inputs unresolved.
     ///
-    /// The entire artifact and all mappings are validated before signing or
-    /// adding transactions to the index.
+    /// The entire artifact, all mappings and all known funding are validated
+    /// before signing. Only a matching `TxIndexError::UnknownTxid` leaves an
+    /// explicit input unresolved; operational errors and invalid outputs fail.
+    /// Known contract outputs must match the contract script. When every input
+    /// is known, their total must cover the outputs and reserved fees.
+    ///
+    /// Every known previous transaction is included in the PSBT. This checks
+    /// transaction identity, not confirmation or whether an output is unspent.
+    /// All signer responses are checked before adding transactions to the index;
+    /// an index write failure can still leave earlier writes in the index.
     pub fn bind_psbt(
         &self,
         out_in: bitcoin::OutPoint,
@@ -78,127 +85,211 @@ impl Object {
                 });
             }
         }
-        let mut result = BTreeMap::<SArc<EffectPath>, SapioStudioObject>::new();
-        // Could use a queue instead to do BFS linking, but order doesn't matter and stack is
-        // faster.
-        let mut stack = vec![(out_in, self)];
-        let mut mock_out = OutPoint::default();
-        mock_out.vout = 0;
+        // Prepare the complete graph before invoking signers or index writers.
+        // Descendants use the actual generated parent, not a second index lookup.
+        let mut prepared = Vec::new();
+        let mut stack = vec![(out_in, self, lookup_funding(blockdata.as_ref(), out_in)?)];
+        let mut reserved: BTreeSet<_> = output_map
+            .values()
+            .flatten()
+            .filter_map(|out| *out)
+            .chain(std::iter::once(out_in))
+            .collect();
+        let mut mock_out = OutPoint {
+            vout: 0,
+            ..OutPoint::default()
+        };
         let secp = bitcoin::secp256k1::Secp256k1::new();
-        while let Some((
-            out,
-            Object {
-                root_path,
-                continue_apis,
-                descriptor,
-                ctv_to_tx,
-                suggested_txs,
-                metadata,
-                ..
-            },
-        )) = stack.pop()
-        {
+        while let Some((out, object, funding)) = stack.pop() {
+            let invalid_funding = |outpoint, reason: String| ObjectError::InvalidFunding {
+                path: object.root_path.clone(),
+                outpoint,
+                reason,
+            };
+            if let Some(previous) = &funding {
+                if previous.output[out.vout as usize].script_pubkey
+                    != bitcoin::Script::from(&object.address)
+                {
+                    return Err(invalid_funding(
+                        out,
+                        "output script does not match the contract".into(),
+                    ));
+                }
+            }
+            let mut transactions = Vec::new();
+            for (hash, template) in object.ctv_to_tx.iter().chain(&object.suggested_txs) {
+                let mut tx = template.tx.clone();
+                tx.input[0].previous_output = out;
+                let mut seen = BTreeSet::from([out]);
+                let mut prev_txs = vec![funding.clone()];
+                for (i, input) in tx.input.iter_mut().enumerate().skip(1) {
+                    let mapped = output_map.get(hash).and_then(|inputs| inputs[i]);
+                    let previous = if let Some(mapped) = mapped {
+                        input.previous_output = mapped;
+                        lookup_funding(blockdata.as_ref(), mapped)?
+                    } else {
+                        // Placeholders remain explicitly unresolved even if an
+                        // index happens to contain a transaction with this ID.
+                        while reserved.contains(&mock_out) || mock_out == out {
+                            mock_out.vout = mock_out.vout.checked_add(1).ok_or_else(|| {
+                                invalid_funding(
+                                    out,
+                                    "exhausted unresolved input identifiers".into(),
+                                )
+                            })?;
+                        }
+                        input.previous_output = mock_out;
+                        reserved.insert(mock_out);
+                        None
+                    };
+                    if !seen.insert(input.previous_output) {
+                        return Err(invalid_funding(
+                            input.previous_output,
+                            "transaction spends an input more than once".into(),
+                        ));
+                    }
+                    prev_txs.push(previous);
+                }
+                let mut psbt = PartiallySignedTransaction::from_unsigned_tx(tx.clone())?;
+                let mut amount = 0u64;
+                let mut complete = true;
+                for ((input, tx_in), previous) in
+                    psbt.inputs.iter_mut().zip(&tx.input).zip(prev_txs)
+                {
+                    if let Some(previous) = previous {
+                        let output = &previous.output[tx_in.previous_output.vout as usize];
+                        amount = amount.checked_add(output.value).ok_or_else(|| {
+                            invalid_funding(
+                                tx_in.previous_output,
+                                "input amount sum overflows".into(),
+                            )
+                        })?;
+                        if output.script_pubkey.is_witness_program() {
+                            input.witness_utxo = Some(output.clone());
+                        }
+                        // The transaction lets downstream signers authenticate
+                        // amounts and scripts against the committed outpoint.
+                        input.non_witness_utxo = Some((*previous).clone());
+                    } else {
+                        complete = false;
+                    }
+                }
+                if complete && amount < template.max.as_sat() {
+                    return Err(invalid_funding(
+                        out,
+                        format!(
+                        "inputs provide {amount} sat but outputs and reserved fees require {} sat",
+                        template.max.as_sat()
+                    ),
+                    ));
+                }
+                match &object.descriptor {
+                    Some(SupportedDescriptors::Pk(d)) => {
+                        psbt.inputs[0].witness_script = Some(d.explicit_script()?);
+                    }
+                    Some(SupportedDescriptors::XOnly(Descriptor::Tr(t))) => {
+                        let mut builder = TaprootBuilder::new();
+                        let mut added = false;
+                        for (depth, ms) in t.iter_scripts() {
+                            added = true;
+                            builder = builder.add_leaf(depth, ms.encode())?;
+                        }
+                        let info = if added {
+                            builder.finalize(&secp, *t.internal_key())?
+                        } else {
+                            TaprootSpendInfo::new_key_spend(&secp, *t.internal_key(), None)
+                        };
+                        let input = &mut psbt.inputs[0];
+                        for item in info.as_script_map().keys() {
+                            let cb = info.control_block(item).expect("Must be present");
+                            input.tap_scripts.insert(cb, item.clone());
+                        }
+                        input.tap_merkle_root = info.merkle_root();
+                        input.tap_internal_key = Some(info.internal_key());
+                    }
+                    _ => (),
+                }
+                let txid = tx.txid();
+                let parent = Arc::new(tx);
+                for (vout, output) in template.outputs.iter().enumerate() {
+                    stack.push((
+                        OutPoint::new(txid, vout as u32),
+                        &output.contract,
+                        Some(parent.clone()),
+                    ));
+                }
+                transactions.push((template, psbt));
+            }
+            prepared.push((out, object, transactions));
+        }
+        // A late invalid signer response must not leave an indexed prefix.
+        for (_, _, transactions) in &mut prepared {
+            for (_, psbt) in transactions {
+                *psbt = sign_checked(emulator, psbt.clone())?;
+            }
+        }
+        let mut result = BTreeMap::<SArc<EffectPath>, SapioStudioObject>::new();
+        for (out, object, transactions) in prepared {
+            let mut txs = Vec::with_capacity(transactions.len());
+            for (template, psbt) in transactions {
+                let tx = Arc::new(psbt.clone().extract_tx());
+                let expected = tx.txid();
+                let actual = blockdata.add_tx(tx)?;
+                if actual != expected {
+                    return Err(TxIndexError::TxidMismatch { expected, actual }.into());
+                }
+                txs.push(
+                    LinkedPSBT {
+                        psbt,
+                        metadata: template.metadata_map_s2s.clone(),
+                        output_metadata: template
+                            .outputs
+                            .iter()
+                            .map(|x| x.contract.metadata.clone())
+                            .collect(),
+                        added_output_metadata: template
+                            .outputs
+                            .iter()
+                            .map(|x| x.added_metadata.clone())
+                            .collect(),
+                    }
+                    .into(),
+                );
+            }
             result.insert(
-                root_path.clone(),
+                object.root_path.clone(),
                 SapioStudioObject {
-                    metadata: metadata.clone(),
+                    metadata: object.metadata.clone(),
                     out,
-                    continue_apis: continue_apis.clone(),
-                    txs: ctv_to_tx
-                        .iter()
-                        .chain(suggested_txs.iter())
-                        .map(
-                            |(
-                                ctv_hash,
-                                Template {
-                                    metadata_map_s2s,
-                                    outputs,
-                                    tx,
-                                    ..
-                                },
-                            )| {
-                                let mut tx = tx.clone();
-                                tx.input[0].previous_output = out;
-                                for inp in tx.input[1..].iter_mut() {
-                                    inp.previous_output = mock_out;
-                                    mock_out.vout += 1;
-                                }
-                                if let Some(outputs) = output_map.get(ctv_hash) {
-                                    for (i, inp) in tx.input.iter_mut().enumerate().skip(1) {
-                                        if let Some(out) = outputs[i] {
-                                            inp.previous_output = out;
-                                        }
-                                    }
-                                }
-                                let mut psbtx =
-                                    PartiallySignedTransaction::from_unsigned_tx(tx.clone())?;
-                                for (psbt_in, tx_in) in psbtx.inputs.iter_mut().zip(tx.input.iter())
-                                {
-                                    psbt_in.witness_utxo =
-                                        blockdata.lookup_output(&tx_in.previous_output).ok();
-                                }
-                                // Missing other Witness Info.
-                                match descriptor {
-                                    Some(SupportedDescriptors::Pk(d)) => {
-                                        psbtx.inputs[0].witness_script = Some(d.explicit_script()?);
-                                    }
-                                    Some(SupportedDescriptors::XOnly(Descriptor::Tr(t))) => {
-                                        let mut builder = TaprootBuilder::new();
-                                        let mut added = false;
-                                        for (depth, ms) in t.iter_scripts() {
-                                            added = true;
-                                            let script = ms.encode();
-                                            builder = builder.add_leaf(depth, script)?;
-                                        }
-                                        let info = if added {
-                                            builder.finalize(&secp, *t.internal_key())?
-                                        } else {
-                                            TaprootSpendInfo::new_key_spend(
-                                                &secp,
-                                                *t.internal_key(),
-                                                None,
-                                            )
-                                        };
-                                        let inp = &mut psbtx.inputs[0];
-                                        for item in info.as_script_map().keys() {
-                                            let cb =
-                                                info.control_block(item).expect("Must be present");
-                                            inp.tap_scripts.insert(cb.clone(), item.clone());
-                                        }
-                                        inp.tap_merkle_root = info.merkle_root();
-                                        inp.tap_internal_key = Some(info.internal_key());
-                                    }
-                                    _ => (),
-                                }
-                                psbtx = emulator.sign(psbtx)?;
-                                let final_tx = psbtx.clone().extract_tx();
-                                let txid = blockdata.add_tx(Arc::new(final_tx))?;
-                                stack.reserve(outputs.len());
-                                for (vout, v) in outputs.iter().enumerate() {
-                                    let vout = vout as u32;
-                                    stack.push((bitcoin::OutPoint { txid, vout }, &v.contract));
-                                }
-                                Ok(LinkedPSBT {
-                                    psbt: psbtx,
-                                    metadata: metadata_map_s2s.clone(),
-                                    output_metadata: outputs
-                                        .iter()
-                                        .cloned()
-                                        .map(|x| x.contract.metadata)
-                                        .collect::<Vec<_>>(),
-                                    added_output_metadata: outputs
-                                        .iter()
-                                        .cloned()
-                                        .map(|x| x.added_metadata)
-                                        .collect::<Vec<_>>(),
-                                }
-                                .into())
-                            },
-                        )
-                        .collect::<Result<Vec<SapioStudioFormat>, ObjectError>>()?,
+                    continue_apis: object.continue_apis.clone(),
+                    txs,
                 },
             );
         }
         Ok(Program { program: result })
     }
+}
+
+// Use lookup_tx directly: a custom lookup_output implementation must not be
+// able to bypass transaction identity or output-bound checks at this boundary.
+fn lookup_funding(
+    index: &dyn TxIndex,
+    out: OutPoint,
+) -> Result<Option<Arc<Transaction>>, TxIndexError> {
+    let tx = match index.lookup_tx(&out.txid) {
+        Ok(tx) => tx,
+        Err(TxIndexError::UnknownTxid(txid)) if txid == out.txid => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    let actual = tx.txid();
+    if actual != out.txid {
+        return Err(TxIndexError::TxidMismatch {
+            expected: out.txid,
+            actual,
+        });
+    }
+    if out.vout as usize >= tx.output.len() {
+        return Err(TxIndexError::IndexTooHigh(out.vout));
+    }
+    Ok(Some(tx))
 }

--- a/sapio/src/contract/abi/object/bind.rs
+++ b/sapio/src/contract/abi/object/bind.rs
@@ -15,7 +15,7 @@ use bitcoin::util::taproot::TaprootBuilder;
 use bitcoin::util::taproot::TaprootSpendInfo;
 use bitcoin::{OutPoint, Transaction};
 use miniscript::*;
-use sapio_base::effects::EffectPath;
+use sapio_base::effects::{EffectPath, PathFragment};
 use sapio_base::miniscript;
 use sapio_base::serialization_helpers::SArc;
 use sapio_base::txindex::{TxIndex, TxIndexError};
@@ -88,7 +88,12 @@ impl Object {
         // Prepare the complete graph before invoking signers or index writers.
         // Descendants use the actual generated parent, not a second index lookup.
         let mut prepared = Vec::new();
-        let mut stack = vec![(out_in, self, lookup_funding(blockdata.as_ref(), out_in)?)];
+        let mut stack = vec![(
+            out_in,
+            self,
+            self.root_path.clone(),
+            lookup_funding(blockdata.as_ref(), out_in)?,
+        )];
         let mut reserved: BTreeSet<_> = output_map
             .values()
             .flatten()
@@ -100,7 +105,7 @@ impl Object {
             ..OutPoint::default()
         };
         let secp = bitcoin::secp256k1::Secp256k1::new();
-        while let Some((out, object, funding)) = stack.pop() {
+        while let Some((out, object, bound_path, funding)) = stack.pop() {
             let invalid_funding = |outpoint, reason: String| ObjectError::InvalidFunding {
                 path: object.root_path.clone(),
                 outpoint,
@@ -117,7 +122,17 @@ impl Object {
                 }
             }
             let mut transactions = Vec::new();
-            for (hash, template) in object.ctv_to_tx.iter().chain(&object.suggested_txs) {
+            for (kind, hash, template) in object
+                .ctv_to_tx
+                .iter()
+                .map(|(hash, template)| (PathFragment::Next, hash, template))
+                .chain(
+                    object
+                        .suggested_txs
+                        .iter()
+                        .map(|(hash, template)| (PathFragment::Suggested, hash, template)),
+                )
+            {
                 let mut tx = template.tx.clone();
                 tx.input[0].previous_output = out;
                 let mut seen = BTreeSet::from([out]);
@@ -211,25 +226,35 @@ impl Object {
                 }
                 let txid = tx.txid();
                 let parent = Arc::new(tx);
+                // Source paths can be reused. An occurrence is identified by
+                // its parent transition and output, independently of metadata.
+                let transition_path = EffectPath::push(
+                    Some(EffectPath::push(Some(bound_path.0.clone()), kind)),
+                    PathFragment::Named(SArc(Arc::new(hash.to_string()))),
+                );
                 for (vout, output) in template.outputs.iter().enumerate() {
                     stack.push((
                         OutPoint::new(txid, vout as u32),
                         &output.contract,
+                        SArc(EffectPath::push(
+                            Some(transition_path.clone()),
+                            PathFragment::Branch(vout as u64),
+                        )),
                         Some(parent.clone()),
                     ));
                 }
                 transactions.push((template, psbt));
             }
-            prepared.push((out, object, transactions));
+            prepared.push((out, object, bound_path, transactions));
         }
         // A late invalid signer response must not leave an indexed prefix.
-        for (_, _, transactions) in &mut prepared {
+        for (_, _, _, transactions) in &mut prepared {
             for (_, psbt) in transactions {
                 *psbt = sign_checked(emulator, psbt.clone())?;
             }
         }
         let mut result = BTreeMap::<SArc<EffectPath>, SapioStudioObject>::new();
-        for (out, object, transactions) in prepared {
+        for (out, object, bound_path, transactions) in prepared {
             let mut txs = Vec::with_capacity(transactions.len());
             for (template, psbt) in transactions {
                 let tx = Arc::new(psbt.clone().extract_tx());
@@ -257,8 +282,9 @@ impl Object {
                 );
             }
             result.insert(
-                object.root_path.clone(),
+                bound_path,
                 SapioStudioObject {
+                    source_path: Some(object.root_path.clone()),
                     metadata: object.metadata.clone(),
                     out,
                     continue_apis: object.continue_apis.clone(),

--- a/sapio/src/contract/abi/object/error.rs
+++ b/sapio/src/contract/abi/object/error.rs
@@ -24,6 +24,19 @@ pub enum ObjectError {
         /// Explanation of the mapping error.
         reason: &'static str,
     },
+    /// Known funding cannot satisfy the bound contract or transaction.
+    InvalidFunding {
+        /// The contract whose funding is invalid.
+        path: sapio_base::serialization_helpers::SArc<sapio_base::effects::EffectPath>,
+        /// The contract or auxiliary input being checked.
+        outpoint: bitcoin::OutPoint,
+        /// Explanation of the funding error.
+        reason: String,
+    },
+    /// Transaction lookup or insertion failed its integrity checks.
+    TxIndex(TxIndexError),
+    /// An emulator failed or returned an invalid signing response.
+    Emulator(EmulatorError),
     /// The transaction cannot be represented as an unsigned PSBT.
     Psbt(bitcoin::util::psbt::Error),
     /// The Error was due to Miniscript Policy
@@ -44,6 +57,8 @@ impl std::error::Error for ObjectError {
         match self {
             Self::InvalidArtifact(error) => Some(error),
             Self::Psbt(error) => Some(error),
+            Self::TxIndex(error) => Some(error),
+            Self::Emulator(error) => Some(error),
             _ => None,
         }
     }
@@ -65,12 +80,12 @@ impl From<TaprootBuilderError> for ObjectError {
 }
 impl From<EmulatorError> for ObjectError {
     fn from(e: EmulatorError) -> Self {
-        ObjectError::Custom(Box::new(e))
+        ObjectError::Emulator(e)
     }
 }
 impl From<TxIndexError> for ObjectError {
     fn from(e: TxIndexError) -> Self {
-        ObjectError::Custom(Box::new(e))
+        ObjectError::TxIndex(e)
     }
 }
 
@@ -94,6 +109,19 @@ impl std::fmt::Display for ObjectError {
                 write!(f, "invalid input mapping for template {template}: {reason}")
             }
             Self::Psbt(error) => write!(f, "invalid unsigned transaction: {error}"),
+            Self::InvalidFunding {
+                path,
+                outpoint,
+                reason,
+            } => {
+                write!(
+                    f,
+                    "invalid funding {outpoint} for contract {}: {reason}",
+                    String::from(path.0.as_ref().clone())
+                )
+            }
+            Self::TxIndex(error) => write!(f, "transaction index: {error}"),
+            Self::Emulator(error) => write!(f, "signing: {error}"),
             _ => write!(f, "{:?}", self),
         }
     }

--- a/sapio/src/contract/abi/studio/mod.rs
+++ b/sapio/src/contract/abi/studio/mod.rs
@@ -69,28 +69,24 @@ impl From<LinkedPSBT> for SapioStudioFormat {
     }
 }
 
-/// A `Program` is a wrapper type for a list of
-/// JSON objects that should be of form:
-/// ```json
-/// {
-///     "hex" : Hex Encoded Transaction
-///     "color" : HTML Color,
-///     "metadata" : JSON Value,
-///     "utxo_metadata" : {
-///         "key" : "value",
-///         ...
-///     }
-/// }
-/// ```
+/// Bound contract occurrences with their PSBTs, outputs and continuation APIs.
+///
+/// Map keys identify occurrences in the bound graph. A compiled contract can
+/// appear at several outputs; its original path is retained in `source_path`.
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 pub struct Program {
-    /// program contains the list of SapioStudio PSBTs
+    /// Entries keyed by their bound occurrence paths. Child paths derive from
+    /// the parent, transition kind, template hash and output index.
     pub program: BTreeMap<SArc<EffectPath>, SapioStudioObject>,
 }
 
 /// A `SapioStudioObject` is a json-friendly format for a `Object` for use in Sapio Studio
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 pub struct SapioStudioObject {
+    /// Original compilation path, independent of this occurrence's binding
+    /// path. Synthetic funding entries have no compilation source.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_path: Option<SArc<EffectPath>>,
     /// The object's metadata
     pub metadata: ObjectMetadata,
     /// The main covenant OutPoint

--- a/sapio/tests/funding_validation.rs
+++ b/sapio/tests/funding_validation.rs
@@ -1,0 +1,391 @@
+use bitcoin::hashes::{sha256, Hash};
+use bitcoin::psbt::PartiallySignedTransaction as Psbt;
+use bitcoin::{Address, Amount, Network, OutPoint, Script, Transaction, TxIn, TxOut, Txid};
+use sapio::contract::abi::object::ObjectError;
+use sapio::contract::abi::studio::{Program, SapioStudioFormat};
+use sapio::contract::{Compilable, Compiled, Context, Contract};
+use sapio::{declare, then};
+use sapio_base::txindex::{TxIndex, TxIndexError};
+use sapio_base::Clause;
+use sapio_ctv_emulator_trait::{CTVAvailable, CTVEmulator, EmulatorError};
+use std::cell::{Cell, RefCell};
+use std::collections::BTreeMap;
+use std::rc::Rc;
+use std::str::FromStr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+struct Payment {
+    destination: Compiled,
+    extra_input: bool,
+    fees: u64,
+}
+
+impl Payment {
+    #[then]
+    fn pay(self, ctx: Context) {
+        let mut builder =
+            ctx.template()
+                .add_output(Amount::from_sat(1_000), &self.destination, None)?;
+        if self.extra_input {
+            builder = builder.add_sequence();
+        }
+        builder.add_fees(Amount::from_sat(self.fees))?.into()
+    }
+}
+
+impl Contract for Payment {
+    declare! {then, Self::pay}
+    declare! {non updatable}
+}
+
+fn leaf() -> Compiled {
+    Compiled::from_address(
+        Address::from_str("bcrt1qumrrqgt7e3a7damzm8x97m6sjs20u8hjw2hcjj").unwrap(),
+        None,
+    )
+}
+
+fn payment(destination: Compiled, extra_input: bool, fees: u64, path: &str) -> Compiled {
+    Payment {
+        destination,
+        extra_input,
+        fees,
+    }
+    .compile(Context::new(
+        Network::Regtest,
+        Amount::from_sat(1_000 + fees),
+        Arc::new(CTVAvailable),
+        path.try_into().unwrap(),
+        Arc::new(Default::default()),
+        None,
+    ))
+    .unwrap()
+}
+
+fn funding(object: &Compiled, value: u64) -> Transaction {
+    Transaction {
+        version: 2,
+        lock_time: 0,
+        input: vec![TxIn::default()],
+        output: vec![TxOut {
+            value,
+            script_pubkey: object.address.clone().into(),
+        }],
+    }
+}
+
+#[derive(Default)]
+struct Index {
+    txs: RefCell<BTreeMap<Txid, Arc<Transaction>>>,
+    writes: Cell<usize>,
+    fail_lookup: Cell<bool>,
+    wrong_ack: Cell<bool>,
+}
+
+impl Index {
+    fn with(tx: Transaction) -> Rc<Self> {
+        let index = Rc::new(Self::default());
+        index.txs.borrow_mut().insert(tx.txid(), Arc::new(tx));
+        index
+    }
+}
+
+impl TxIndex for Index {
+    fn lookup_tx(&self, txid: &Txid) -> Result<Arc<Transaction>, TxIndexError> {
+        if self.fail_lookup.get() {
+            return Err(TxIndexError::NetworkError(std::io::Error::other(
+                "unavailable",
+            )));
+        }
+        self.txs
+            .borrow()
+            .get(txid)
+            .cloned()
+            .ok_or(TxIndexError::UnknownTxid(*txid))
+    }
+
+    fn add_tx(&self, tx: Arc<Transaction>) -> Result<Txid, TxIndexError> {
+        self.writes.set(self.writes.get() + 1);
+        if self.wrong_ack.get() {
+            return Ok(Txid::from_slice(&[0; 32]).unwrap());
+        }
+        let txid = tx.txid();
+        self.txs.borrow_mut().insert(txid, tx);
+        Ok(txid)
+    }
+}
+
+#[derive(Default)]
+struct Signer {
+    calls: AtomicUsize,
+    corrupt_on: Option<usize>,
+}
+
+impl CTVEmulator for Signer {
+    fn get_signer_for(&self, _: sha256::Hash) -> Result<Clause, EmulatorError> {
+        unreachable!("binding does not compile signer policies")
+    }
+
+    fn sign(&self, mut psbt: Psbt) -> Result<Psbt, EmulatorError> {
+        let call = self.calls.fetch_add(1, Ordering::SeqCst) + 1;
+        if self.corrupt_on == Some(call) {
+            psbt.inputs[0].witness_utxo.as_mut().unwrap().value += 1;
+        }
+        Ok(psbt)
+    }
+}
+
+fn psbt(program: &Program, object: &Compiled) -> Psbt {
+    let SapioStudioFormat::LinkedPSBT { psbt, .. } =
+        &program.program.get(&object.root_path).unwrap().txs[0];
+    bitcoin::consensus::deserialize(&base64::decode(psbt).unwrap()).unwrap()
+}
+
+#[test]
+fn authenticates_funding_transactions_and_propagates_lookup_errors() {
+    let object = payment(leaf(), false, 100, "payment");
+    for case in 0..3 {
+        let tx = funding(&object, 1_100);
+        let mut out = OutPoint::new(tx.txid(), 0);
+        let index = Index::with(tx.clone());
+        match case {
+            0 => {
+                let mut wrong = tx;
+                wrong.output[0].value += 1;
+                index.txs.borrow_mut().insert(out.txid, Arc::new(wrong));
+            }
+            1 => out.vout = 1,
+            2 => index.fail_lookup.set(true),
+            _ => unreachable!(),
+        }
+        let signer = Signer::default();
+        assert!(
+            object
+                .bind_psbt(out, BTreeMap::new(), index.clone(), &signer)
+                .is_err(),
+            "case {case}"
+        );
+        assert_eq!(signer.calls.load(Ordering::SeqCst), 0);
+        assert_eq!(index.writes.get(), 0);
+    }
+}
+
+#[test]
+fn unrelated_unknown_txid_is_an_error_before_signing_or_indexing() {
+    struct UnrelatedMiss(Txid);
+
+    impl TxIndex for UnrelatedMiss {
+        fn lookup_tx(&self, _: &Txid) -> Result<Arc<Transaction>, TxIndexError> {
+            Err(TxIndexError::UnknownTxid(self.0))
+        }
+
+        fn add_tx(&self, _: Arc<Transaction>) -> Result<Txid, TxIndexError> {
+            panic!("an unrelated lookup miss must stop before index writes")
+        }
+    }
+
+    let object = payment(leaf(), false, 100, "payment");
+    let requested = funding(&object, 1_100).txid();
+    let unrelated = funding(&object, 1_101).txid();
+    assert_ne!(requested, unrelated);
+    let signer = Signer::default();
+    let result = object.bind_psbt(
+        OutPoint::new(requested, 0),
+        BTreeMap::new(),
+        Rc::new(UnrelatedMiss(unrelated)),
+        &signer,
+    );
+    assert!(matches!(
+        result,
+        Err(ObjectError::TxIndex(TxIndexError::UnknownTxid(txid))) if txid == unrelated
+    ));
+    assert_eq!(signer.calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn authenticates_known_funding_without_calling_output_lookup_overrides() {
+    struct OutputOverride(Rc<Index>);
+
+    impl TxIndex for OutputOverride {
+        fn lookup_tx(&self, txid: &Txid) -> Result<Arc<Transaction>, TxIndexError> {
+            self.0.lookup_tx(txid)
+        }
+
+        fn lookup_output(&self, _: &OutPoint) -> Result<TxOut, TxIndexError> {
+            panic!("binding must authenticate whole previous transactions")
+        }
+
+        fn add_tx(&self, tx: Arc<Transaction>) -> Result<Txid, TxIndexError> {
+            self.0.add_tx(tx)
+        }
+    }
+
+    let object = payment(leaf(), false, 100, "payment");
+    let tx = funding(&object, 1_100);
+    let out = OutPoint::new(tx.txid(), 0);
+    let program = object
+        .bind_psbt(
+            out,
+            BTreeMap::new(),
+            Rc::new(OutputOverride(Index::with(tx.clone()))),
+            &CTVAvailable,
+        )
+        .unwrap();
+    let bound = psbt(&program, &object);
+    assert_eq!(bound.unsigned_tx.input[0].previous_output, out);
+    assert_eq!(bound.inputs[0].non_witness_utxo, Some(tx.clone()));
+    assert_eq!(bound.inputs[0].witness_utxo, Some(tx.output[0].clone()));
+}
+
+#[test]
+fn checks_contract_script_and_reserved_fees_before_signing() {
+    let object = payment(leaf(), false, 100, "payment");
+    for wrong_script in [false, true] {
+        let mut tx = funding(&object, if wrong_script { 1_100 } else { 1_099 });
+        if wrong_script {
+            tx.output[0].script_pubkey = Script::new();
+        }
+        let out = OutPoint::new(tx.txid(), 0);
+        let index = Index::with(tx);
+        let signer = Signer::default();
+        assert!(object
+            .bind_psbt(out, BTreeMap::new(), index.clone(), &signer)
+            .is_err());
+        assert_eq!(signer.calls.load(Ordering::SeqCst), 0);
+        assert_eq!(index.writes.get(), 0);
+    }
+}
+
+#[test]
+fn authenticates_every_known_prevout_and_accepts_excess_funding() {
+    let object = payment(leaf(), false, 100, "payment");
+    let tx = funding(&object, 1_200);
+    let out = OutPoint::new(tx.txid(), 0);
+    let program = object
+        .bind_psbt(out, BTreeMap::new(), Index::with(tx.clone()), &CTVAvailable)
+        .unwrap();
+    let bound = psbt(&program, &object);
+    assert_eq!(bound.inputs[0].non_witness_utxo, Some(tx.clone()));
+    assert_eq!(bound.inputs[0].witness_utxo, Some(tx.output[0].clone()));
+    assert_eq!(bound.unsigned_tx.input[0].previous_output, out);
+    assert_eq!(bound.unsigned_tx.output[0].value, 1_000);
+}
+
+#[test]
+fn sums_auxiliary_funding_and_rejects_duplicates_and_overflow() {
+    let object = payment(leaf(), true, 100, "payment");
+    let hash = *object.ctv_to_tx.keys().next().unwrap();
+    for (root_value, auxiliary_value, duplicate, valid) in [
+        (400, 700, false, true),
+        (400, 699, false, false),
+        (1_100, 1_100, true, false),
+        (u64::MAX, 1, false, false),
+    ] {
+        let tx = funding(&object, root_value);
+        let out = OutPoint::new(tx.txid(), 0);
+        let index = Index::with(tx);
+        let auxiliary = funding(&leaf(), auxiliary_value);
+        let auxiliary_out = OutPoint::new(auxiliary.txid(), 0);
+        index
+            .txs
+            .borrow_mut()
+            .insert(auxiliary.txid(), Arc::new(auxiliary));
+        let mapping = BTreeMap::from([(
+            hash,
+            vec![None, Some(if duplicate { out } else { auxiliary_out })],
+        )]);
+        let signer = Signer::default();
+        let result = object.bind_psbt(out, mapping, index.clone(), &signer);
+        assert_eq!(
+            result.is_ok(),
+            valid,
+            "{root_value} + {auxiliary_value}, duplicate {duplicate}"
+        );
+        if valid {
+            let bound = psbt(&result.unwrap(), &object);
+            assert_eq!(
+                bound.inputs[1].witness_utxo.as_ref().unwrap().value,
+                auxiliary_value
+            );
+            assert_eq!(
+                bound.inputs[1].non_witness_utxo.as_ref().unwrap().txid(),
+                auxiliary_out.txid
+            );
+        } else {
+            assert_eq!(signer.calls.load(Ordering::SeqCst), 0);
+            assert_eq!(index.writes.get(), 0);
+        }
+    }
+}
+
+#[test]
+fn unresolved_inputs_remain_unsigned_and_do_not_collide_with_contract_input() {
+    let object = payment(leaf(), true, 100, "payment");
+    let out = OutPoint::new(Txid::from_slice(&[0; 32]).unwrap(), 0);
+    let program = object
+        .bind_psbt(
+            out,
+            BTreeMap::new(),
+            Rc::new(Index::default()),
+            &CTVAvailable,
+        )
+        .unwrap();
+    let bound = psbt(&program, &object);
+    assert_ne!(
+        bound.unsigned_tx.input[0].previous_output,
+        bound.unsigned_tx.input[1].previous_output
+    );
+    assert!(bound
+        .inputs
+        .iter()
+        .all(|input| input.witness_utxo.is_none() && input.non_witness_utxo.is_none()));
+}
+
+#[test]
+fn rejects_underfunded_descendants_before_any_signing_or_index_writes() {
+    let child = payment(leaf(), false, 100, "child");
+    let object = payment(child, false, 0, "parent");
+    let tx = funding(&object, 1_000);
+    let out = OutPoint::new(tx.txid(), 0);
+    let index = Index::with(tx);
+    let signer = Signer::default();
+    assert!(object
+        .bind_psbt(out, BTreeMap::new(), index.clone(), &signer)
+        .is_err());
+    assert_eq!(signer.calls.load(Ordering::SeqCst), 0);
+    assert_eq!(index.writes.get(), 0);
+}
+
+#[test]
+fn validates_all_signer_responses_before_indexing_the_graph() {
+    let child = payment(leaf(), false, 0, "child");
+    let object = payment(child, false, 0, "parent");
+    for corrupt_on in [1, 2] {
+        let tx = funding(&object, 1_000);
+        let out = OutPoint::new(tx.txid(), 0);
+        let index = Index::with(tx);
+        let signer = Signer {
+            corrupt_on: Some(corrupt_on),
+            ..Default::default()
+        };
+        assert!(object
+            .bind_psbt(out, BTreeMap::new(), index.clone(), &signer)
+            .is_err());
+        assert_eq!(signer.calls.load(Ordering::SeqCst), corrupt_on);
+        assert_eq!(index.writes.get(), 0);
+    }
+}
+
+#[test]
+fn rejects_incorrect_index_acknowledgements() {
+    let object = payment(leaf(), false, 0, "payment");
+    let tx = funding(&object, 1_000);
+    let out = OutPoint::new(tx.txid(), 0);
+    let index = Index::with(tx);
+    index.wrong_ack.set(true);
+    assert!(object
+        .bind_psbt(out, BTreeMap::new(), index.clone(), &CTVAvailable)
+        .is_err());
+    assert_eq!(index.writes.get(), 1);
+}

--- a/sapio/tests/graph_binding.rs
+++ b/sapio/tests/graph_binding.rs
@@ -1,0 +1,147 @@
+use bitcoin::consensus::deserialize;
+use bitcoin::psbt::PartiallySignedTransaction as Psbt;
+use bitcoin::{Address, Amount, Network, OutPoint};
+use sapio::contract::abi::continuation::ContinuationPoint;
+use sapio::contract::abi::studio::{Program, SapioStudioFormat};
+use sapio::contract::{Compilable, Compiled, Context, Contract};
+use sapio::{declare, then};
+use sapio_base::serialization_helpers::SArc;
+use sapio_base::txindex::TxIndexLogger;
+use sapio_ctv_emulator_trait::CTVAvailable;
+use std::collections::{BTreeMap, BTreeSet};
+use std::rc::Rc;
+use std::str::FromStr;
+use std::sync::Arc;
+
+struct Payment(Vec<Compiled>);
+
+impl Payment {
+    #[then]
+    fn pay(self, ctx: Context) {
+        let mut builder = ctx.template();
+        for destination in &self.0 {
+            builder = builder.add_output(Amount::from_sat(1_000), destination, None)?;
+        }
+        builder.into()
+    }
+}
+
+impl Contract for Payment {
+    declare! {then, Self::pay}
+    declare! {non updatable}
+}
+
+fn payment(destinations: Vec<Compiled>, path: &str) -> Compiled {
+    let amount = Amount::from_sat(1_000 * destinations.len() as u64);
+    Payment(destinations)
+        .compile(Context::new(
+            Network::Regtest,
+            amount,
+            Arc::new(CTVAvailable),
+            path.try_into().unwrap(),
+            Arc::new(Default::default()),
+            None,
+        ))
+        .unwrap()
+}
+
+fn leaf(label: &str) -> Compiled {
+    let mut object = Compiled::from_address(
+        Address::from_str("bcrt1qumrrqgt7e3a7damzm8x97m6sjs20u8hjw2hcjj").unwrap(),
+        None,
+    );
+    object.metadata.extra.insert("label".into(), label.into());
+    object
+}
+
+fn bind(object: &Compiled) -> Program {
+    object
+        .bind_psbt(
+            OutPoint::default(),
+            BTreeMap::new(),
+            Rc::new(TxIndexLogger::new()),
+            &CTVAvailable,
+        )
+        .unwrap()
+}
+
+fn psbt(format: &SapioStudioFormat) -> Psbt {
+    let SapioStudioFormat::LinkedPSBT { psbt, .. } = format;
+    deserialize(&base64::decode(psbt).unwrap()).unwrap()
+}
+
+#[test]
+fn reused_leaf_paths_preserve_every_output_and_its_metadata() {
+    let object = payment(vec![leaf("alice"), leaf("bob")], "payment");
+    let program = bind(&object);
+    assert_eq!(program.program.len(), 3);
+    let root = program.program.get(&object.root_path).unwrap();
+    let tx = psbt(&root.txs[0]).unsigned_tx;
+    for (vout, label) in [(0, "alice"), (1, "bob")] {
+        let child = program
+            .program
+            .values()
+            .find(|node| node.out == OutPoint::new(tx.txid(), vout))
+            .unwrap();
+        assert!(child.txs.is_empty());
+        assert_eq!(child.metadata.extra["label"], label);
+    }
+    assert_eq!(
+        serde_json::to_value(bind(&object)).unwrap(),
+        serde_json::to_value(&program).unwrap()
+    );
+    let roundtrip: Program =
+        serde_json::from_value(serde_json::to_value(&program).unwrap()).unwrap();
+    assert_eq!(
+        serde_json::to_value(roundtrip).unwrap(),
+        serde_json::to_value(&program).unwrap()
+    );
+}
+
+#[test]
+fn reused_contract_paths_preserve_both_bound_spending_branches() {
+    let mut child = payment(vec![leaf("destination")], "reused");
+    let continuation: Arc<sapio_base::effects::EffectPath> =
+        Arc::new("reused/continue".try_into().unwrap());
+    child.continue_apis.insert(
+        SArc(continuation.clone()),
+        ContinuationPoint::at(None, continuation),
+    );
+    let object = payment(vec![child.clone(), child.clone()], "parent");
+    let program = bind(&object);
+    assert_eq!(program.program.len(), 5);
+    let parent = psbt(&program.program.get(&object.root_path).unwrap().txs[0]).unsigned_tx;
+    let mut spent = BTreeSet::new();
+    for node in program
+        .program
+        .values()
+        .filter(|node| node.out.txid == parent.txid())
+    {
+        assert_eq!(node.txs.len(), 1);
+        assert_eq!(node.source_path.as_ref(), Some(&child.root_path));
+        assert_eq!(node.continue_apis, child.continue_apis);
+        let bound = psbt(&node.txs[0]);
+        assert_eq!(bound.unsigned_tx.input[0].previous_output, node.out);
+        assert_eq!(bound.inputs[0].non_witness_utxo, Some(parent.clone()));
+        spent.insert(node.out.vout);
+    }
+    assert_eq!(spent, BTreeSet::from([0, 1]));
+}
+
+#[test]
+fn suggested_and_enforced_transitions_have_distinct_binding_paths() {
+    let mut object = payment(vec![leaf("destination")], "parent");
+    object.suggested_txs = object.ctv_to_tx.clone();
+    let program = bind(&object);
+    assert_eq!(program.program.len(), 3);
+    let root = program.program.get(&object.root_path).unwrap();
+    assert_eq!(root.txs.len(), 2);
+    let leaves: Vec<_> = program
+        .program
+        .iter()
+        .filter(|(_, node)| node.txs.is_empty())
+        .collect();
+    assert_eq!(leaves.len(), 2);
+    assert_eq!(leaves[0].1.out, leaves[1].1.out);
+    assert_ne!(leaves[0].0, leaves[1].0);
+}


### PR DESCRIPTION
Binding could accept the wrong funding transaction, hide lookup failures, trust modified signer responses, and overwrite reused contract outputs. This PR checks funding throughout the graph before signing, enforces complete PSBT responses with signature additions only, and preserves every bound occurrence.

- Authenticate transaction-index lookups and acknowledgements; propagate operational errors and forward changed witnesses through caches.
- Validate known contract scripts, distinct inputs, checked amounts and reserved fees. Retain authenticated previous transactions in PSBTs and keep unresolved offline inputs explicit.
- Check raw HD replies and each federation participant; validate all binding responses before inserting generated transactions.
- Preserve wallet/supplied funding PSBT metadata and signatures, including finalized legacy funding. Reject malformed/trailing PSBT input and select funding outputs by script.
- Derive child program keys from parent/transition/template/output identities. Keep original compilation paths in `source_path`, and place synthetic funding at `<root>/@funding`.

The child-key and complete-response contracts are deliberate API changes. [Binding documentation](https://github.com/JeremyRubin/sapio/blob/d8b35288d6496bfebefdedb6fafa7ce23ff7e91a/docs/BINDING.md) describes migration, cache/write behavior, and limits around chain state, unresolved inputs and legacy transaction-ID changes.

Validation: 95 native tests pass (43 new regression tests), with eight existing ignored doctests; formatting, feature checks, Clippy and API documentation pass. All four inscription-plugin tests, every WASM example build, and direct/cross-module/inscription CLI compilation plus mock binding pass. Includes real TCP adversarial signer responses and two-step signing/finalization. The main funding, cache, CLI and graph defects were reproduced before fixing.

Based directly on merged `master` at b72f2b5 (PR #278), in six independently reviewable commits.
