### PR TITLE
Bound WASM execution and replace native module caches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2170,6 +2170,8 @@ dependencies = [
  "tokio",
  "wasmer",
  "wasmer-cache",
+ "wasmer-middlewares",
+ "wasmer-types",
 ]
 
 [[package]]
@@ -2886,6 +2888,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "wasmer-middlewares"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fdc1455c09a2b8e3aae9df8e163430d87353a2b467a3c48ceeb3e3bbeeed69"
+dependencies = [
+ "wasmer",
+ "wasmer-types",
+ "wasmer-vm",
 ]
 
 [[package]]

--- a/contrib/check_wasm.py
+++ b/contrib/check_wasm.py
@@ -6,11 +6,15 @@ from pathlib import Path
 import subprocess
 import sys
 import tempfile
+import time
 
 ROOT = Path(__file__).resolve().parent.parent
 cli = Path(sys.argv[1]).resolve()
 modules = Path(sys.argv[2]).resolve()
 vectors = ROOT / "contrib" / "vectors"
+# Cross-module calls compile several Rust modules from authenticated source.
+# This bounds the whole CLI request, including native compilation outside fuel.
+REQUEST_TIMEOUT_SECONDS = 180
 
 with tempfile.TemporaryDirectory(prefix="sapio-wasm-") as workspace:
     def request(command, module=None, parameters=None, extra_args=()):
@@ -19,11 +23,14 @@ with tempfile.TemporaryDirectory(prefix="sapio-wasm-") as workspace:
         if module is not None:
             args.extend(["--workspace", workspace, "--file", str(modules / module)])
         args.extend(extra_args)
+        started = time.monotonic()
         result = subprocess.run(
             args,
             input=json.dumps(parameters) if parameters is not None else "",
-            text=True, capture_output=True, check=True, timeout=60,
+            text=True, capture_output=True, check=True, timeout=REQUEST_TIMEOUT_SECONDS,
         )
+        print(f"WASM {command} {module or ''}: {time.monotonic() - started:.2f}s",
+              file=sys.stderr)
         response = json.loads(result.stdout)["result"]
         if "Err" in response:
             raise RuntimeError(response["Err"])

--- a/docs/CTV_FORK_AUDIT.md
+++ b/docs/CTV_FORK_AUDIT.md
@@ -114,10 +114,13 @@ returned errors and preserve the remaining partial PSBT.
 
 The fork verifies scripts against supplied prevouts. It does not authenticate
 funding UTXO identity or reconcile conflicting witness/non-witness UTXO records.
-Funding identity and emulator-response validation remain Sapio boundary work.
-Backend capability checks and execution against a node implementing the intended
-CTV semantics remain release requirements. Guest execution, aggregate memory,
-nested-call limits and native compiled-cache trust remain hosting requirements.
+Sapio's binder now authenticates known funding transactions and checks emulator
+responses, including responses returned to WASM guests; callers outside those
+boundaries must establish the same invariants. Backend capability checks and
+execution against a node implementing the intended CTV semantics remain release
+requirements. The [host limits](DEVELOPMENT.md) cover guest fuel, accessible
+memory, tables, nested calls and source-cache integrity. Process memory, native
+compilation and external service deadlines remain hosting requirements.
 
 [fork]: https://github.com/sapio-lang/rust-miniscript
 [psbt]: https://github.com/sapio-lang/rust-miniscript/blob/04b69f69459fe3b043ca61fb649cf546d5a241b6/src/psbt/mod.rs

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -54,7 +54,9 @@ bash contrib/sapio_wasm.sh
 
 This requires Python 3. The smoke test uses a temporary module cache and compares
 parsed JSON with checked-in expected results. It fails on CLI errors, malformed
-output, or a changed contract result. No jq or global module-cache setup is needed.
+output, or a changed contract result. Each CLI request has a 180-second wall-clock
+allowance, including native compilation of nested modules, and reports its
+duration. No jq or global module-cache setup is needed.
 The scripts use Cargo's default target directories. The WASM script also runs
 the inscription plugin's native artifact/signing tests and compiles a 521-byte
 inscription through the real guest ABI. See [inscription validation](INSCRIPTIONS.md).

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -119,14 +119,50 @@ mutable global function pointers.
 Diagnostic logs go to stderr. Emulator protocol JSON frames are bounded to one
 million bytes, and failed connections are discarded before another request.
 
-These checks do not establish a complete sandbox: execution metering, aggregate
-memory limits, nested-call limits, and compiled-cache trust still need work.
-Use modules and module caches you trust. The runtime uses native compiled
-artifacts internally; a hash-shaped filename is not a trust boundary.
+The host uses Wasmer 6.1 with these fixed execution limits:
 
-The host uses Wasmer 6.1 for compatibility with current Rust on x86 Linux.
-Compiled module caches are runtime-specific. After upgrading from Wasmer 4,
-reload the original `.wasm` files before referring to their cached keys:
+| Resource | Limit |
+| --- | --- |
+| Binary module source, including debug information | 128 MiB |
+| Accessible linear memory per instance | One memory, at most 64 MiB |
+| Table per instance | One table, at most 65,536 elements |
+| Execution fuel per instance | 100,000,000 points across its entire lifetime |
+| Nested module depth | Eight levels below the top-level instance |
+| Child module attempts | 64 across the top-level handle and all descendants |
+
+Fuel is installed before instantiation: WASM start functions, plugin
+initialization, allocation, metadata and contract calls all consume the same
+allowance. Each operator costs one point, accounted at block boundaries. Bulk
+memory operations additionally cost one point per byte; memory growth costs
+65,536 points per requested page. Bulk table operations and table growth cost
+16 points per requested element. An exhausted allowance traps execution. Threads
+are disabled so atomic waits cannot block outside the fuel accounting.
+Declared memory/table maxima below the host caps remain in effect.
+
+Nested calls reserve an attempt before loading a module, including failed
+lookups. Dropping a child does not restore attempts. A new top-level handle or
+`fresh_clone()` receives independent fuel, memory and nested-call allowances;
+ordinary calls on an existing handle do not reset them. Allocating host callbacks
+cannot recursively reenter the guest allocator. The WASM signing import accepts
+only checked signature additions, just like native signing.
+
+These are guest execution limits, not a wall-clock deadline or a process memory
+limit. Native compilation, host serialization/schema work and emulator I/O are
+outside instruction metering. Wasmer may reserve substantially more virtual
+address space than the accessible linear-memory limit. Evaluate those costs
+before exposing compilation as a service.
+
+The cache stores binary WASM sources at `CACHE/sources/HASH.wasm` (the CLI uses
+`WORKSPACE/modules/sources/HASH.wasm`), verifies their
+size and content hash, and recompiles with the current host engine on every
+load. It never deserializes cached native executables. Recompilation costs more
+than loading a native artifact. The host skips Cranelift optimization passes
+to reduce compilation latency for short-lived instances. `fresh_clone()` reuses already compiled code
+while creating a separate instance. Cache corruption and I/O failures propagate
+as errors.
+
+Legacy executable caches are ignored. Reload the original `.wasm` files before
+referring to their cached keys; the content hashes remain unchanged:
 
 ```sh
 sapio-cli contract load --workspace PATH --file MODULE.wasm

--- a/docs/MODERNIZATION.md
+++ b/docs/MODERNIZATION.md
@@ -58,8 +58,10 @@ with upstream crates would remove semantics, not complete a migration.
 | Fees | Enforce the strongest requested minimum in virtual bytes against that template's reserved fees; reject overflow and unknown extra-input weights |
 | Ordinal allocation | Preserve allocated/remaining range prefixes and suffixes; reject malformed and insufficient ranges |
 | WASM host | Bound ABI messages, validate every memory read/write, bound string scans, propagate errors, and test hostile guests through Wasmer; register guest callbacks once with `OnceLock` |
+| WASM execution | Meter start and every guest call, charge variable-size memory/table operations, cap accessible memory and tables, disable threads, and bound nested module attempts/depth and allocator reentry |
+| WASM source cache | Limit binary sources to 128 MiB, authenticate content hashes, recompile with the current engine, preserve corruption/I/O errors and ignore legacy native caches |
 | Emulator protocol | Bound both directions of framed JSON, discard failed streams, reject malformed PSBT maps, support prebound listeners |
-| Emulator responses | Accept complete PSBT responses containing only signature additions; preserve existing signatures and every other field, including raw HD responses and each federation participant |
+| Emulator responses | Accept complete PSBT responses containing only signature additions; preserve existing signatures and every other field, including raw HD responses, each federation participant and the WASM signing import |
 | Integration | Restore the suite to the workspace; compile, sign and finalize two contract steps and reject a modified output |
 | Developer checks | Formatting, real feature checks, native tests, all WASM example builds, CLI smoke checks, and API documentation |
 
@@ -148,14 +150,16 @@ This is the next release blocker, before a broad dependency migration.
   versioned interfaces and validate actual calls on both sides. Use an offline
   validator that works in standalone WASM without browser imports; bound schema
   work and reject unresolved references.
-- Meter guest execution, total guest memory and cross-module depth. Bound cache
-  input sizes and document/validate native compiled-artifact trust. A limit on
-  one JSON transfer does not bound an entire compilation.
+- Extend the [guest execution limits](DEVELOPMENT.md) with service-level
+  compilation deadlines, process memory and concurrency policy. Guest fuel,
+  memory/table caps, nested-call bounds and authenticated source caching are
+  enforced; native compilation, schema work and emulator I/O still need their
+  own bounds. Benchmark real contracts before changing the fixed allowances.
 - Review emulator request timeouts, concurrency, authentication and authorization.
   A signature service reachable over TCP is not automatically a safe oracle.
 
-Acceptance: malformed inputs fail with attributable errors; adversarial modules
-terminate within configured limits; the hash, script, signing and finalization
+Acceptance: malformed inputs fail with attributable errors; adversarial guest execution
+traps at the documented bounds; the hash, script, signing and finalization
 layers agree on the supported transaction domain.
 
 ### 2. Modernize dependencies in semantic groups

--- a/docs/learn-sapio/src/ch06-01-wasm.md
+++ b/docs/learn-sapio/src/ch06-01-wasm.md
@@ -9,9 +9,11 @@ So what's it doing in Sapio?
 
 WASM is designed to be cross platform and deterministic, which makes it a
 great target for smart contracts that we want to be able to be reproduced
-locally. It also makes it *relatively* safe to run smart contracts provided
-by untrusted parties as the security of the WASM sandbox prevents bad code from
-harming or infecting our system.
+locally. Sapio validates guest memory access and applies execution fuel,
+memory/table caps and nested-call limits before running a module. These bounds
+cover guest execution; native compilation and external services need their own
+resource policy. Loading a module is not a guarantee that its contract is safe
+or that its intended covenant is enforced on the selected chain.
 
 Sapio Contract objects can be built into  WASM binaries very easily. The code required is basically:
 

--- a/plugins/Cargo.toml
+++ b/plugins/Cargo.toml
@@ -13,7 +13,7 @@ description = "Libarary for building client/host sapio plugin bindings"
 
 [features]
 default = ["client"]
-host = ["wasmer", "wasmer-cache", "tokio"]
+host = ["wasmer", "wasmer-cache", "wasmer-middlewares", "wasmer-types", "tokio"]
 client = []
 
 [dependencies]
@@ -34,6 +34,14 @@ optional = true
 
 [dependencies.wasmer-cache]
 version = "6.1.0"
+optional = true
+
+[dependencies.wasmer-middlewares]
+version = "=6.1.0"
+optional = true
+
+[dependencies.wasmer-types]
+version = "=6.1.0"
 optional = true
 
 [dependencies.tokio]

--- a/plugins/src/host/invocation.rs
+++ b/plugins/src/host/invocation.rs
@@ -1,0 +1,87 @@
+//! Shared limits for the descendants of one top-level plugin handle.
+
+use super::memory::runtime_error;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use wasmer::RuntimeError;
+
+/// Maximum nesting below the top-level plugin instance.
+pub(crate) const MAX_DEPTH: usize = 8;
+/// Maximum child-module attempts across the complete invocation tree.
+pub(crate) const MAX_MODULE_CALLS: usize = 64;
+
+/// A depth bound and a shared, nonrenewable child-module allowance.
+#[derive(Clone, Debug)]
+pub(crate) struct InvocationBudget {
+    depth: usize,
+    remaining: Arc<AtomicUsize>,
+}
+
+impl InvocationBudget {
+    /// Start the independent invocation tree of a top-level handle.
+    pub(crate) fn new() -> Self {
+        Self {
+            depth: 0,
+            remaining: Arc::new(AtomicUsize::new(MAX_MODULE_CALLS)),
+        }
+    }
+
+    /// Reserve an attempt before loading or constructing a child module.
+    /// Failed calls and dropped children never restore the shared allowance.
+    pub(crate) fn child(&self) -> Result<Self, RuntimeError> {
+        self.remaining
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .map_err(|_| runtime_error("WASM nested module call limit exceeded"))?;
+        if self.depth >= MAX_DEPTH {
+            return Err(runtime_error("WASM module invocation depth limit exceeded"));
+        }
+        Ok(Self {
+            depth: self.depth + 1,
+            remaining: Arc::clone(&self.remaining),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nesting_is_bounded_and_failed_attempts_are_not_refunded() {
+        let root = InvocationBudget::new();
+        let mut nested = root.clone();
+        for _ in 0..MAX_DEPTH {
+            nested = nested.child().unwrap();
+        }
+        assert!(nested
+            .child()
+            .unwrap_err()
+            .to_string()
+            .contains("depth limit"));
+        drop(nested);
+        for _ in 0..MAX_MODULE_CALLS - MAX_DEPTH - 1 {
+            root.child().unwrap();
+        }
+        assert!(root.child().unwrap_err().to_string().contains("call limit"));
+    }
+
+    #[test]
+    fn siblings_and_their_descendants_share_one_allowance() {
+        let root = InvocationBudget::new();
+        let left = root.child().unwrap();
+        let right = root.child().unwrap();
+        for _ in 0..MAX_MODULE_CALLS - 2 {
+            left.child().unwrap();
+        }
+        for exhausted in [&root, &left, &right] {
+            assert!(exhausted
+                .child()
+                .unwrap_err()
+                .to_string()
+                .contains("call limit"));
+        }
+        assert!(InvocationBudget::new().child().is_ok());
+    }
+}

--- a/plugins/src/host/mod.rs
+++ b/plugins/src/host/mod.rs
@@ -23,6 +23,7 @@ use wasmer::*;
 mod invocation;
 mod memory;
 pub mod plugin_handle;
+mod runtime;
 pub mod wasm_cache;
 
 #[cfg(test)]

--- a/plugins/src/host/mod.rs
+++ b/plugins/src/host/mod.rs
@@ -12,21 +12,30 @@ use bitcoin::hashes::Hash;
 use bitcoin::util::psbt::PartiallySignedTransaction;
 pub use plugin_handle::WasmPluginHandle;
 use sapio_base::plugin_args::CreateArgs;
-use sapio_ctv_emulator_trait::CTVEmulator;
+use sapio_ctv_emulator_trait::{sign_checked, CTVEmulator};
 use std::collections::BTreeMap;
 use std::io::Write;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use wasmer::*;
 
+mod invocation;
 mod memory;
 pub mod plugin_handle;
 pub mod wasm_cache;
+
+#[cfg(test)]
+mod tests;
 
 /// The state that host-side functions need to be able to use
 /// Also handles the imports of plugin-side functions
 #[derive(Clone)]
 pub struct HostEnvironmentInner {
+    /// Shared allowance for this instance's nested module calls.
+    pub(crate) invocation_budget: invocation::InvocationBudget,
+    /// Prevent recursive host callbacks from reentering the guest allocator.
+    pub(crate) allocator_active: Arc<AtomicBool>,
     /// the module file path
     pub path: PathBuf,
     /// the currently running module's hash
@@ -87,11 +96,16 @@ mod exports {
         value: &str,
     ) -> Result<i32, RuntimeError> {
         memory::check_length(value.len().saturating_add(1))?;
-        let ptr = env
+        let allocate = env
             .sapio_v1_wasm_plugin_client_allocate_bytes
             .as_ref()
-            .ok_or_else(|| runtime_error("WASM guest allocator is not initialized"))?
-            .call(store, value.len() as i32)?;
+            .ok_or_else(|| runtime_error("WASM guest allocator is not initialized"))?;
+        if env.allocator_active.swap(true, Ordering::Relaxed) {
+            return Err(runtime_error("WASM guest allocator reentry is not allowed"));
+        }
+        let allocation = allocate.call(store, value.len() as i32);
+        env.allocator_active.store(false, Ordering::Relaxed);
+        let ptr = allocation?;
         memory::write_string(&guest_memory(env, store)?, ptr, value)?;
         Ok(ptr)
     }
@@ -199,15 +213,17 @@ mod exports {
         } else {
             None
         };
+        let budget = env.invocation_budget.child()?;
         // Ordinary module errors retain the v1 Result JSON representation.
         // Invalid memory and malformed inputs trap before loading another module.
         let result = (|| -> Result<serde_json::Value, String> {
-            let mut plugin = WasmPluginHandle::<serde_json::Value>::new(
+            let mut plugin = WasmPluginHandle::<serde_json::Value>::new_with_budget(
                 env.path.clone(),
                 &env.emulator,
                 SyncModuleLocator::Key(wasmer_cache::Hash::new(key_bytes)),
                 env.net,
                 Some(env.module_map.clone()),
+                budget,
             )
             .map_err(|error| error.to_string())?;
             match action {
@@ -275,7 +291,7 @@ mod exports {
         let bytes = read_buffer(&guest_memory(env, &store)?, psbt, len as usize)?;
         let psbt: PartiallySignedTransaction =
             serde_json::from_slice(&bytes).map_err(runtime_error)?;
-        let signed = env.emulator.sign(psbt).map_err(runtime_error)?;
+        let signed = sign_checked(env.emulator.as_ref(), psbt).map_err(runtime_error)?;
         let value = serde_json::to_string(&signed).map_err(runtime_error)?;
         return_string(env, &mut store, &value)
     }

--- a/plugins/src/host/plugin_handle/wasm.rs
+++ b/plugins/src/host/plugin_handle/wasm.rs
@@ -341,20 +341,12 @@ fn load_module_from_cache<I: Into<PathBuf> + Clone>(
     path: &I,
     store: &Store,
 ) -> Result<(Module, WASMCacheID), Box<dyn Error>> {
-    let (module, key) = match module_locator {
+    match module_locator {
         SyncModuleLocator::Bytes(wasm_bytes) => {
-            match wasm_cache::load_module(path.clone(), store, &wasm_bytes[..]) {
-                Ok(module) => module,
-                Err(_) => {
-                    let module = Module::new(&store, &wasm_bytes)?;
-                    let key = wasm_cache::store_module(path.clone(), &module, &wasm_bytes)?;
-                    (module, key)
-                }
-            }
+            wasm_cache::load_module(path.clone(), store, &wasm_bytes)
         }
-        SyncModuleLocator::Key(key) => wasm_cache::load_module_key(path.clone(), store, key)?,
-    };
-    Ok((module, key))
+        SyncModuleLocator::Key(key) => wasm_cache::load_module_key(path.clone(), store, key),
+    }
 }
 
 impl<GOutput> PluginHandle for WasmPluginHandle<GOutput>

--- a/plugins/src/host/plugin_handle/wasm.rs
+++ b/plugins/src/host/plugin_handle/wasm.rs
@@ -6,6 +6,7 @@
 
 //!  a plugin handle for a wasm plugin.
 use super::*;
+use crate::host::invocation::InvocationBudget;
 use crate::host::memory::{self, runtime_error};
 use crate::host::wasm_cache::get_all_keys_from_fs;
 use crate::host::HostEnvironmentInner;
@@ -20,6 +21,7 @@ use serde::{Deserialize, Serialize};
 use std::error::Error;
 use std::marker::PhantomData;
 use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
 use wasmer::{FunctionEnv, TypedFunction};
 
 /// Helper to resolve modules
@@ -96,6 +98,7 @@ impl<T> WasmPluginHandle<T> {
             &env.emulator,
             self.module.clone(),
             self.key,
+            InvocationBudget::new(),
         )?)
     }
 }
@@ -152,13 +155,41 @@ impl<Output> WasmPluginHandle<Output> {
         net: bitcoin::Network,
         plugin_map: Option<BTreeMap<Vec<u8>, [u8; 32]>>,
     ) -> Result<Self, Box<dyn Error>> {
+        Self::new_with_budget(
+            path,
+            emulator,
+            module_locator,
+            net,
+            plugin_map,
+            InvocationBudget::new(),
+        )
+    }
+
+    pub(in crate::host) fn new_with_budget<I: Into<PathBuf> + Clone>(
+        path: I,
+        emulator: &Arc<dyn CTVEmulator>,
+        module_locator: SyncModuleLocator,
+        net: bitcoin::Network,
+        plugin_map: Option<BTreeMap<Vec<u8>, [u8; 32]>>,
+        invocation_budget: InvocationBudget,
+    ) -> Result<Self, Box<dyn Error>> {
         let store = Store::default();
 
         let (module, key) = load_module_from_cache(module_locator, &path, &store)?;
 
         let mut this = [0; 32];
         this.clone_from_slice(&hex::decode(key.to_string())?);
-        Self::setup_plugin_inner(store, path, this, plugin_map, net, emulator, module, key)
+        Self::setup_plugin_inner(
+            store,
+            path,
+            this,
+            plugin_map,
+            net,
+            emulator,
+            module,
+            key,
+            invocation_budget,
+        )
     }
 
     /// forget an allocated pointer
@@ -228,10 +259,13 @@ impl<Output> WasmPluginHandle<Output> {
         emulator: &Arc<dyn CTVEmulator>,
         module: Module,
         key: WASMCacheID,
+        invocation_budget: InvocationBudget,
     ) -> Result<Self, Box<dyn Error>> {
         let host_env = FunctionEnv::new(
             &mut store,
             HostEnvironmentInner {
+                invocation_budget,
+                allocator_active: Arc::new(AtomicBool::new(false)),
                 path: path.into(),
                 this,
                 module_map: plugin_map.unwrap_or_default(),
@@ -459,6 +493,7 @@ mod tests {
             &emulator,
             module,
             WASMCacheID::generate(source.as_bytes()),
+            InvocationBudget::new(),
         )
         .unwrap()
     }
@@ -552,6 +587,7 @@ mod tests {
             &emulator,
             module,
             WASMCacheID::generate(source.as_bytes()),
+            InvocationBudget::new(),
         );
         assert!(result.is_err());
     }

--- a/plugins/src/host/plugin_handle/wasm.rs
+++ b/plugins/src/host/plugin_handle/wasm.rs
@@ -22,6 +22,7 @@ use std::error::Error;
 use std::marker::PhantomData;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
+use tokio::io::AsyncReadExt;
 use wasmer::{FunctionEnv, TypedFunction};
 
 /// Helper to resolve modules
@@ -44,7 +45,28 @@ impl ModuleLocator {
                 let key = WASMCacheID::from_str(&k)?;
                 Ok(SyncModuleLocator::Key(key))
             }
-            ModuleLocator::FileName(f) => Ok(SyncModuleLocator::Bytes(tokio::fs::read(f).await?)),
+            ModuleLocator::FileName(f) => {
+                let limit = wasm_cache::MAX_MODULE_BYTES as u64;
+                let check_file = |metadata: std::fs::Metadata| {
+                    if !metadata.is_file() || metadata.len() > limit {
+                        Err(std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            "WASM module must be a regular file no larger than 128 MiB",
+                        ))
+                    } else {
+                        Ok(())
+                    }
+                };
+                check_file(tokio::fs::metadata(&f).await?)?;
+                let file = tokio::fs::File::open(f).await?;
+                check_file(file.metadata().await?)?;
+                let mut bytes = Vec::new();
+                file.take(limit + 1).read_to_end(&mut bytes).await?;
+                if bytes.len() > limit as usize {
+                    return Err("WASM source exceeds the module size limit".into());
+                }
+                Ok(SyncModuleLocator::Bytes(bytes))
+            }
             ModuleLocator::Bytes(b) => Ok(SyncModuleLocator::Bytes(b)),
             ModuleLocator::Unknown => Err(Err(CompilationError::UnknownModule)?),
         }
@@ -173,7 +195,7 @@ impl<Output> WasmPluginHandle<Output> {
         plugin_map: Option<BTreeMap<Vec<u8>, [u8; 32]>>,
         invocation_budget: InvocationBudget,
     ) -> Result<Self, Box<dyn Error>> {
-        let store = Store::default();
+        let store = crate::host::runtime::new_store();
 
         let (module, key) = load_module_from_cache(module_locator, &path, &store)?;
 
@@ -450,13 +472,18 @@ where
 mod tests {
     use super::*;
     use sapio_ctv_emulator_trait::CTVAvailable;
+    use wasmer_middlewares::metering::{get_remaining_points, MeteringPoints};
 
     fn plugin(
         name_body: &str,
         extra: &str,
         allocation: i32,
     ) -> WasmPluginHandle<serde_json::Value> {
-        let source = format!(
+        load_plugin(&plugin_source(name_body, extra, allocation)).unwrap()
+    }
+
+    fn plugin_source(name_body: &str, extra: &str, allocation: i32) -> String {
+        format!(
             r#"(module
                 (import "env" "sapio_v1_wasm_plugin_debug_log_string"
                     (func $log (param i32 i32)))
@@ -480,9 +507,12 @@ mod tests {
                 (func (export "sapio_v1_wasm_plugin_entry_point"))
                 {extra}
             )"#
-        );
-        let store = Store::default();
-        let module = Module::new(&store, source.as_bytes()).unwrap();
+        )
+    }
+
+    fn load_plugin(source: &str) -> Result<WasmPluginHandle<serde_json::Value>, Box<dyn Error>> {
+        let store = crate::host::runtime::new_store();
+        let module = Module::new(&store, source.as_bytes())?;
         let emulator: Arc<dyn CTVEmulator> = Arc::new(CTVAvailable);
         WasmPluginHandle::setup_plugin_inner(
             store,
@@ -495,7 +525,207 @@ mod tests {
             WASMCacheID::generate(source.as_bytes()),
             InvocationBudget::new(),
         )
-        .unwrap()
+    }
+
+    fn spinning_export(name: &str, signature: &str) -> String {
+        let export = format!("sapio_v1_wasm_plugin_{name}");
+        let mut source =
+            plugin_source("i32.const 8", "", 16).replacen(&format!("(export \"{export}\")"), "", 1);
+        let end = source.rfind(')').unwrap();
+        source.insert_str(
+            end,
+            &format!("(func (export \"{export}\") {signature} (loop br 0) unreachable)"),
+        );
+        source
+    }
+
+    #[test]
+    fn infinite_wasm_start_and_entrypoint_exhaust_fuel_before_setup_completes() {
+        let source = plugin_source(
+            "i32.const 8",
+            "(func $start (loop br 0)) (start $start)",
+            16,
+        );
+        let error = load_plugin(&source)
+            .err()
+            .expect("infinite start must trap");
+        assert!(
+            matches!(
+                error.downcast_ref::<wasmer::InstantiationError>(),
+                Some(wasmer::InstantiationError::Start(_))
+            ),
+            "{error}"
+        );
+
+        let error = load_plugin(&spinning_export("entry_point", ""))
+            .err()
+            .expect("infinite entrypoint must trap");
+        assert!(
+            error.downcast_ref::<wasmer::RuntimeError>().is_some(),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn infinite_guest_code_traps_on_every_public_call_path() {
+        let arguments = CreateArgs {
+            arguments: serde_json::Value::Null,
+            context: crate::ContextualArguments {
+                network: bitcoin::Network::Regtest,
+                amount: bitcoin::Amount::from_sat(0),
+                effects: Default::default(),
+                ordinals_info: None,
+            },
+        };
+        let path = EffectPath::try_from("metering").unwrap();
+        for (export, signature) in [
+            ("client_get_name", "(result i32)"),
+            ("client_get_logo", "(result i32)"),
+            ("client_get_create_arguments", "(result i32)"),
+            ("client_create", "(param i32 i32) (result i32)"),
+            ("client_allocate_bytes", "(param i32) (result i32)"),
+            ("client_drop_allocation", "(param i32)"),
+        ] {
+            let mut plugin = load_plugin(&spinning_export(export, signature)).unwrap();
+            let failed = match export {
+                "client_get_name" => plugin.get_name().is_err(),
+                "client_get_logo" => plugin.get_logo().is_err(),
+                "client_get_create_arguments" => plugin.get_api().is_err(),
+                "client_create" => plugin.call(&path, &arguments).is_err(),
+                "client_allocate_bytes" => plugin.pass_string("guest input").is_err(),
+                // Retrieval invokes cleanup after reading a valid result.
+                "client_drop_allocation" => plugin.get_name().is_err(),
+                _ => unreachable!(),
+            };
+            assert!(failed, "{export} must trap");
+            assert_eq!(
+                get_remaining_points(&mut plugin.store, &plugin._instance),
+                MeteringPoints::Exhausted,
+                "{export} must fail from fuel exhaustion"
+            );
+        }
+    }
+
+    struct FixtureDirectory(PathBuf);
+
+    impl FixtureDirectory {
+        fn new() -> Self {
+            use std::sync::atomic::{AtomicUsize, Ordering};
+            static NEXT: AtomicUsize = AtomicUsize::new(0);
+            let path = std::env::temp_dir().join(format!(
+                "sapio-metered-plugin-{}-{}",
+                std::process::id(),
+                NEXT.fetch_add(1, Ordering::Relaxed)
+            ));
+            std::fs::create_dir(&path).unwrap();
+            Self(path)
+        }
+    }
+
+    impl Drop for FixtureDirectory {
+        fn drop(&mut self) {
+            std::fs::remove_dir_all(&self.0).unwrap();
+        }
+    }
+
+    fn remaining_fuel(plugin: &mut WasmPluginHandle<serde_json::Value>) -> u64 {
+        match get_remaining_points(&mut plugin.store, &plugin._instance) {
+            MeteringPoints::Remaining(fuel) => fuel,
+            MeteringPoints::Exhausted => panic!("expected unspent fuel"),
+        }
+    }
+
+    fn exhaust_finite_calls(plugin: &mut WasmPluginHandle<serde_json::Value>) {
+        for _ in 0..10 {
+            let before = remaining_fuel(plugin);
+            match plugin.get_name() {
+                Ok(name) => {
+                    assert_eq!(name, "ok");
+                    assert!(remaining_fuel(plugin) < before);
+                }
+                Err(_) => {
+                    assert_eq!(
+                        get_remaining_points(&mut plugin.store, &plugin._instance),
+                        MeteringPoints::Exhausted
+                    );
+                    return;
+                }
+            }
+        }
+        panic!("finite guest calls must spend one cumulative allowance");
+    }
+
+    #[test]
+    fn cache_reload_and_fresh_clone_keep_metering_with_independent_fuel() {
+        let cache = FixtureDirectory::new();
+        // Each call terminates on its own, so a regression that replenishes
+        // fuel between exports fails an assertion instead of hanging.
+        let body = format!(
+            "(local $left i32) i32.const {} local.set $left
+             (loop local.get $left i32.const 1 i32.sub local.tee $left br_if 0)
+             i32.const 8",
+            crate::host::runtime::INSTANCE_FUEL / 20,
+        );
+        let source = plugin_source(&body, "", 16);
+        let binary = wasmer::wat2wasm(source.as_bytes()).unwrap().into_owned();
+        let emulator: Arc<dyn CTVEmulator> = Arc::new(CTVAvailable);
+        let mut original = WasmPluginHandle::<serde_json::Value>::new(
+            cache.0.clone(),
+            &emulator,
+            SyncModuleLocator::Bytes(binary),
+            bitcoin::Network::Regtest,
+            None,
+        )
+        .unwrap();
+        let initial = remaining_fuel(&mut original);
+        assert!(initial > 0 && initial <= crate::host::runtime::INSTANCE_FUEL);
+        assert_eq!(original.get_name().unwrap(), "ok");
+        assert!(remaining_fuel(&mut original) < initial);
+        exhaust_finite_calls(&mut original);
+
+        let mut fresh = original.fresh_clone().unwrap();
+        assert_eq!(remaining_fuel(&mut fresh), initial);
+        assert_eq!(fresh.get_name().unwrap(), "ok");
+        exhaust_finite_calls(&mut fresh);
+
+        let mut reloaded = WasmPluginHandle::<serde_json::Value>::new(
+            cache.0.clone(),
+            &emulator,
+            SyncModuleLocator::Key(original.id()),
+            bitcoin::Network::Regtest,
+            None,
+        )
+        .unwrap();
+        assert_eq!(remaining_fuel(&mut reloaded), initial);
+        assert_eq!(reloaded.get_name().unwrap(), "ok");
+        exhaust_finite_calls(&mut reloaded);
+    }
+
+    #[tokio::test]
+    async fn async_file_locator_accepts_wasm_and_rejects_oversized_or_nonfiles() {
+        let directory = FixtureDirectory::new();
+        let valid = directory.0.join("valid.wasm");
+        let binary = wasmer::wat2wasm(b"(module)").unwrap().into_owned();
+        std::fs::write(&valid, &binary).unwrap();
+        match ModuleLocator::FileName(valid.to_str().unwrap().to_owned())
+            .locate()
+            .await
+            .unwrap()
+        {
+            SyncModuleLocator::Bytes(bytes) => assert_eq!(bytes, binary),
+            _ => panic!("file locator must return source bytes"),
+        }
+        let oversized = directory.0.join("oversized.wasm");
+        std::fs::File::create(&oversized)
+            .unwrap()
+            .set_len(crate::host::wasm_cache::MAX_MODULE_BYTES as u64 + 1)
+            .unwrap();
+        for path in [&oversized, &directory.0] {
+            assert!(ModuleLocator::FileName(path.to_str().unwrap().to_owned())
+                .locate()
+                .await
+                .is_err());
+        }
     }
 
     #[test]
@@ -569,7 +799,7 @@ mod tests {
 
     #[test]
     fn host_calls_during_wasm_start_trap_without_initialized_memory() {
-        let store = Store::default();
+        let store = crate::host::runtime::new_store();
         let source = r#"(module
             (import "env" "sapio_v1_wasm_plugin_debug_log_string"
                 (func $log (param i32 i32)))

--- a/plugins/src/host/runtime.rs
+++ b/plugins/src/host/runtime.rs
@@ -1,0 +1,192 @@
+//! Execution limits applied before instantiation, including WASM start code.
+
+use std::sync::{Arc, OnceLock};
+use wasmer::sys::{
+    BaseTunables, CompilerConfig, Cranelift, CraneliftOptLevel, EngineBuilder, Features,
+    FunctionMiddleware, MiddlewareError, MiddlewareReaderState, ModuleMiddleware,
+};
+use wasmer::wasmparser::{BlockType, Operator};
+use wasmer::{ExportIndex, GlobalInit, GlobalType, LocalFunctionIndex, Mutability, Store, Type};
+use wasmer_middlewares::Metering;
+use wasmer_types::ModuleInfo;
+
+/// Nonrenewable fuel for one instance, shared by start and every exported call.
+pub(crate) const INSTANCE_FUEL: u64 = 100_000_000;
+/// Accessible linear memory, in 64 KiB WASM pages.
+const MAX_MEMORY_PAGES: u32 = 1024;
+const MAX_TABLE_ELEMENTS: u32 = 65_536;
+
+pub(super) fn new_store() -> Store {
+    store_with_fuel(INSTANCE_FUEL)
+}
+
+fn store_with_fuel(fuel: u64) -> Store {
+    // Metering carries module-specific global indexes. Each compiler is used
+    // for one module; fresh instances may safely share that compiled module.
+    let mut compiler = Cranelift::default();
+    // Contracts are short-lived; avoid optimizing the large Rust runtime on
+    // every source load before executing the small requested compilation.
+    compiler.opt_level(CraneliftOptLevel::None);
+    compiler.push_middleware(Arc::new(Metering::new(fuel, |_| 1)));
+    compiler.push_middleware(Arc::new(ResourceLimits::default()));
+    let mut features = Features::new();
+    // Atomic waits can block inside native runtime code without spending fuel.
+    features.threads(false).memory64(false).multi_memory(false);
+    let mut engine = EngineBuilder::new(compiler)
+        .set_features(Some(features))
+        .engine();
+    engine.set_tunables(BaseTunables::for_target(engine.target()));
+    Store::new(engine)
+}
+
+#[derive(Clone, Copy, Debug)]
+struct FuelGlobals {
+    remaining: u32,
+    exhausted: u32,
+    count: u32,
+}
+
+#[derive(Debug, Default)]
+struct ResourceLimits {
+    globals: OnceLock<FuelGlobals>,
+}
+
+fn limit_error(message: &str) -> MiddlewareError {
+    MiddlewareError::new("sapio-resource-limits", message)
+}
+
+impl ModuleMiddleware for ResourceLimits {
+    fn transform_module_info(&self, module: &mut ModuleInfo) -> Result<(), MiddlewareError> {
+        if module.memories.len() > 1 || module.tables.len() > 1 {
+            return Err(limit_error(
+                "WASM supports at most one memory and one table",
+            ));
+        }
+        for memory in module.memories.values_mut() {
+            if memory.shared || memory.minimum.0 > MAX_MEMORY_PAGES {
+                return Err(limit_error("WASM memory exceeds the 64 MiB limit"));
+            }
+            memory.maximum = Some(
+                memory
+                    .maximum
+                    .unwrap_or(MAX_MEMORY_PAGES.into())
+                    .min(MAX_MEMORY_PAGES.into()),
+            );
+        }
+        for table in module.tables.values_mut() {
+            if table.minimum > MAX_TABLE_ELEMENTS {
+                return Err(limit_error("WASM table exceeds the 65536 element limit"));
+            }
+            table.maximum = Some(
+                table
+                    .maximum
+                    .unwrap_or(MAX_TABLE_ELEMENTS)
+                    .min(MAX_TABLE_ELEMENTS),
+            );
+        }
+        let global = |name: &str| match module.exports.get(name) {
+            Some(ExportIndex::Global(index)) => Ok(index.as_u32()),
+            _ => Err(limit_error("WASM metering globals are missing")),
+        };
+        let remaining = global("wasmer_metering_remaining_points")?;
+        let exhausted = global("wasmer_metering_points_exhausted")?;
+        // Original bytecode is validated before middleware appends globals.
+        // Guests cannot address this scratch index or the metering indexes.
+        let count = module
+            .globals
+            .push(GlobalType::new(Type::I32, Mutability::Var));
+        module.global_initializers.push(GlobalInit::I32Const(0));
+        self.globals
+            .set(FuelGlobals {
+                remaining,
+                exhausted,
+                count: count.as_u32(),
+            })
+            .map_err(|_| limit_error("WASM compiler cannot be reused for another module"))
+    }
+
+    fn generate_function_middleware(&self, _: LocalFunctionIndex) -> Box<dyn FunctionMiddleware> {
+        Box::new(BulkMetering(
+            *self.globals.get().expect("module limits initialized"),
+        ))
+    }
+}
+
+#[derive(Debug)]
+struct BulkMetering(FuelGlobals);
+
+impl FunctionMiddleware for BulkMetering {
+    fn feed<'a>(
+        &mut self,
+        operator: Operator<'a>,
+        state: &mut MiddlewareReaderState<'a>,
+    ) -> Result<(), MiddlewareError> {
+        use Operator::*;
+        let unit = match operator {
+            MemoryCopy { .. } | MemoryFill { .. } | MemoryInit { .. } => 1,
+            MemoryGrow { .. } => 65_536,
+            TableCopy { .. } | TableFill { .. } | TableInit { .. } | TableGrow { .. } => 16,
+            _ => {
+                state.push_operator(operator);
+                return Ok(());
+            }
+        };
+        let FuelGlobals {
+            remaining,
+            exhausted,
+            count,
+        } = self.0;
+        // Each bulk operation's top operand is its unsigned i32 count. Save
+        // and restore it without a guest call between, then charge in i64 so
+        // even u32::MAX pages cannot overflow. Charge before touching memory.
+        state.extend([
+            GlobalSet {
+                global_index: count,
+            },
+            GlobalGet {
+                global_index: remaining,
+            },
+            GlobalGet {
+                global_index: count,
+            },
+            I64ExtendI32U,
+            I64Const { value: unit },
+            I64Mul,
+            I64LtU,
+            If {
+                blockty: BlockType::Empty,
+            },
+            I32Const { value: 1 },
+            GlobalSet {
+                global_index: exhausted,
+            },
+            I64Const { value: 0 },
+            GlobalSet {
+                global_index: remaining,
+            },
+            Unreachable,
+            End,
+            GlobalGet {
+                global_index: remaining,
+            },
+            GlobalGet {
+                global_index: count,
+            },
+            I64ExtendI32U,
+            I64Const { value: unit },
+            I64Mul,
+            I64Sub,
+            GlobalSet {
+                global_index: remaining,
+            },
+            GlobalGet {
+                global_index: count,
+            },
+        ]);
+        state.push_operator(operator);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/plugins/src/host/runtime/tests.rs
+++ b/plugins/src/host/runtime/tests.rs
@@ -1,0 +1,329 @@
+use super::*;
+use wasmer::{imports, CompileError, Instance, Module, Value};
+use wasmer_middlewares::metering::{get_remaining_points, MeteringPoints};
+
+fn instance(source: &str, fuel: u64) -> (Store, Instance) {
+    let mut store = store_with_fuel(fuel);
+    let module = Module::new(&store, source).unwrap();
+    let instance = Instance::new(&mut store, &module, &imports! {}).unwrap();
+    (store, instance)
+}
+
+fn run(instance: &Instance, store: &mut Store, count: i32) -> Result<i32, wasmer::RuntimeError> {
+    instance
+        .exports
+        .get_typed_function::<i32, i32>(store, "run")
+        .unwrap()
+        .call(store, count)
+}
+
+fn remaining(instance: &Instance, store: &mut Store) -> u64 {
+    match get_remaining_points(store, instance) {
+        MeteringPoints::Remaining(fuel) => fuel,
+        MeteringPoints::Exhausted => panic!("unexpected fuel exhaustion"),
+    }
+}
+
+#[test]
+fn oversized_initial_resources_and_multiple_tables_fail_before_instantiation() {
+    for (source, reason) in [
+        ("(module (memory 1025))", "64 MiB"),
+        ("(module (table 65537 funcref))", "65536 element"),
+        (
+            "(module (table 1 funcref) (table 1 funcref))",
+            "at most one",
+        ),
+    ] {
+        let store = store_with_fuel(1_000_000);
+        let error = Module::new(&store, source).unwrap_err();
+        assert!(
+            matches!(error, CompileError::MiddlewareError(_)),
+            "{source}: {error}"
+        );
+        assert!(error.to_string().contains(reason), "{source}: {error}");
+    }
+}
+
+#[test]
+fn memory_growth_obeys_host_cap_and_smaller_declared_maximum() {
+    for (limits, maximum) in [("0", 1024), ("0 65536", 1024), ("0 2", 2)] {
+        let source = format!(
+            "(module (memory (export \"memory\") {limits})
+                (func (export \"run\") (param i32) (result i32)
+                    local.get 0 memory.grow))"
+        );
+        let (mut store, instance) = instance(&source, 1 << 40);
+        let memory = instance.exports.get_memory("memory").unwrap();
+        assert_eq!(memory.ty(&store).maximum.unwrap().0, maximum);
+        assert_eq!(run(&instance, &mut store, maximum as i32).unwrap(), 0);
+        assert_eq!(memory.size(&store).0, maximum);
+        assert_eq!(run(&instance, &mut store, 1).unwrap(), -1);
+        assert_eq!(memory.size(&store).0, maximum);
+    }
+}
+
+#[test]
+fn table_growth_obeys_host_cap_and_smaller_declared_maximum() {
+    for (limits, maximum) in [("0", 65_536), ("0 100000", 65_536), ("0 2", 2)] {
+        let source = format!(
+            "(module (table (export \"table\") {limits} funcref)
+                (func (export \"run\") (param i32) (result i32)
+                    ref.null func local.get 0 table.grow))"
+        );
+        let (mut store, instance) = instance(&source, 1 << 40);
+        let table = instance.exports.get_table("table").unwrap();
+        assert_eq!(table.ty(&store).maximum, Some(maximum));
+        assert_eq!(run(&instance, &mut store, maximum as i32).unwrap(), 0);
+        assert_eq!(table.size(&store), maximum);
+        assert_eq!(run(&instance, &mut store, 1).unwrap(), -1);
+        assert_eq!(table.size(&store), maximum);
+    }
+}
+
+struct BulkCase {
+    name: &'static str,
+    source: String,
+    unit_cost: u64,
+    result: i32,
+}
+
+fn bulk_cases() -> Vec<BulkCase> {
+    let memory = "(memory (export \"memory\") 1)";
+    let table = "(table (export \"table\") 8192 funcref)";
+    let answer = "(type $answer (func (result i32))) (func $answer (type $answer) i32.const 42)";
+    let call = "i32.const 0 call_indirect (type $answer)";
+    [
+        (
+            "memory.copy",
+            format!("{memory} (data (i32.const 32768) \"*\")"),
+            "i32.const 0 i32.const 32768 local.get 0 memory.copy i32.const 0 i32.load8_u".into(),
+            1,
+            42,
+        ),
+        (
+            "memory.fill",
+            memory.into(),
+            "i32.const 0 i32.const 42 local.get 0 memory.fill i32.const 0 i32.load8_u".into(),
+            1,
+            42,
+        ),
+        (
+            "memory.init",
+            format!("{memory} (data $bytes \"{}\")", "*".repeat(2048)),
+            "i32.const 0 i32.const 0 local.get 0 memory.init $bytes i32.const 0 i32.load8_u".into(),
+            1,
+            42,
+        ),
+        (
+            "memory.grow",
+            "(memory (export \"memory\") 0)".into(),
+            "local.get 0 memory.grow".into(),
+            65_536,
+            0,
+        ),
+        (
+            "table.copy",
+            format!("{table} {answer} (elem (i32.const 4096) $answer $answer)"),
+            format!("i32.const 0 i32.const 4096 local.get 0 table.copy {call}"),
+            16,
+            42,
+        ),
+        (
+            "table.fill",
+            format!("{table} {answer} (elem declare func $answer)"),
+            format!("i32.const 0 ref.func $answer local.get 0 table.fill {call}"),
+            16,
+            42,
+        ),
+        (
+            "table.init",
+            format!(
+                "{table} {answer} (elem $entries func {})",
+                "$answer ".repeat(2048)
+            ),
+            format!("i32.const 0 i32.const 0 local.get 0 table.init $entries {call}"),
+            16,
+            42,
+        ),
+        (
+            "table.grow",
+            "(table (export \"table\") 0 funcref)".into(),
+            "ref.null func local.get 0 table.grow".into(),
+            16,
+            0,
+        ),
+    ]
+    .into_iter()
+    .map(|(name, declarations, body, unit_cost, result)| BulkCase {
+        name,
+        source: format!(
+            "(module {declarations} (func (export \"run\") (param i32) (result i32) {body}))"
+        ),
+        unit_cost,
+        result,
+    })
+    .collect()
+}
+
+fn assert_destination_untouched(case: &BulkCase, instance: &Instance, store: &mut Store) {
+    if case.name.starts_with("memory") {
+        let memory = instance.exports.get_memory("memory").unwrap();
+        if case.name == "memory.grow" {
+            assert_eq!(memory.size(&*store).0, 0, "{}", case.name);
+        } else {
+            let mut byte = [255];
+            memory.view(&*store).read(0, &mut byte).unwrap();
+            assert_eq!(byte, [0], "{}", case.name);
+        }
+    } else {
+        let table = instance.exports.get_table("table").unwrap();
+        if case.name == "table.grow" {
+            assert_eq!(table.size(&*store), 0, "{}", case.name);
+        } else {
+            assert!(
+                matches!(table.get(store, 0), Some(Value::FuncRef(None))),
+                "{}",
+                case.name
+            );
+        }
+    }
+}
+
+#[test]
+fn every_bulk_operation_charges_runtime_count_before_changing_resources() {
+    for case in bulk_cases() {
+        let fuel = if case.name == "memory.grow" {
+            100_000
+        } else {
+            1024
+        };
+        let (mut store, instance) = instance(&case.source, fuel);
+        assert_eq!(
+            run(&instance, &mut store, 1).unwrap(),
+            case.result,
+            "{}",
+            case.name
+        );
+        assert!(remaining(&instance, &mut store) < fuel);
+
+        let (mut store, instance) = self::instance(&case.source, fuel);
+        let large = if case.name == "memory.grow" { 2 } else { 2048 };
+        assert!(run(&instance, &mut store, large).is_err(), "{}", case.name);
+        assert_eq!(
+            get_remaining_points(&mut store, &instance),
+            MeteringPoints::Exhausted,
+            "{}",
+            case.name
+        );
+        assert_destination_untouched(&case, &instance, &mut store);
+    }
+}
+
+#[test]
+fn bulk_fuel_scales_with_bytes_pages_and_table_elements() {
+    for case in bulk_cases() {
+        let mut consumed = Vec::new();
+        for count in [1, 2] {
+            let (mut store, instance) = instance(&case.source, 1_000_000);
+            assert_eq!(
+                run(&instance, &mut store, count).unwrap(),
+                case.result,
+                "{}",
+                case.name
+            );
+            consumed.push(1_000_000 - remaining(&instance, &mut store));
+        }
+        // These runs execute identical opcodes. Only the runtime size changes.
+        assert_eq!(consumed[1] - consumed[0], case.unit_cost, "{}", case.name);
+    }
+}
+
+#[test]
+fn negative_counts_exhaust_small_budgets_without_wrapping() {
+    for case in bulk_cases() {
+        for count in [i32::MIN, -1] {
+            let (mut store, instance) = instance(&case.source, 1_000_000);
+            assert!(
+                run(&instance, &mut store, count).is_err(),
+                "{} {count}",
+                case.name
+            );
+            assert_eq!(
+                get_remaining_points(&mut store, &instance),
+                MeteringPoints::Exhausted,
+                "{} {count}",
+                case.name
+            );
+            assert_destination_untouched(&case, &instance, &mut store);
+        }
+    }
+}
+
+#[test]
+fn max_unsigned_count_has_finite_u64_cost_before_normal_bounds_failure() {
+    for case in bulk_cases() {
+        let initial = 1 << 60;
+        let (mut store, instance) = instance(&case.source, initial);
+        let result = run(&instance, &mut store, -1);
+        if case.name.ends_with(".grow") {
+            assert_eq!(result.unwrap(), -1, "{}", case.name);
+        } else {
+            assert!(result.is_err(), "{}", case.name);
+        }
+        let charged = initial - remaining(&instance, &mut store);
+        let expected = u64::from(u32::MAX) * case.unit_cost;
+        // Instruction charges are tiny compared with the bulk request. A signed
+        // extension, i32 multiply, or missing charge cannot meet this bound.
+        assert!(
+            (expected..expected + 64).contains(&charged),
+            "{}: charged {charged}, expected {expected} plus instructions",
+            case.name
+        );
+        assert_destination_untouched(&case, &instance, &mut store);
+    }
+}
+
+#[test]
+fn guests_cannot_address_appended_metering_or_scratch_globals() {
+    for source in [
+        "(module (func i64.const -1 global.set 0))",
+        "(module (func i32.const 0 global.set 1))",
+        "(module (func i32.const 0 global.set 2))",
+        "(module (global (mut i32) (i32.const 0)) (func i64.const -1 global.set 1))",
+    ] {
+        let store = store_with_fuel(100);
+        assert!(
+            matches!(Module::new(&store, source), Err(CompileError::Validate(_))),
+            "{source}"
+        );
+    }
+}
+
+#[test]
+fn shared_memories_and_atomic_waits_are_rejected_before_execution() {
+    for source in [
+        "(module (memory 1 1 shared))",
+        "(module (memory 1) (func i32.const 0 i32.const 0 i64.const -1 memory.atomic.wait32 drop))",
+        "(module (memory 1) (func i32.const 0 i64.const 0 i64.const -1 memory.atomic.wait64 drop))",
+    ] {
+        let store = store_with_fuel(100);
+        assert!(
+            matches!(Module::new(&store, source), Err(CompileError::Validate(_))),
+            "{source}"
+        );
+    }
+}
+
+#[test]
+fn direct_guest_recursion_traps_on_stack_limit_before_fuel_exhaustion() {
+    let source = "(module
+        (func $recurse (export \"run\") (param i32) (result i32)
+            local.get 0 call $recurse
+            i32.const 1 i32.add))";
+    let initial = 100_000_000;
+    let (mut store, instance) = instance(source, initial);
+    let error = run(&instance, &mut store, 0).unwrap_err();
+    assert_eq!(error.to_trap(), Some(wasmer_types::TrapCode::StackOverflow));
+    let fuel = remaining(&instance, &mut store);
+    assert!(fuel > 0 && fuel < initial);
+}

--- a/plugins/src/host/tests.rs
+++ b/plugins/src/host/tests.rs
@@ -1,0 +1,321 @@
+use super::plugin_handle::SyncModuleLocator;
+use super::*;
+use bitcoin::secp256k1::{Message, Secp256k1, SecretKey};
+use bitcoin::util::psbt::raw;
+use bitcoin::{EcdsaSig, EcdsaSighashType, PublicKey, Script, Transaction, TxIn, TxOut};
+use sapio_ctv_emulator_trait::{Clause, EmulatorError};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+struct FixtureCache(PathBuf);
+
+impl FixtureCache {
+    fn new() -> Self {
+        static NEXT: AtomicUsize = AtomicUsize::new(0);
+        let path = std::env::temp_dir().join(format!(
+            "sapio-host-imports-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir(&path).unwrap();
+        Self(path)
+    }
+
+    fn load(
+        &self,
+        wat: &str,
+        emulator: &Arc<dyn CTVEmulator>,
+    ) -> WasmPluginHandle<serde_json::Value> {
+        WasmPluginHandle::new(
+            self.0.clone(),
+            emulator,
+            SyncModuleLocator::Bytes(wasmer::wat2wasm(wat.as_bytes()).unwrap().into_owned()),
+            bitcoin::Network::Regtest,
+            None,
+        )
+        .unwrap()
+    }
+}
+
+impl Drop for FixtureCache {
+    fn drop(&mut self) {
+        std::fs::remove_dir_all(&self.0).unwrap();
+    }
+}
+
+fn fixture(data: &[u8], name: &str, api: &str, entry: &str) -> String {
+    let encoded = data
+        .iter()
+        .map(|byte| format!("\\{byte:02x}"))
+        .collect::<String>();
+    format!(
+        r#"(module
+          (import "env" "sapio_v1_wasm_plugin_ctv_emulator_sign"
+            (func $sign (param i32 i32) (result i32)))
+          (import "env" "sapio_v1_wasm_plugin_ctv_emulator_signer_for"
+            (func $signer_for (param i32) (result i32)))
+          (import "env" "sapio_v1_wasm_plugin_lookup_module_name"
+            (func $lookup (param i32 i32 i32 i32)))
+          (import "env" "sapio_v1_wasm_plugin_get_api"
+            (func $api (param i32) (result i32)))
+          (import "env" "sapio_v1_wasm_plugin_get_logo"
+            (func $logo (param i32) (result i32)))
+          (memory (export "memory") 1)
+          (data (i32.const 8) "ok\00")
+          (data (i32.const 1024) "{encoded}")
+          (func (export "sapio_v1_wasm_plugin_client_allocate_bytes")
+            (param i32) (result i32) i32.const 32768)
+          (func (export "sapio_v1_wasm_plugin_client_get_create_arguments")
+            (result i32) {api})
+          (func (export "sapio_v1_wasm_plugin_client_get_name")
+            (result i32) {name})
+          (func (export "sapio_v1_wasm_plugin_client_get_logo")
+            (result i32) i32.const 8)
+          (func (export "sapio_v1_wasm_plugin_client_drop_allocation") (param i32))
+          (func (export "sapio_v1_wasm_plugin_client_create")
+            (param i32 i32) (result i32) i32.const 8)
+          (func (export "sapio_v1_wasm_plugin_entry_point") {entry}))"#
+    )
+}
+
+fn signing_request() -> PartiallySignedTransaction {
+    let mut psbt = PartiallySignedTransaction::from_unsigned_tx(Transaction {
+        version: 2,
+        lock_time: 0,
+        input: vec![TxIn::default()],
+        output: vec![TxOut {
+            value: 9000,
+            script_pubkey: Script::from(vec![0x51]),
+        }],
+    })
+    .unwrap();
+    psbt.unknown.insert(
+        raw::Key {
+            type_value: 0x80,
+            key: vec![1],
+        },
+        vec![2, 3],
+    );
+    psbt
+}
+
+struct SigningEmulator(fn(&mut PartiallySignedTransaction));
+
+impl CTVEmulator for SigningEmulator {
+    fn get_signer_for(&self, h: sha256::Hash) -> Result<Clause, EmulatorError> {
+        Ok(Clause::TxTemplate(h))
+    }
+
+    fn sign(
+        &self,
+        mut psbt: PartiallySignedTransaction,
+    ) -> Result<PartiallySignedTransaction, EmulatorError> {
+        self.0(&mut psbt);
+        Ok(psbt)
+    }
+}
+
+#[test]
+fn signing_import_rejects_transaction_and_metadata_changes() {
+    let cache = FixtureCache::new();
+    let bytes = serde_json::to_vec(&signing_request()).unwrap();
+    let wat = fixture(
+        &bytes,
+        &format!("i32.const 1024 i32.const {} call $sign", bytes.len()),
+        "i32.const 8",
+        "",
+    );
+    for mutate in [
+        (|psbt: &mut PartiallySignedTransaction| psbt.unsigned_tx.output[0].value += 1)
+            as fn(&mut PartiallySignedTransaction),
+        |psbt: &mut PartiallySignedTransaction| psbt.unknown.clear(),
+    ] {
+        let emulator: Arc<dyn CTVEmulator> = Arc::new(SigningEmulator(mutate));
+        let mut plugin = cache.load(&wat, &emulator);
+        let error = plugin
+            .get_name()
+            .expect_err("the host must reject a signer that changes the PSBT");
+        assert!(
+            error
+                .to_string()
+                .contains("Emulator response must preserve the PSBT and only add signatures"),
+            "{error}"
+        );
+    }
+}
+
+#[test]
+fn signing_import_preserves_psbt_and_accepts_signature_additions() {
+    fn add_signature(psbt: &mut PartiallySignedTransaction) {
+        let secp = Secp256k1::new();
+        let secret = SecretKey::from_slice(&[7; 32]).unwrap();
+        let public = PublicKey::new(bitcoin::secp256k1::PublicKey::from_secret_key(
+            &secp, &secret,
+        ));
+        let message = Message::from_digest_slice(&[9; 32]).unwrap();
+        psbt.inputs[0].partial_sigs.insert(
+            public,
+            EcdsaSig {
+                sig: secp.sign_ecdsa(&message, &secret),
+                hash_ty: EcdsaSighashType::All,
+            },
+        );
+    }
+    let cache = FixtureCache::new();
+    let mut expected = signing_request();
+    let bytes = serde_json::to_vec(&expected).unwrap();
+    let emulator: Arc<dyn CTVEmulator> = Arc::new(SigningEmulator(add_signature));
+    let wat = fixture(
+        &bytes,
+        &format!("i32.const 1024 i32.const {} call $sign", bytes.len()),
+        "i32.const 8",
+        "",
+    );
+    let mut plugin = cache.load(&wat, &emulator);
+    let response: PartiallySignedTransaction =
+        serde_json::from_str(&plugin.get_name().unwrap()).unwrap();
+    add_signature(&mut expected);
+    assert_eq!(response, expected);
+}
+
+struct CountingEmulator(AtomicUsize);
+
+impl CTVEmulator for CountingEmulator {
+    fn get_signer_for(&self, h: sha256::Hash) -> Result<Clause, EmulatorError> {
+        self.0.fetch_add(1, Ordering::Relaxed);
+        Ok(Clause::TxTemplate(h))
+    }
+
+    fn sign(
+        &self,
+        psbt: PartiallySignedTransaction,
+    ) -> Result<PartiallySignedTransaction, EmulatorError> {
+        Ok(psbt)
+    }
+}
+
+const FIND_SELF: &str = "i32.const 0 i32.const 0 i32.const 64 i32.const 96 call $lookup";
+const COUNT_INSTANCE: &str = "i32.const 128 call $signer_for drop";
+
+#[test]
+fn guest_allocator_cannot_reenter_an_allocating_host_import() {
+    let cache = FixtureCache::new();
+    let counter = Arc::new(CountingEmulator(AtomicUsize::new(0)));
+    let emulator: Arc<dyn CTVEmulator> = counter.clone();
+    let wat = fixture(&[], "i32.const 128 call $signer_for", "i32.const 8", "")
+        .replacen(
+            "(memory (export \"memory\") 1)",
+            "(global $allocations (mut i32) (i32.const 0)) (memory (export \"memory\") 1)",
+            1,
+        )
+        .replacen(
+            "(param i32) (result i32) i32.const 32768)",
+            "(param i32) (result i32)
+             global.get $allocations i32.const 1 i32.add global.set $allocations
+             global.get $allocations i32.const 16 i32.lt_u
+             if i32.const 128 call $signer_for drop end
+             i32.const 32768)",
+            1,
+        );
+    let mut plugin = cache.load(&wat, &emulator);
+    // The adversarial recursion is finite even without the guard; this test
+    // cannot overflow the native stack when demonstrating the old behavior.
+    let error = plugin.get_name().unwrap_err();
+    assert!(error.to_string().contains("allocator reentry"), "{error}");
+    assert_eq!(counter.0.load(Ordering::Relaxed), 2);
+    // A failed allocator callback must release the guard before the next call.
+    let error = plugin.get_name().unwrap_err();
+    assert!(error.to_string().contains("allocator reentry"), "{error}");
+    assert_eq!(counter.0.load(Ordering::Relaxed), 4);
+}
+
+#[test]
+fn recursive_guest_api_stops_at_the_depth_limit() {
+    let cache = FixtureCache::new();
+    let counter = Arc::new(CountingEmulator(AtomicUsize::new(0)));
+    let emulator: Arc<dyn CTVEmulator> = counter.clone();
+    let wat = fixture(
+        &[],
+        "i32.const 8",
+        &format!("{FIND_SELF} i32.const 64 call $api"),
+        COUNT_INSTANCE,
+    );
+    let mut plugin = cache.load(&wat, &emulator);
+    assert!(plugin.get_api().is_err());
+    // Count initialization through a real host import, including the root.
+    assert_eq!(counter.0.load(Ordering::Relaxed), invocation::MAX_DEPTH + 1);
+}
+
+fn sibling_calls(count: usize, find_key: &str) -> String {
+    format!(
+        "(local $calls i32) {find_key}
+         (loop $again
+           i32.const 64 call $logo drop
+           local.get $calls i32.const 1 i32.add local.tee $calls
+           i32.const {count} i32.lt_u br_if $again)
+         i32.const 8"
+    )
+}
+
+#[test]
+fn sibling_guest_calls_share_a_nonrenewable_allowance_and_fresh_clone_resets_it() {
+    let cache = FixtureCache::new();
+    let counter = Arc::new(CountingEmulator(AtomicUsize::new(0)));
+    let emulator: Arc<dyn CTVEmulator> = counter.clone();
+    let wat = fixture(
+        &[],
+        &sibling_calls(invocation::MAX_MODULE_CALLS, FIND_SELF),
+        "i32.const 8",
+        COUNT_INSTANCE,
+    );
+    let mut plugin = cache.load(&wat, &emulator);
+    assert_eq!(plugin.get_name().unwrap(), "ok");
+    assert_eq!(
+        counter.0.load(Ordering::Relaxed),
+        invocation::MAX_MODULE_CALLS + 1
+    );
+    let error = plugin.get_name().unwrap_err();
+    assert!(
+        error.to_string().contains("nested module call limit"),
+        "{error}"
+    );
+    assert_eq!(
+        counter.0.load(Ordering::Relaxed),
+        invocation::MAX_MODULE_CALLS + 1
+    );
+
+    let mut fresh = plugin.fresh_clone().unwrap();
+    assert_eq!(fresh.get_name().unwrap(), "ok");
+    assert_eq!(
+        counter.0.load(Ordering::Relaxed),
+        2 * (invocation::MAX_MODULE_CALLS + 1)
+    );
+    assert!(fresh
+        .get_name()
+        .unwrap_err()
+        .to_string()
+        .contains("nested module call limit"));
+}
+
+#[test]
+fn failed_child_lookups_consume_the_guest_call_allowance() {
+    let cache = FixtureCache::new();
+    let counter = Arc::new(CountingEmulator(AtomicUsize::new(0)));
+    let emulator: Arc<dyn CTVEmulator> = counter.clone();
+    // The zero hash at offset 64 names no cached module. The guest ignores
+    // these ordinary lookup errors, but cannot keep issuing calls forever.
+    let wat = fixture(
+        &[],
+        &sibling_calls(invocation::MAX_MODULE_CALLS, ""),
+        "i32.const 8",
+        COUNT_INSTANCE,
+    );
+    let mut plugin = cache.load(&wat, &emulator);
+    assert_eq!(plugin.get_name().unwrap(), "ok");
+    assert_eq!(counter.0.load(Ordering::Relaxed), 1);
+    let error = plugin.get_name().unwrap_err();
+    assert!(
+        error.to_string().contains("nested module call limit"),
+        "{error}"
+    );
+    assert_eq!(counter.0.load(Ordering::Relaxed), 1);
+}

--- a/plugins/src/host/wasm_cache.rs
+++ b/plugins/src/host/wasm_cache.rs
@@ -4,64 +4,387 @@
 //  License, v. 2.0. If a copy of the MPL was not distributed with this
 //  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-//! tools for caching compilations of wasm plugins to disk
-use std::path::PathBuf;
-use wasmer::{DeserializeError, Module, SerializeError, Store};
-use wasmer_cache::{Cache, FileSystemCache, Hash};
+//! Content-addressed WASM source storage. Every load compiles with its caller's
+//! engine; cached native executables are never deserialized.
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::sync::atomic::{AtomicU64, Ordering};
+use wasmer::{Module, Store};
+use wasmer_cache::Hash;
 
-/// look at the cache and get all of the keys (as Strings) for plugins
+/// Maximum binary WASM source size, including debug information.
+pub const MAX_MODULE_BYTES: usize = 128 * 1024 * 1024;
+
+const WASM_HEADER: &[u8] = b"\0asm\x01\0\0\0";
+static NEXT_TEMP_FILE: AtomicU64 = AtomicU64::new(0);
+
+fn invalid_source(message: &str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message)
+}
+
+fn check_source(bytes: &[u8]) -> io::Result<()> {
+    if bytes.len() > MAX_MODULE_BYTES {
+        return Err(invalid_source("WASM source exceeds the module size limit"));
+    }
+    if !bytes.starts_with(WASM_HEADER) {
+        return Err(invalid_source("Expected a binary WASM module header"));
+    }
+    Ok(())
+}
+
+fn source_path(path: &Path, key: Hash) -> PathBuf {
+    path.join("sources").join(format!("{key}.wasm"))
+}
+
+fn read_source(path: &Path, key: Hash) -> io::Result<Vec<u8>> {
+    // Reject non-files before opening, so directories and ordinary named pipes
+    // cannot act as source entries. Hash verification still authenticates bytes.
+    if !fs::symlink_metadata(path)?.file_type().is_file() {
+        return Err(invalid_source(
+            "WASM source cache entry is not a regular file",
+        ));
+    }
+    let file = File::open(path)?;
+    let metadata = file.metadata()?;
+    if !metadata.is_file() || metadata.len() > MAX_MODULE_BYTES as u64 {
+        return Err(invalid_source(
+            "WASM source cache entry exceeds the module size limit",
+        ));
+    }
+    let mut bytes = Vec::new();
+    // The file may grow after the metadata check. Read at most one byte beyond
+    // the limit so growth cannot make the allocation unbounded.
+    file.take(MAX_MODULE_BYTES as u64 + 1)
+        .read_to_end(&mut bytes)?;
+    check_source(&bytes)?;
+    if Hash::generate(&bytes) != key {
+        return Err(invalid_source(
+            "WASM source does not match the requested cache key",
+        ));
+    }
+    Ok(bytes)
+}
+
+/// List authenticated source keys in deterministic order.
+///
+/// A missing source directory is empty. Legacy executable caches and unrelated
+/// files are ignored; I/O failures and corruption of source entries are errors.
+/// Full WASM validation occurs when loading with the caller's engine.
 pub fn get_all_keys_from_fs<I: Into<PathBuf>>(
     path: I,
 ) -> Result<Vec<String>, Box<dyn std::error::Error>> {
-    std::fs::read_dir(path.into())?
-        .map(|entry| {
-            match entry.map(|x| {
-                x.path()
-                    .file_stem()
-                    .and_then(|f| f.to_str().map(String::from))
-                    .ok_or(String::from("Nothing").into())
-            }) {
-                Ok(x) => x,
-                Err(x) => Err(x.into()),
-            }
-        })
-        .collect()
+    let directory = path.into().join("sources");
+    let entries = match fs::read_dir(directory) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(error.into()),
+    };
+    let mut keys = Vec::new();
+    for entry in entries {
+        let entry = entry?;
+        let filename = entry.file_name();
+        let Some(name) = filename
+            .to_str()
+            .and_then(|name| name.strip_suffix(".wasm"))
+        else {
+            continue;
+        };
+        let Ok(key) = Hash::from_str(name) else {
+            continue;
+        };
+        if key.to_string() != name {
+            continue;
+        }
+        read_source(&entry.path(), key)?;
+        keys.push(name.to_owned());
+    }
+    keys.sort_unstable();
+    Ok(keys)
 }
 
-/// load a module given the bytes of the module, may consult cache if available
+/// Compile binary WASM with the supplied store and cache its exact source.
+///
+/// Existing source entries must be intact. Compilation and cache errors are
+/// propagated rather than treated as cache misses.
 pub fn load_module<I: Into<PathBuf>>(
     path: I,
     store: &Store,
     bytes: &[u8],
-) -> Result<(Module, Hash), DeserializeError> {
+) -> Result<(Module, Hash), Box<dyn std::error::Error>> {
+    check_source(bytes)?;
     let key = Hash::generate(bytes);
-    let f = FileSystemCache::new(path)?;
-    unsafe { f.load(store, key) }.map(|m| (m, key))
+    let module = Module::new(store, bytes)?;
+    let source = source_path(&path.into(), key);
+    match read_source(&source, key) {
+        Ok(_) => return Ok((module, key)),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+    let directory = source.parent().expect("source path has a parent");
+    fs::create_dir_all(directory)?;
+    let temporary = directory.join(format!(
+        ".{key}.{}.{}.tmp",
+        std::process::id(),
+        NEXT_TEMP_FILE.fetch_add(1, Ordering::Relaxed)
+    ));
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temporary)?;
+    let result = (|| -> io::Result<()> {
+        file.write_all(bytes)?;
+        drop(file);
+        // Publish complete sources so concurrent readers never see our partial
+        // writes. Writers for the same content key publish identical bytes.
+        fs::rename(&temporary, &source)
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result?;
+    Ok((module, key))
 }
 
-/// load a module from the cache
+/// Authenticate cached source and compile it with the supplied store.
+///
+/// Native executable cache entries are never consulted. A new store's compiler
+/// configuration therefore applies even when this source was previously used.
 pub fn load_module_key<I: Into<PathBuf>>(
     path: I,
     store: &Store,
     key: Hash,
-) -> Result<(Module, Hash), DeserializeError> {
-    let f = FileSystemCache::new(path)?;
-    unsafe { f.load(store, key) }.map(|m| (m, key))
+) -> Result<(Module, Hash), Box<dyn std::error::Error>> {
+    let bytes = read_source(&source_path(&path.into(), key), key)?;
+    Ok((Module::new(store, &bytes)?, key))
 }
 
-/// store a module into the cache
-pub fn store_module<I: Into<PathBuf>>(
-    path: I,
-    module: &Module,
-    bytes: &[u8],
-) -> Result<Hash, SerializeError> {
-    let mut cache = FileSystemCache::new(path)?;
-    #[cfg(target_os = "windows")]
-    {
-        cache.set_cache_extension(Some("dll"))
-    }
-    let key = Hash::generate(bytes);
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wasmer::{imports, Instance};
 
-    cache.store(key, module)?;
-    Ok(key)
+    struct TempCache(PathBuf);
+
+    impl TempCache {
+        fn new() -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "sapio-wasm-source-cache-{}-{}",
+                std::process::id(),
+                NEXT_TEMP_FILE.fetch_add(1, Ordering::Relaxed)
+            ));
+            fs::create_dir(&path).unwrap();
+            Self(path)
+        }
+
+        fn write_source(&self, key: Hash, bytes: &[u8]) {
+            fs::create_dir_all(self.0.join("sources")).unwrap();
+            fs::write(source_path(&self.0, key), bytes).unwrap();
+        }
+    }
+
+    impl Drop for TempCache {
+        fn drop(&mut self) {
+            fs::remove_dir_all(&self.0).unwrap();
+        }
+    }
+
+    fn source(value: i32) -> Vec<u8> {
+        wasmer::wat2wasm(
+            format!("(module (func (export \"answer\") (result i32) i32.const {value}))")
+                .as_bytes(),
+        )
+        .unwrap()
+        .into_owned()
+    }
+
+    fn answer(module: &Module, store: &mut Store) -> i32 {
+        Instance::new(store, module, &imports! {})
+            .unwrap()
+            .exports
+            .get_typed_function::<(), i32>(store, "answer")
+            .unwrap()
+            .call(store)
+            .unwrap()
+    }
+
+    #[test]
+    fn source_roundtrip_preserves_bytes_and_runs_in_fresh_stores() {
+        let cache = TempCache::new();
+        let bytes = source(42);
+        let mut first_store = Store::default();
+        let (module, key) = load_module(&cache.0, &first_store, &bytes).unwrap();
+        assert_eq!(key, Hash::generate(&bytes));
+        assert_eq!(fs::read(source_path(&cache.0, key)).unwrap(), bytes);
+        assert_eq!(answer(&module, &mut first_store), 42);
+        let mut second_store = Store::default();
+        let (loaded, loaded_key) = load_module_key(&cache.0, &second_store, key).unwrap();
+        assert_eq!(loaded_key, key);
+        assert_eq!(answer(&loaded, &mut second_store), 42);
+        let (_, repeated_key) = load_module(&cache.0, &second_store, &bytes).unwrap();
+        assert_eq!(repeated_key, key);
+        let (_, other_key) = load_module(&cache.0, &second_store, &source(7)).unwrap();
+        let mut expected_keys = vec![key.to_string(), other_key.to_string()];
+        expected_keys.sort_unstable();
+        assert_eq!(get_all_keys_from_fs(&cache.0).unwrap(), expected_keys);
+    }
+
+    #[test]
+    fn mismatched_source_is_an_error_and_is_not_silently_replaced() {
+        let cache = TempCache::new();
+        let bytes = source(42);
+        let key = Hash::generate(&bytes);
+        let changed = source(43);
+        cache.write_source(key, &changed);
+        let store = Store::default();
+        for error in [
+            load_module_key(&cache.0, &store, key).unwrap_err(),
+            load_module(&cache.0, &store, &bytes).unwrap_err(),
+            get_all_keys_from_fs(&cache.0).unwrap_err(),
+        ] {
+            assert!(error.to_string().contains("does not match"));
+        }
+        assert_eq!(fs::read(source_path(&cache.0, key)).unwrap(), changed);
+    }
+
+    #[test]
+    fn truncated_wasm_is_rejected_even_under_its_own_content_key() {
+        let cache = TempCache::new();
+        let mut bytes = source(42);
+        bytes.pop();
+        let key = Hash::generate(&bytes);
+        let store = Store::default();
+        assert!(load_module(&cache.0, &store, &bytes).is_err());
+        assert!(get_all_keys_from_fs(&cache.0).unwrap().is_empty());
+        cache.write_source(key, &bytes);
+        assert!(load_module_key(&cache.0, &store, key)
+            .unwrap_err()
+            .downcast_ref::<wasmer::CompileError>()
+            .is_some());
+    }
+
+    #[test]
+    fn oversized_sources_are_rejected_before_reading_or_writing() {
+        let cache = TempCache::new();
+        let bytes = source(42);
+        let key = Hash::generate(&bytes);
+        cache.write_source(key, &bytes);
+        File::options()
+            .write(true)
+            .open(source_path(&cache.0, key))
+            .unwrap()
+            .set_len(MAX_MODULE_BYTES as u64 + 1)
+            .unwrap();
+        let store = Store::default();
+        assert!(load_module_key(&cache.0, &store, key)
+            .unwrap_err()
+            .to_string()
+            .contains("size limit"));
+        assert!(get_all_keys_from_fs(&cache.0)
+            .unwrap_err()
+            .to_string()
+            .contains("size limit"));
+        let oversized = vec![0; MAX_MODULE_BYTES + 1];
+        let empty_cache = TempCache::new();
+        assert!(load_module(&empty_cache.0, &store, &oversized)
+            .unwrap_err()
+            .to_string()
+            .contains("size limit"));
+        assert!(!empty_cache.0.join("sources").exists());
+    }
+
+    #[test]
+    fn legacy_executables_and_unrelated_files_are_not_source_entries() {
+        let cache = TempCache::new();
+        let bytes = source(42);
+        let key = Hash::generate(&bytes);
+        let store = Store::default();
+        let native = Module::new(&store, &bytes).unwrap().serialize().unwrap();
+        fs::write(cache.0.join(key.to_string()), &native).unwrap();
+        fs::write(cache.0.join(format!("{key}.dll")), &native).unwrap();
+        assert!(get_all_keys_from_fs(&cache.0).unwrap().is_empty());
+        assert_eq!(
+            load_module_key(&cache.0, &store, key)
+                .unwrap_err()
+                .downcast_ref::<io::Error>()
+                .unwrap()
+                .kind(),
+            io::ErrorKind::NotFound
+        );
+        load_module(&cache.0, &store, &bytes).unwrap();
+        let directory = cache.0.join("sources");
+        fs::write(directory.join("notes.txt"), &bytes).unwrap();
+        fs::write(directory.join("not-a-key.wasm"), &bytes).unwrap();
+        fs::write(directory.join(format!(".{key}.tmp")), &bytes).unwrap();
+        fs::create_dir(directory.join("unrelated-directory")).unwrap();
+        assert_eq!(
+            get_all_keys_from_fs(&cache.0).unwrap(),
+            vec![key.to_string()]
+        );
+        assert_eq!(
+            fs::read(cache.0.join(key.to_string())).unwrap(),
+            native.as_ref()
+        );
+    }
+
+    #[test]
+    fn native_bytes_and_text_are_rejected_without_creating_source_entries() {
+        let cache = TempCache::new();
+        let store = Store::default();
+        let native = Module::new(&store, source(42))
+            .unwrap()
+            .serialize()
+            .unwrap();
+        for bytes in [native.as_ref(), b"(module)".as_slice(), b"\0asm".as_slice()] {
+            assert!(load_module(&cache.0, &store, bytes)
+                .unwrap_err()
+                .to_string()
+                .contains("binary WASM"));
+            let key = Hash::generate(bytes);
+            cache.write_source(key, bytes);
+            assert!(load_module_key(&cache.0, &store, key).is_err());
+            fs::remove_file(source_path(&cache.0, key)).unwrap();
+        }
+        assert!(get_all_keys_from_fs(&cache.0).unwrap().is_empty());
+    }
+
+    #[test]
+    fn invalid_cache_directory_is_an_error_instead_of_a_miss() {
+        let cache = TempCache::new();
+        fs::write(cache.0.join("sources"), b"not a directory").unwrap();
+        let bytes = source(42);
+        let store = Store::default();
+        assert!(get_all_keys_from_fs(&cache.0).is_err());
+        assert!(load_module_key(&cache.0, &store, Hash::generate(&bytes)).is_err());
+        assert!(load_module(&cache.0, &store, &bytes).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unreadable_source_is_not_treated_as_a_cache_miss() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let cache = TempCache::new();
+        let bytes = source(42);
+        let key = Hash::generate(&bytes);
+        cache.write_source(key, &bytes);
+        let path = source_path(&cache.0, key);
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o0)).unwrap();
+        // A privileged test runner may bypass Unix file permissions.
+        if File::open(&path).is_ok() {
+            return;
+        }
+        let store = Store::default();
+        for error in [
+            load_module_key(&cache.0, &store, key).unwrap_err(),
+            load_module(&cache.0, &store, &bytes).unwrap_err(),
+            get_all_keys_from_fs(&cache.0).unwrap_err(),
+        ] {
+            assert_eq!(
+                error.downcast_ref::<io::Error>().unwrap().kind(),
+                io::ErrorKind::PermissionDenied
+            );
+        }
+    }
 }


### PR DESCRIPTION
WASM modules could loop indefinitely during start or exported calls, grow memory and tables without host caps, and recursively create more modules. Disk-cache loads could also deserialize native executables outside the current compiler policy. This change bounds guest execution before instantiation and recompiles authenticated WASM source on every load.

- Apply cumulative instruction fuel and size-based bulk-operation charges; cap each instance at 64 MiB of accessible memory and 65,536 table elements, and disable threads/atomic waits.
- Share a 64-attempt allowance and eight-level depth limit across nested modules. Trap recursive allocator callbacks and validate emulator responses returned to guests.
- Store binary sources with a 128 MiB size limit and verified content hashes. Preserve corruption/I/O errors; ignore legacy native caches. Reload original `.wasm` files to repopulate the cache with unchanged content keys.
- Document the fixed limits, handle/fresh-clone lifecycle, cache migration, and remaining native compilation, process-memory and external-service limits. Skip Cranelift optimization passes to reduce source-compilation latency. The smoke test allows 180 seconds per CLI request, including native compilation, and logs command timings; the cross-module request compiles three Rust modules and exceeded the old 60-second CI allowance.

Validation: 125 native tests pass (eight existing ignored doctests), including 30 new hostile-guest/cache/resource regressions. The four inscription-plugin tests also pass. All WASM examples build; the real CLI smoke passes direct and cross-module compilation, inscription compilation and mock binding. Feature checks, formatting, Clippy and API documentation are included in the full native check script. The signing regression reproduces PSBT tampering before the fix.

These limits apply to guest execution. They do not establish a process memory cap, compilation deadline, chain/backend capability check, or contract audit.
