### PR TITLE
Bound emulator requests and clean up server connections

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -34,7 +34,8 @@ A Sapio Config file (on linux at `~/.config/sapio-cli/config.json`) is a valid J
           "ctv.d31373.org:8367"
         ]
       ],
-      "threshold": 1
+      "threshold": 1,
+      "request_timeout_secs": 30
     },
     "plugin_map": {
       "example": "95db1a828dd1c9ab18d431eda9f99af46b9913e818277278a60708012f1d41b3"
@@ -54,6 +55,34 @@ CheckTemplateVerify-like functionality. You can replace emulators with your
 own servers (which can be started via the CLI), and you can set up emulation
 to work with an arbitrary M of N of your choice. Note that this may create
 issues with script lengths. You can read more about the emulator in [ctv_emulators](../ctv_emulators/README.md).
+
+`request_timeout_secs` defaults to 30. Resolving the complete peer list has one
+deadline; each peer signing request has a separate deadline covering the wait
+for a previous request, connecting, and the complete exchange. A federation
+contacts peers sequentially, so its total duration can span multiple deadlines.
+The threshold must be between one and the number of peers.
+Failed or interrupted exchanges close the
+connection so that the next request can reconnect.
+The DNS deadline stops the async wait; blocking system resolver work can
+continue and delay process shutdown.
+
+Run your own emulator with a seed file and a listening address:
+
+```sh
+sapio-cli --config config.json emulator server seed.bin 127.0.0.1:8367 \
+  --request-timeout-secs 30 --max-connections 64
+```
+
+Both limits must be positive. They default to 30 seconds per request and 64
+admitted connections. Idle connections expire under the same deadline; partial
+progress does not restart it. At capacity, new connections wait in the operating
+system's backlog. These limits bound I/O waits and admitted connections, not
+synchronous signing CPU time.
+
+The server prints one JSON readiness record after binding, including the actual
+address, public key and limits. Port `0` requests an automatically assigned port.
+Starting a server does not resolve the configured remote emulator peers. The
+old `--sync` debug mode has been removed.
 
 The plugin_map parameter is used to map human readable names to keys for a
 plugin (you can see a plugin's key with the `cli contract load` command).

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -17,12 +17,15 @@ use schemars::JsonSchema;
 use serde::*;
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
-use std::net::ToSocketAddrs;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
-use tokio::sync::Mutex;
-use tokio::{io::BufReader, runtime::Handle};
+use std::time::Duration;
+use tokio::io::BufReader;
+
+#[cfg(test)]
+mod tests;
+
 /// EmulatorConfig is used to determine how this sapio-cli instance should stub
 /// out CTV. Emulators are specified by EPK and interface address. Threshold
 /// should be <= emulators.len().
@@ -36,51 +39,54 @@ pub struct EmulatorConfig {
     pub emulators: Vec<(ExtendedPubKey, String)>,
     /// threshold could be larger than u8, but that seems very unlikely/an error.
     pub threshold: u8,
+    /// Elapsed seconds allowed for configuration resolution and each signing
+    /// request, including time waiting for this connection's previous request.
+    #[serde(default = "default_request_timeout_secs")]
+    pub request_timeout_secs: u64,
+}
+
+fn default_request_timeout_secs() -> u64 {
+    emulator_connect::DEFAULT_REQUEST_TIMEOUT.as_secs()
 }
 
 impl EmulatorConfig {
-    /// Converts a config instance into an emulator trait object. Intenrally, we
-    /// are using a Federated Emulator Connection if emulators.len() > 1, or a
-    /// bare HDOracleEmulatorConnection if emulators.len() == 1
-    pub fn get_emulator(&self) -> Result<Arc<dyn CTVEmulator>, Box<dyn std::error::Error>> {
-        if self.emulators.len() < self.threshold as usize {
-            Err(String::from("Too High Thresh"))?;
-        } else if self.emulators.is_empty() {
-            Err(String::from("No Emulators Provided"))?;
+    /// Resolve the configured peers without opening signing connections.
+    /// Waiting for resolution has one deadline across the whole configuration.
+    /// The system's blocking DNS work can outlive this wait and delay shutdown.
+    pub async fn get_emulator(&self) -> Result<Arc<dyn CTVEmulator>, Box<dyn std::error::Error>> {
+        if self.threshold == 0 || usize::from(self.threshold) > self.emulators.len() {
+            return Err(
+                "Emulator threshold must be positive and no greater than the peer count".into(),
+            );
         }
-        let _n_emulators = self.emulators.len();
-        let rt = Handle::try_current()
-            .err()
-            .map(|_e| Arc::new(tokio::runtime::Runtime::new().unwrap()));
-        let secp = Arc::new(bitcoin::secp256k1::Secp256k1::new());
-        let mut it =
-            self.emulators
-                .iter()
-                .map(|(epk, host)| -> Result<_, Box<dyn std::error::Error>> {
-                    let handle = Handle::try_current().unwrap_or_else(|_e| {
-                        rt.as_ref().expect("must have own runtime").handle().clone()
-                    });
-                    Ok(HDOracleEmulatorConnection {
-                        handle,
-                        runtime: rt.clone(),
-                        connection: Mutex::new(None),
-                        reconnect: host.to_socket_addrs()?.next().unwrap(),
-                        root: *epk,
-                        secp: secp.clone(),
-                    })
-                });
-        Ok(if self.emulators.len() == 1 {
-            Arc::new(it.next().unwrap()?)
-        } else {
-            Arc::new(FederatedEmulatorConnection::new(
-                it.map(|n| -> Result<_, Box<dyn std::error::Error>> {
-                    let b: Arc<dyn CTVEmulator> = Arc::new(n?);
-                    Ok(b)
-                })
-                .collect::<Result<Vec<_>, _>>()?,
-                self.threshold,
-            ))
+        let timeout = Duration::from_secs(self.request_timeout_secs);
+        let deadline = tokio::time::Instant::now()
+            .checked_add(timeout)
+            .filter(|_| !timeout.is_zero())
+            .ok_or("Emulator request timeout must be positive and representable")?;
+        tokio::time::timeout_at(deadline, async {
+            let secp = Arc::new(bitcoin::secp256k1::Secp256k1::new());
+            let mut peers: Vec<Arc<dyn CTVEmulator>> = Vec::with_capacity(self.emulators.len());
+            for (root, host) in &self.emulators {
+                peers.push(Arc::new(
+                    HDOracleEmulatorConnection::new(host.as_str(), *root, None, secp.clone())
+                        .await?
+                        .with_request_timeout(timeout)?,
+                ));
+            }
+            Ok(if peers.len() == 1 {
+                peers.pop().expect("one peer")
+            } else {
+                Arc::new(FederatedEmulatorConnection::new(peers, self.threshold))
+            })
         })
+        .await
+        .map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "Emulator configuration resolution timed out",
+            )
+        })?
     }
 }
 
@@ -437,6 +443,7 @@ impl ConfigVerifier {
             emulator_nodes: Some(EmulatorConfig{
                 enabled: false,
                 threshold: 1u8,
+                request_timeout_secs: default_request_timeout_secs(),
                 emulators: vec![(ExtendedPubKey::from_str("tpubD6NzVbkrYhZ4Wf398td3H8YhWBsXx9Sxa4W3cQWkNW3N3DHSNB2qtPoUMXrA6JNaPxodQfRpoZNE5tGM9iZ4xfUEFRJEJvfs8W5paUagYCE").unwrap(),
                     "example.please.change.this.before.using:8367".into())],
             }),
@@ -484,6 +491,7 @@ impl std::default::Default for ConfigVerifier {
             emulator_nodes: Some(EmulatorConfig{
                 enabled: true,
                 threshold: 1u8,
+                request_timeout_secs: default_request_timeout_secs(),
                 emulators: vec![(ExtendedPubKey::from_str("tpubD6NzVbkrYhZ4Wf398td3H8YhWBsXx9Sxa4W3cQWkNW3N3DHSNB2qtPoUMXrA6JNaPxodQfRpoZNE5tGM9iZ4xfUEFRJEJvfs8W5paUagYCE").unwrap(),
                     "ctv.d31373.org:8367".into())],
             }),

--- a/cli/src/config/tests.rs
+++ b/cli/src/config/tests.rs
@@ -1,0 +1,68 @@
+use super::*;
+
+fn emulator_config() -> EmulatorConfig {
+    serde_json::from_value(
+        serde_json::from_str::<serde_json::Value>(include_str!(
+            "../../../contrib/vectors/basic_config.json"
+        ))
+        .unwrap()["regtest"]["emulator_nodes"]
+            .clone(),
+    )
+    .unwrap()
+}
+
+#[tokio::test]
+async fn numeric_peers_resolve_without_opening_a_connection() {
+    let mut config = emulator_config();
+    assert_eq!(config.request_timeout_secs, 30);
+    config.emulators[0].1 = "127.0.0.1:0".into();
+    let emulator = config.get_emulator().await.unwrap();
+    let hash = bitcoin::hashes::Hash::from_slice(&[7; 32]).unwrap();
+    assert!(emulator.get_signer_for(hash).is_ok());
+    let root = ExtendedPubKey::from_priv(
+        &bitcoin::secp256k1::Secp256k1::new(),
+        &bitcoin::util::bip32::ExtendedPrivKey::new_master(bitcoin::Network::Regtest, &[8; 32])
+            .unwrap(),
+    );
+    config.emulators.push((root, "127.0.0.1:0".into()));
+    config.threshold = 2;
+    assert!(config
+        .get_emulator()
+        .await
+        .unwrap()
+        .get_signer_for(hash)
+        .is_ok());
+}
+
+#[tokio::test]
+async fn invalid_thresholds_and_timeouts_fail_before_resolving_peers() {
+    let original = emulator_config();
+    for threshold in [0, 2] {
+        let mut config = original.clone();
+        config.threshold = threshold;
+        let error = config.get_emulator().await.err().unwrap().to_string();
+        assert!(error.contains("threshold"), "{error}");
+    }
+    let mut empty = original.clone();
+    empty.emulators.clear();
+    assert!(empty
+        .get_emulator()
+        .await
+        .err()
+        .unwrap()
+        .to_string()
+        .contains("threshold"));
+    for request_timeout_secs in [0, u64::MAX] {
+        let mut config = original.clone();
+        config.request_timeout_secs = request_timeout_secs;
+        let error = config.get_emulator().await.err().unwrap().to_string();
+        assert!(error.contains("timeout"), "{error}");
+    }
+}
+
+#[tokio::test]
+async fn malformed_peer_addresses_return_errors() {
+    let mut config = emulator_config();
+    config.emulators[0].1 = "address-without-a-port".into();
+    assert!(config.get_emulator().await.is_err());
+}

--- a/cli/src/contracts/request.rs
+++ b/cli/src/contracts/request.rs
@@ -151,7 +151,7 @@ impl Request {
     async fn get_emulator(&self) -> ResultT<Arc<dyn CTVEmulator>> {
         let emulator: Arc<dyn CTVEmulator> = if let Some(emcfg) = &self.context.emulator {
             if emcfg.enabled {
-                emcfg.get_emulator()?
+                emcfg.get_emulator().await?
             } else {
                 Arc::new(CTVAvailable)
             }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -125,7 +125,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
      )
      (@subcommand server =>
       (about: "run an emulation server")
-      (@arg sync: --sync  "Run in Synchronous mode")
+      (@arg request_timeout_secs: --("request-timeout-secs") +takes_value "Whole-request I/O deadline in seconds (default: 30)")
+      (@arg max_connections: --("max-connections") +takes_value "Maximum admitted connections (default: 64)")
       (@arg seed: +takes_value +required {check_file} "The file containing the Seed")
       (@arg interface: +required +takes_value "The Interface to Bind")
      )
@@ -287,65 +288,58 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             _ => unreachable!(),
         },
-        Some(("emulator", sign_matches)) => {
-            let config = config(custom_config).await?;
-            let emulator: Arc<dyn CTVEmulator> = if let Some(emcfg) = &config.active.emulator_nodes
-            {
-                if emcfg.enabled {
-                    emcfg.get_emulator()?
-                } else {
-                    Arc::new(CTVAvailable)
-                }
-            } else {
-                Arc::new(CTVAvailable)
-            };
-            // TODO: is this still required to drop the emulator from a unique thread?
-            {
-                let mut emulator = emulator.clone();
-                // Drop Emulator from own thread...
-                std::thread::spawn(move || loop {
-                    if Arc::get_mut(&mut emulator).is_some() {
-                        break;
-                    }
-                });
+        Some(("emulator", sign_matches)) => match sign_matches.subcommand() {
+            Some(("sign", args)) => {
+                let emulator = configured_emulator(custom_config).await?;
+                let psbt = decode_psbt_file(args, "psbt")?;
+                let psbt = emulator.sign(psbt)?;
+                let bytes = serialize(&psbt);
+                std::fs::write(args.value_of_os("out").unwrap(), &base64::encode(bytes))?;
             }
-            match sign_matches.subcommand() {
-                Some(("sign", args)) => {
-                    let psbt = decode_psbt_file(args, "psbt")?;
-                    let psbt = emulator.sign(psbt)?;
-                    let bytes = serialize(&psbt);
-                    std::fs::write(args.value_of_os("out").unwrap(), &base64::encode(bytes))?;
-                }
-                Some(("get_key", args)) => {
-                    let psbt = decode_psbt_file(args, "psbt")?;
-                    let h = emulator.get_signer_for(psbt.extract_tx().get_ctv_hash(0))?;
-                    println!("{}", h);
-                }
-                Some(("show", args)) => {
-                    let psbt = decode_psbt_file(args, "psbt")?;
-                    println!("{:?}", psbt);
-                }
-                Some(("server", args)) => {
-                    let filename = args.value_of("seed").unwrap();
-                    let contents = tokio::fs::read(filename).await?;
+            Some(("get_key", args)) => {
+                let emulator = configured_emulator(custom_config).await?;
+                let psbt = decode_psbt_file(args, "psbt")?;
+                let h = emulator.get_signer_for(psbt.extract_tx().get_ctv_hash(0))?;
+                println!("{}", h);
+            }
+            Some(("show", args)) => {
+                let psbt = decode_psbt_file(args, "psbt")?;
+                println!("{:?}", psbt);
+            }
+            Some(("server", args)) => {
+                let config = config(custom_config).await?;
+                let filename = args.value_of("seed").unwrap();
+                let contents = tokio::fs::read(filename).await?;
 
-                    let root = ExtendedPrivKey::new_master(config.network, &contents[..]).unwrap();
-                    let pk_root = ExtendedPubKey::from_priv(&Secp256k1::new(), &root);
-                    let sync_mode = args.is_present("sync");
-                    let oracle = HDOracleEmulator::new(root, sync_mode);
-                    let interface = args.value_of("interface").unwrap();
-                    let server = oracle.bind(interface);
-                    let status = serde_json::json! {{
-                        "interface": interface,
-                        "pk": pk_root,
-                        "sync": sync_mode,
-                    }};
-                    println!("{}", serde_json::to_string_pretty(&status).unwrap());
-                    server.await?;
-                }
-                _ => unreachable!(),
+                let root = ExtendedPrivKey::new_master(config.network, &contents)?;
+                let pk_root = ExtendedPubKey::from_priv(&Secp256k1::new(), &root);
+                let timeout_secs = args
+                    .value_of("request_timeout_secs")
+                    .map(str::parse::<u64>)
+                    .transpose()?
+                    .unwrap_or(emulator_connect::DEFAULT_REQUEST_TIMEOUT.as_secs());
+                let max_connections = args
+                    .value_of("max_connections")
+                    .map(str::parse::<usize>)
+                    .transpose()?
+                    .unwrap_or(64);
+                let oracle = HDOracleEmulator::new(root).with_limits(
+                    std::time::Duration::from_secs(timeout_secs),
+                    max_connections,
+                )?;
+                let listener =
+                    tokio::net::TcpListener::bind(args.value_of("interface").unwrap()).await?;
+                let status = serde_json::json!({
+                    "interface": listener.local_addr()?,
+                    "pk": pk_root,
+                    "request_timeout_secs": timeout_secs,
+                    "max_connections": max_connections,
+                });
+                println!("{}", serde_json::to_string(&status)?);
+                oracle.serve(listener).await?;
             }
-        }
+            _ => unreachable!(),
+        },
         Some(("psbt", matches)) => match matches.subcommand() {
             Some(("finalize", args)) => {
                 let psbt_str = args.value_of("psbt");
@@ -465,6 +459,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     Ok(())
+}
+
+async fn configured_emulator(
+    custom_config: Option<&str>,
+) -> Result<Arc<dyn CTVEmulator>, Box<dyn Error>> {
+    let config = config(custom_config).await?;
+    match config.active.emulator_nodes {
+        Some(emulator) if emulator.enabled => emulator.get_emulator().await,
+        _ => Ok(Arc::new(CTVAvailable)),
+    }
 }
 
 async fn run_server_stdin() -> Result<(), Box<dyn Error>> {

--- a/cli/tests/emulator_server.rs
+++ b/cli/tests/emulator_server.rs
@@ -1,0 +1,105 @@
+use serde_json::Value;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
+use tokio::net::TcpStream;
+use tokio::process::Command;
+use tokio::time::timeout;
+
+struct Fixture(PathBuf);
+
+impl Fixture {
+    fn new() -> Self {
+        let path = std::env::temp_dir().join(format!(
+            "sapio-emulator-test-{}-{}",
+            std::process::id(),
+            rand::random::<u64>()
+        ));
+        std::fs::create_dir(&path).unwrap();
+        let mut config: Value =
+            serde_json::from_str(include_str!("../../contrib/vectors/basic_config.json")).unwrap();
+        config["regtest"]["emulator_nodes"]["enabled"] = true.into();
+        config["regtest"]["emulator_nodes"]["emulators"][0][1] = "address-without-a-port".into();
+        std::fs::write(
+            path.join("config.json"),
+            serde_json::to_vec(&config).unwrap(),
+        )
+        .unwrap();
+        std::fs::write(path.join("seed"), [44; 32]).unwrap();
+        Self(path)
+    }
+
+    fn server(&self) -> Command {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_sapio-cli"));
+        command
+            .arg("--config")
+            .arg(self.0.join("config.json"))
+            .args(["emulator", "server"])
+            .arg(self.0.join("seed"))
+            .arg("127.0.0.1:0")
+            .kill_on_drop(true);
+        command
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        std::fs::remove_dir_all(&self.0).unwrap();
+    }
+}
+
+#[tokio::test]
+async fn server_binds_without_resolving_unused_peers_and_applies_limits() {
+    let fixture = Fixture::new();
+    let mut child = fixture
+        .server()
+        .args(["--request-timeout-secs", "1", "--max-connections", "1"])
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let mut output = BufReader::new(child.stdout.take().unwrap());
+    let mut line = String::new();
+    timeout(Duration::from_secs(10), output.read_line(&mut line))
+        .await
+        .unwrap()
+        .unwrap();
+    let status: Value = serde_json::from_str(&line).unwrap();
+    assert_eq!(status["request_timeout_secs"], 1);
+    assert_eq!(status["max_connections"], 1);
+    let address: std::net::SocketAddr = status["interface"].as_str().unwrap().parse().unwrap();
+    assert_ne!(address.port(), 0);
+    assert!(status["pk"].as_str().unwrap().starts_with("tpub"));
+
+    // An idle connection expires and returns its only slot for another peer.
+    for _ in 0..2 {
+        let mut stream = TcpStream::connect(address).await.unwrap();
+        assert_eq!(
+            timeout(Duration::from_secs(10), stream.read(&mut [0]))
+                .await
+                .unwrap()
+                .unwrap(),
+            0
+        );
+        assert!(child.try_wait().unwrap().is_none());
+    }
+    child.kill().await.unwrap();
+    child.wait().await.unwrap();
+}
+
+#[tokio::test]
+async fn invalid_limits_fail_without_announcing_readiness() {
+    let fixture = Fixture::new();
+    for flag in ["--request-timeout-secs", "--max-connections"] {
+        let output = timeout(
+            Duration::from_secs(10),
+            fixture.server().args([flag, "0"]).output(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert!(!output.status.success());
+        assert!(output.stdout.is_empty());
+        assert!(String::from_utf8_lossy(&output.stderr).contains("InvalidInput"));
+    }
+}

--- a/ctv_emulators/Cargo.toml
+++ b/ctv_emulators/Cargo.toml
@@ -18,6 +18,9 @@ serde = "1.0"
 serde_derive = "1.0"
 rand = "0.8.1"
 
+[dev-dependencies]
+tokio = { version = "1", features = ["test-util"] }
+
 
 [dependencies.sapio-ctv-emulator-trait]
 path = "../emulator-trait"

--- a/ctv_emulators/README.md
+++ b/ctv_emulators/README.md
@@ -9,6 +9,48 @@ This crate also defines logic for servers that want to offer emulator services.
 
 See [Sapio CLI](../cli/README.md) for how to run a server.
 
+## Connection lifecycle
+
+The default client deadline is 30 seconds for each peer's signing exchange. It
+includes waiting for that connection's previous request, connecting, sending the
+request, reading the complete response and validating that only signatures were
+added. Only a successfully validated exchange returns its socket to the cache.
+Timeout, invalid response or cancellation during an exchange discards the socket;
+the next call connects again. A request that times out while queued leaves the
+previous request's socket alone.
+
+`HDOracleEmulatorConnection::with_request_timeout` changes this allowance. The
+CLI's `emulator_nodes.request_timeout_secs` defaults to 30 and also supplies a
+separate deadline for awaiting resolution of the complete peer configuration.
+Blocking system resolver work can continue after that deadline and delay runtime
+shutdown. Library callers
+using the asynchronous connection constructor directly must bound its DNS
+resolution themselves. Federation signing visits peers sequentially, with a
+separate request deadline for each peer. A federation with N peers can therefore
+spend N times the configured allowance on peer exchanges.
+
+The server admits at most 64 live connections by default. At capacity it stops
+accepting sockets; additional clients wait in the operating system's backlog.
+Time spent in that backlog is outside the server request allowance. Each admitted
+connection has 30 seconds per request, including idle time, the complete frame
+header/body and the response write. Partial bytes do not restart the deadline.
+A successfully completed response starts a fresh allowance for the next request.
+JSON frames remain limited to one million bytes.
+
+Create a server with `HDOracleEmulator::new(root)`, and override its policy with
+`.with_limits(request_timeout, max_connections)`. Both limits must be positive
+and the timeout must fit the runtime's clock. The CLI exposes these as
+`--request-timeout-secs` and `--max-connections`. The former debug/`--sync` mode
+has been removed: a malformed request or disconnected peer closes its connection
+without terminating the listener. Completed tasks are reaped; cancelling the
+server aborts its active connection tasks. Listener failures and unexpected task
+failures are returned to the caller.
+
+These are I/O and connection-admission limits. Async timers cannot interrupt
+synchronous parsing, cryptography or response validation, and cancellation of
+running native work takes effect when it yields. They do not establish a hard
+CPU or process-memory budget for a public deployment.
+
 
 ## How it works
 
@@ -36,6 +78,14 @@ entire transaction they want to occur and send it to the emulator server.
 Without even checking to see that the key is used in the transaction, the
 server generates the template hash H' (which should equal H) and then signs,
 returning the signature to the client.
+
+The implemented signing rule derives its key from this transaction's CTV hash
+at input zero and signs with `SIGHASH_ALL`. The service does not accept an
+arbitrary derivation path or a caller-selected signing policy. This restriction
+is structural and does not depend on authenticating the requesting account.
+Operator access controls can govern service availability and privacy; they do
+not replace the covenant's key-derivation rule. Backend selection, key custody
+and deployment availability still need explicit assumptions.
 
 Before creating a contract, clients may wish to collect all possible
 signatures required to prevent an availability fault.

--- a/ctv_emulators/src/bin/main.rs
+++ b/ctv_emulators/src/bin/main.rs
@@ -5,30 +5,35 @@
 //  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use bitcoin::secp256k1::Secp256k1;
-use bitcoin::util::bip32::*;
-use emulator_connect::servers::hd::*;
+use bitcoin::util::bip32::{ExtendedPrivKey, ExtendedPubKey};
+use emulator_connect::servers::hd::HDOracleEmulator;
+use std::io::{Error, ErrorKind};
 
-use tokio::io::AsyncReadExt;
 #[tokio::main]
-async fn main() -> Result<(), std::io::Error> {
-    let filename = std::env::args().nth(1).expect("No Seed File Provided");
-    let mut file = tokio::fs::File::open(filename)
-        .await
-        .expect("File Not Found");
-    let mut contents = vec![];
-    file.read_to_end(&mut contents).await?;
-
+async fn main() -> Result<(), Error> {
+    let args: Vec<_> = std::env::args_os().skip(1).collect();
+    if args.len() == 1 && (args[0] == "--help" || args[0] == "-h") {
+        println!("Usage: emulator_server SEED_FILE LISTEN_ADDRESS");
+        return Ok(());
+    }
+    if args.len() != 2 {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            "Usage: emulator_server SEED_FILE LISTEN_ADDRESS",
+        ));
+    }
+    let contents = tokio::fs::read(&args[0]).await?;
+    let address = args[1]
+        .to_str()
+        .ok_or_else(|| Error::new(ErrorKind::InvalidInput, "Listen address must be UTF-8"))?;
     let root =
-        ExtendedPrivKey::new_master(bitcoin::network::constants::Network::Regtest, &contents[..])
-            .unwrap();
-    let pk_root = ExtendedPubKey::from_private(&Secp256k1::new(), &root);
-    let oracle = HDOracleEmulator::new(root, true);
-    let server = oracle.bind(
-        std::env::args()
-            .nth(2)
-            .expect("No Interface given (e.g., 127.0.0.1:8080"),
+        ExtendedPrivKey::new_master(bitcoin::Network::Regtest, &contents).map_err(Error::other)?;
+    let public = ExtendedPubKey::from_priv(&Secp256k1::new(), &root);
+    let listener = tokio::net::TcpListener::bind(address).await?;
+    println!(
+        "Running Oracle With Key: {} on {}",
+        public,
+        listener.local_addr()?
     );
-    println!("Running Oracle With Key: {}", pk_root);
-    server.await?;
-    Ok(())
+    HDOracleEmulator::new(root).serve(listener).await
 }

--- a/ctv_emulators/src/connections/hd.rs
+++ b/ctv_emulators/src/connections/hd.rs
@@ -7,6 +7,7 @@
 //! Hierarchical Deterministic Emulator Connection
 
 use super::*;
+use std::time::Duration;
 /// HDOracleEmulatorConnection wraps a tokio runtime and a TCPStream
 /// with a key to be able to talk to an Oracle server.
 ///
@@ -28,6 +29,7 @@ pub struct HDOracleEmulatorConnection {
     pub root: ExtendedPubKey,
     /// a secp context
     pub secp: Arc<bitcoin::secp256k1::Secp256k1<bitcoin::secp256k1::All>>,
+    request_timeout: Duration,
 }
 
 impl HDOracleEmulatorConnection {
@@ -73,7 +75,49 @@ impl HDOracleEmulatorConnection {
             runtime,
             root,
             secp,
+            request_timeout: crate::DEFAULT_REQUEST_TIMEOUT,
         })
+    }
+
+    /// Set the deadline for one signing request, including waiting for another
+    /// request, connecting, and exchanging the complete response.
+    ///
+    /// The duration must be positive and representable by the runtime's clock.
+    pub fn with_request_timeout(mut self, timeout: Duration) -> Result<Self, std::io::Error> {
+        crate::validate_request_timeout(timeout)?;
+        self.request_timeout = timeout;
+        Ok(self)
+    }
+
+    async fn request(
+        &self,
+        request: PartiallySignedTransaction,
+    ) -> Result<PartiallySignedTransaction, EmulatorError> {
+        tokio::time::timeout(self.request_timeout, async {
+            let mut mconn = self.connection.lock().await;
+            // Only a fully validated exchange restores the cached connection.
+            // Timeout or caller cancellation drops a partially consumed stream.
+            let mut connection = match mconn.take() {
+                Some(connection) => connection,
+                None => TcpStream::connect(self.reconnect).await?,
+            };
+            crate::wire::write_message(
+                &mut connection,
+                &msgs::Request::SignPSBT(msgs::PSBT(request.clone())),
+            )
+            .await?;
+            let response = crate::wire::read_message::<msgs::PSBT>(&mut connection).await?;
+            sapio_ctv_emulator_trait::validate_signing_response(&request, &response.0)?;
+            *mconn = Some(connection);
+            Ok(response.0)
+        })
+        .await
+        .map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "Emulator signing request deadline exceeded",
+            )
+        })?
     }
 }
 
@@ -86,29 +130,9 @@ impl CTVEmulator for HDOracleEmulatorConnection {
         &self,
         b: PartiallySignedTransaction,
     ) -> Result<PartiallySignedTransaction, EmulatorError> {
-        let inp: Result<PartiallySignedTransaction, std::io::Error> =
-            tokio::task::block_in_place(|| {
-                self.handle.block_on(async {
-                    let mut mconn = self.connection.lock().await;
-                    // Take the socket out until a complete response is received.
-                    // A failed frame leaves the stream unusable for the next request.
-                    let mut connection = match mconn.take() {
-                        Some(connection) => connection,
-                        None => TcpStream::connect(self.reconnect).await?,
-                    };
-                    crate::wire::write_message(
-                        &mut connection,
-                        &msgs::Request::SignPSBT(msgs::PSBT(b.clone())),
-                    )
-                    .await?;
-                    let response = crate::wire::read_message::<msgs::PSBT>(&mut connection).await?;
-                    *mconn = Some(connection);
-                    Ok(response.0)
-                })
-            });
-
-        let response = inp?;
-        sapio_ctv_emulator_trait::validate_signing_response(&b, &response)?;
-        Ok(response)
+        tokio::task::block_in_place(|| self.handle.block_on(self.request(b)))
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/ctv_emulators/src/connections/hd/tests.rs
+++ b/ctv_emulators/src/connections/hd/tests.rs
@@ -1,0 +1,215 @@
+use super::*;
+use bitcoin::{Network, Script, Transaction, TxIn, TxOut};
+use std::{future::Future, io::ErrorKind, pin::Pin, task::Poll};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+const DEADLINE: Duration = Duration::from_secs(10);
+
+fn request() -> PartiallySignedTransaction {
+    PartiallySignedTransaction::from_unsigned_tx(Transaction {
+        version: 2,
+        lock_time: 0,
+        input: vec![TxIn::default()],
+        output: vec![TxOut {
+            value: 1_000,
+            script_pubkey: Script::new(),
+        }],
+    })
+    .unwrap()
+}
+
+async fn connected() -> (HDOracleEmulatorConnection, TcpListener, TcpStream) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let secp = Arc::new(Secp256k1::new());
+    let root = ExtendedPubKey::from_priv(
+        &secp,
+        &ExtendedPrivKey::new_master(Network::Regtest, &[7; 32]).unwrap(),
+    );
+    let connection = HDOracleEmulatorConnection::new(address, root, None, secp)
+        .await
+        .unwrap()
+        .with_request_timeout(DEADLINE)
+        .unwrap();
+    let (client, peer) = tokio::join!(TcpStream::connect(address), listener.accept());
+    *connection.connection.lock().await = Some(client.unwrap());
+    (connection, listener, peer.unwrap().0)
+}
+
+// Polling explicitly keeps the paused clock from advancing while establishing
+// which part of the exchange is pending on the real local socket.
+async fn assert_pending(mut future: Pin<&mut impl Future>) {
+    std::future::poll_fn(|cx| {
+        assert!(future.as_mut().poll(cx).is_pending());
+        Poll::Ready(())
+    })
+    .await;
+}
+
+fn assert_timeout(result: Result<PartiallySignedTransaction, EmulatorError>) {
+    assert!(matches!(
+        result,
+        Err(EmulatorError::NetworkIssue(error)) if error.kind() == ErrorKind::TimedOut
+    ));
+}
+
+async fn assert_closed(mut peer: TcpStream) {
+    tokio::time::timeout(Duration::from_secs(2), async {
+        let _: msgs::Request = crate::wire::read_message(&mut peer).await.unwrap();
+        assert_eq!(peer.read(&mut [0]).await.unwrap(), 0);
+    })
+    .await
+    .unwrap();
+}
+
+async fn assert_reconnect(connection: &HDOracleEmulatorConnection, listener: TcpListener) {
+    tokio::time::timeout(Duration::from_secs(2), async {
+        let peer = async {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            for _ in 0..2 {
+                let msgs::Request::SignPSBT(response) =
+                    crate::wire::read_message(&mut stream).await.unwrap();
+                crate::wire::write_message(&mut stream, &response)
+                    .await
+                    .unwrap();
+            }
+        };
+        let requests = async {
+            for _ in 0..2 {
+                assert_eq!(connection.request(request()).await.unwrap(), request());
+            }
+        };
+        tokio::join!(peer, requests);
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn stalled_response_header_and_body_expire_and_reconnect() {
+    for prefix in [vec![], vec![0, 0], vec![0, 0, 0, 100, b'{']] {
+        let (connection, listener, mut peer) = connected().await;
+        if !prefix.is_empty() {
+            peer.write_all(&prefix).await.unwrap();
+            connection
+                .connection
+                .lock()
+                .await
+                .as_ref()
+                .unwrap()
+                .readable()
+                .await
+                .unwrap();
+        }
+        tokio::time::pause();
+        let mut exchange = Box::pin(connection.request(request()));
+        assert_pending(exchange.as_mut()).await;
+        tokio::time::advance(DEADLINE).await;
+        assert_timeout(exchange.await);
+        assert!(connection.connection.try_lock().unwrap().is_none());
+        tokio::time::resume();
+        assert_closed(peer).await;
+        assert_reconnect(&connection, listener).await;
+    }
+}
+
+#[tokio::test]
+async fn queue_wait_consumes_the_same_deadline_as_the_exchange() {
+    let (connection, _, peer) = connected().await;
+    let queued_behind = connection.connection.lock().await;
+    tokio::time::pause();
+    let mut exchange = Box::pin(connection.request(request()));
+    assert_pending(exchange.as_mut()).await;
+    tokio::time::advance(Duration::from_secs(6)).await;
+    assert_pending(exchange.as_mut()).await;
+    drop(queued_behind);
+    assert_pending(exchange.as_mut()).await;
+    tokio::time::advance(Duration::from_secs(4)).await;
+    assert_timeout(exchange.await);
+    assert!(connection.connection.try_lock().unwrap().is_none());
+    tokio::time::resume();
+    assert_closed(peer).await;
+}
+
+#[tokio::test]
+async fn queued_timeout_preserves_the_socket_owned_by_the_previous_request() {
+    let (connection, _, _) = connected().await;
+    let queued_behind = connection.connection.lock().await;
+    tokio::time::pause();
+    let mut exchange = Box::pin(connection.request(request()));
+    assert_pending(exchange.as_mut()).await;
+    tokio::time::advance(DEADLINE).await;
+    assert_timeout(exchange.await);
+    assert!(queued_behind.is_some());
+}
+
+#[tokio::test]
+async fn response_trickle_does_not_restart_the_deadline() {
+    let (connection, _, mut peer) = connected().await;
+    peer.write_u32(100).await.unwrap();
+    connection
+        .connection
+        .lock()
+        .await
+        .as_ref()
+        .unwrap()
+        .readable()
+        .await
+        .unwrap();
+    tokio::time::pause();
+    let mut exchange = Box::pin(connection.request(request()));
+    assert_pending(exchange.as_mut()).await;
+    for _ in 0..2 {
+        tokio::time::advance(Duration::from_secs(4)).await;
+        peer.write_all(b" ").await.unwrap();
+        tokio::task::yield_now().await;
+        assert_pending(exchange.as_mut()).await;
+    }
+    tokio::time::advance(Duration::from_secs(2)).await;
+    assert_timeout(exchange.await);
+    assert!(connection.connection.try_lock().unwrap().is_none());
+    tokio::time::resume();
+    assert_closed(peer).await;
+}
+
+#[tokio::test]
+async fn cancellation_discards_an_inflight_socket_and_allows_reconnect() {
+    let (connection, listener, peer) = connected().await;
+    let mut exchange = Box::pin(connection.request(request()));
+    assert_pending(exchange.as_mut()).await;
+    drop(exchange);
+    assert!(connection.connection.try_lock().unwrap().is_none());
+    assert_closed(peer).await;
+    assert_reconnect(&connection, listener).await;
+}
+
+#[tokio::test]
+async fn invalid_response_discards_the_socket_before_reconnecting() {
+    let (connection, listener, mut peer) = connected().await;
+    let mut changed = request();
+    changed.unsigned_tx.output[0].value -= 1;
+    crate::wire::write_message(&mut peer, &msgs::PSBT(changed))
+        .await
+        .unwrap();
+    assert!(matches!(
+        connection.request(request()).await,
+        Err(EmulatorError::InvalidResponse)
+    ));
+    assert!(connection.connection.try_lock().unwrap().is_none());
+    assert_closed(peer).await;
+    assert_reconnect(&connection, listener).await;
+}
+
+#[tokio::test]
+async fn timeout_configuration_rejects_zero_and_unrepresentable_durations() {
+    let (connection, _, _) = connected().await;
+    assert!(matches!(
+        connection.with_request_timeout(Duration::ZERO),
+        Err(error) if error.kind() == ErrorKind::InvalidInput
+    ));
+    let (connection, _, _) = connected().await;
+    assert!(matches!(
+        connection.with_request_timeout(Duration::MAX),
+        Err(error) if error.kind() == ErrorKind::InvalidInput
+    ));
+}

--- a/ctv_emulators/src/lib.rs
+++ b/ctv_emulators/src/lib.rs
@@ -13,6 +13,19 @@ use bitcoin::util::bip32::*;
 use sapio_ctv_emulator_trait::Clause;
 pub use sapio_ctv_emulator_trait::{CTVAvailable, CTVEmulator, EmulatorError, NullEmulator};
 
+/// Default elapsed I/O allowance for one emulator request, including queued
+/// client calls and idle server connections. This is not a CPU execution limit.
+pub const DEFAULT_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+pub(crate) fn validate_request_timeout(timeout: std::time::Duration) -> std::io::Result<()> {
+    if timeout.is_zero() || tokio::time::Instant::now().checked_add(timeout).is_none() {
+        return Err(input_err(
+            "Emulator request timeout must be positive and representable",
+        ));
+    }
+    Ok(())
+}
+
 use std::net::SocketAddr;
 use tokio::net::{TcpListener, TcpStream, ToSocketAddrs};
 

--- a/ctv_emulators/src/servers/hd.rs
+++ b/ctv_emulators/src/servers/hd.rs
@@ -13,26 +13,52 @@ use bitcoin::SchnorrSig;
 use bitcoin::Script;
 use bitcoin::TxOut;
 use bitcoin::XOnlyPublicKey;
+use std::io::{Error as IoError, ErrorKind};
+use std::time::Duration;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::task::JoinSet;
 
 /// hierarchical deterministic oracle emulator
 #[derive(Clone)]
 pub struct HDOracleEmulator {
     root: ExtendedPrivKey,
-    debug: bool,
+    request_timeout: Duration,
+    max_connections: usize,
 }
 
 impl HDOracleEmulator {
-    /// create a new HDOracleEmulator
+    /// Create an oracle with a 30-second request timeout and 64 connections.
     ///
-    /// if debug is set, runs in a "single threaded" mode where we can observe errors on connections rather than ignoring them.
-    pub fn new(root: ExtendedPrivKey, debug: bool) -> Self {
-        HDOracleEmulator { root, debug }
+    /// Idle connections consume a slot and must send their next complete
+    /// request within the request timeout.
+    pub fn new(root: ExtendedPrivKey) -> Self {
+        HDOracleEmulator {
+            root,
+            request_timeout: crate::DEFAULT_REQUEST_TIMEOUT,
+            max_connections: 64,
+        }
     }
-    /// binds a HDOracleEmulator to a socket interface and runs the server
+
+    /// Override the request timeout and maximum number of live connections.
     ///
-    /// This will only return when debug = false if The TcpListener fails.
-    /// When debug = true, then we join each connection one at a time and return
-    /// any errors.
+    /// Both limits must be nonzero and the timeout must fit a timer deadline.
+    /// Each timeout covers an entire request, including its response, and is
+    /// not extended by partial progress.
+    pub fn with_limits(
+        mut self,
+        request_timeout: Duration,
+        max_connections: usize,
+    ) -> Result<Self, IoError> {
+        crate::validate_request_timeout(request_timeout)?;
+        if max_connections == 0 {
+            return Err(input_err("Oracle connection limit must be nonzero"));
+        }
+        self.request_timeout = request_timeout;
+        self.max_connections = max_connections;
+        Ok(self)
+    }
+
+    /// Bind an oracle to a socket interface and run the server.
     pub async fn bind<A: ToSocketAddrs>(self, a: A) -> std::io::Result<()> {
         let listener = TcpListener::bind(a).await?;
         self.serve(listener).await
@@ -40,22 +66,38 @@ impl HDOracleEmulator {
 
     /// Serve an already bound listener, allowing callers to establish readiness
     /// and discover an automatically assigned port before starting clients.
+    ///
+    /// At capacity, new connections wait in the operating system's backlog.
+    /// Peer errors close only that connection; listener errors and unexpected
+    /// task failures stop the service. Cancelling this future aborts its active
+    /// connections rather than leaving detached signing tasks behind.
     pub async fn serve(self, listener: TcpListener) -> std::io::Result<()> {
+        let mut connections = JoinSet::new();
         loop {
-            let (mut socket, _) = listener.accept().await?;
-            {
-                let this = self.clone();
-                let j: tokio::task::JoinHandle<Result<(), std::io::Error>> =
-                    tokio::spawn(async move {
-                        loop {
-                            socket.readable().await?;
-                            this.handle(&mut socket).await?;
-                        }
-                    });
-                if self.debug {
-                    tokio::join!(j).0??;
+            tokio::select! {
+                completed = connections.join_next(), if !connections.is_empty() => {
+                    // Malformed requests, EOF and timeouts belong to the peer.
+                    // A task panic is an unexpected service failure.
+                    let _peer_result = completed.expect("A connection task is present")
+                        .map_err(IoError::other)?;
+                }
+                accepted = listener.accept(), if connections.len() < self.max_connections => {
+                    let (socket, _) = accepted?;
+                    let this = self.clone();
+                    connections.spawn(async move { this.serve_connection(socket).await });
                 }
             }
+        }
+    }
+
+    async fn serve_connection(
+        &self,
+        mut stream: impl AsyncRead + AsyncWrite + Unpin,
+    ) -> Result<(), IoError> {
+        loop {
+            tokio::time::timeout(self.request_timeout, self.handle(&mut stream))
+                .await
+                .map_err(|_| IoError::new(ErrorKind::TimedOut, "Oracle request timed out"))??;
         }
     }
     /// helper to get an EPK for the oracle.
@@ -140,7 +182,10 @@ impl HDOracleEmulator {
     /// the main server business logic.
     ///
     /// - on receiving Request::SignPSBT, signs the PSBT.
-    async fn handle(&self, t: &mut TcpStream) -> Result<(), std::io::Error> {
+    async fn handle(
+        &self,
+        t: &mut (impl AsyncRead + AsyncWrite + Unpin),
+    ) -> Result<(), std::io::Error> {
         let request = crate::wire::read_message(t).await?;
         match request {
             msgs::Request::SignPSBT(msgs::PSBT(unsigned)) => {
@@ -161,7 +206,7 @@ mod tests {
     fn rejects_psbts_without_an_input_to_sign() {
         let secp = Secp256k1::new();
         let root = ExtendedPrivKey::new_master(bitcoin::Network::Regtest, &[44; 32]).unwrap();
-        let oracle = HDOracleEmulator::new(root, false);
+        let oracle = HDOracleEmulator::new(root);
         let psbt = PartiallySignedTransaction::from_unsigned_tx(bitcoin::Transaction {
             version: 2,
             lock_time: 0,
@@ -179,7 +224,7 @@ mod tests {
     fn signing_adds_both_taproot_signature_forms_without_replacing_existing_entries() {
         let secp = Secp256k1::new();
         let root = ExtendedPrivKey::new_master(bitcoin::Network::Regtest, &[44; 32]).unwrap();
-        let oracle = HDOracleEmulator::new(root, false);
+        let oracle = HDOracleEmulator::new(root);
         let mut request = PartiallySignedTransaction::from_unsigned_tx(bitcoin::Transaction {
             version: 2,
             lock_time: 0,
@@ -228,3 +273,6 @@ mod tests {
         assert_eq!(repeated, existing);
     }
 }
+
+#[cfg(test)]
+mod lifecycle_tests;

--- a/ctv_emulators/src/servers/hd/lifecycle_tests.rs
+++ b/ctv_emulators/src/servers/hd/lifecycle_tests.rs
@@ -1,0 +1,207 @@
+use super::*;
+use crate::{msgs, wire};
+use bitcoin::{Network, Transaction, TxIn};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio::task::JoinHandle;
+use tokio::time::{advance, timeout};
+
+fn oracle() -> HDOracleEmulator {
+    HDOracleEmulator::new(ExtendedPrivKey::new_master(Network::Regtest, &[17; 32]).unwrap())
+}
+
+fn request() -> PartiallySignedTransaction {
+    let mut psbt = PartiallySignedTransaction::from_unsigned_tx(Transaction {
+        version: 2,
+        lock_time: 0,
+        input: vec![TxIn::default()],
+        output: vec![TxOut {
+            value: 9_000,
+            script_pubkey: Script::new(),
+        }],
+    })
+    .unwrap();
+    let secp = Secp256k1::new();
+    let key = oracle()
+        .derive(psbt.unsigned_tx.get_ctv_hash(0), &secp)
+        .unwrap()
+        .to_keypair(&secp)
+        .x_only_public_key()
+        .0;
+    psbt.inputs[0].witness_utxo = Some(TxOut {
+        value: 10_000,
+        script_pubkey: Script::new_v1_p2tr(&secp, key, None),
+    });
+    psbt
+}
+
+async fn send_request(stream: &mut (impl AsyncRead + AsyncWrite + Unpin)) {
+    wire::write_message(stream, &msgs::Request::SignPSBT(msgs::PSBT(request())))
+        .await
+        .unwrap();
+}
+
+async fn read_response(stream: &mut (impl AsyncRead + AsyncWrite + Unpin)) {
+    let response = wire::read_message::<msgs::PSBT>(stream).await.unwrap().0;
+    sapio_ctv_emulator_trait::validate_signing_response(&request(), &response).unwrap();
+    assert!(response.inputs[0].tap_key_sig.is_some());
+}
+
+async fn start_server(max_connections: usize) -> (SocketAddr, JoinHandle<std::io::Result<()>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = oracle()
+        .with_limits(Duration::from_secs(60), max_connections)
+        .unwrap();
+    (address, tokio::spawn(server.serve(listener)))
+}
+
+async fn stop_server(server: JoinHandle<std::io::Result<()>>) {
+    server.abort();
+    assert!(server.await.unwrap_err().is_cancelled());
+}
+
+#[test]
+fn rejects_limits_that_disable_progress() {
+    for duration in [Duration::ZERO, Duration::MAX] {
+        assert!(matches!(
+            oracle().with_limits(duration, 1),
+            Err(error) if error.kind() == ErrorKind::InvalidInput
+        ));
+    }
+    assert!(matches!(
+        oracle().with_limits(Duration::from_secs(1), 0),
+        Err(error) if error.kind() == ErrorKind::InvalidInput
+    ));
+}
+
+#[tokio::test(start_paused = true)]
+async fn idle_partial_headers_and_partial_bodies_expire() {
+    for partial_request in [vec![], vec![0], vec![0, 0, 0, 16, b'{']] {
+        let (mut client, stream) = tokio::io::duplex(64);
+        let server = oracle().with_limits(Duration::from_secs(5), 1).unwrap();
+        let connection = tokio::spawn(async move { server.serve_connection(stream).await });
+        client.write_all(&partial_request).await.unwrap();
+        tokio::task::yield_now().await;
+        advance(Duration::from_secs(5)).await;
+        assert_eq!(
+            connection.await.unwrap().unwrap_err().kind(),
+            ErrorKind::TimedOut
+        );
+        assert_eq!(client.read(&mut [0]).await.unwrap(), 0);
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn partial_progress_does_not_restart_the_deadline() {
+    let (mut client, stream) = tokio::io::duplex(64);
+    let server = oracle().with_limits(Duration::from_secs(5), 1).unwrap();
+    let connection = tokio::spawn(async move { server.serve_connection(stream).await });
+    client.write_u32(16).await.unwrap();
+    tokio::task::yield_now().await;
+    for _ in 0..4 {
+        advance(Duration::from_secs(1)).await;
+        client.write_u8(b' ').await.unwrap();
+        tokio::task::yield_now().await;
+        assert!(!connection.is_finished());
+    }
+    advance(Duration::from_secs(1)).await;
+    assert_eq!(
+        connection.await.unwrap().unwrap_err().kind(),
+        ErrorKind::TimedOut
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn a_peer_that_does_not_read_its_response_expires() {
+    let (mut client, stream) = tokio::io::duplex(64);
+    let server = oracle().with_limits(Duration::from_secs(5), 1).unwrap();
+    let connection = tokio::spawn(async move { server.serve_connection(stream).await });
+    send_request(&mut client).await;
+    tokio::task::yield_now().await;
+    advance(Duration::from_secs(5)).await;
+    assert_eq!(
+        connection.await.unwrap().unwrap_err().kind(),
+        ErrorKind::TimedOut
+    );
+    let mut partial_response = vec![];
+    client.read_to_end(&mut partial_response).await.unwrap();
+    assert_eq!(partial_response.len(), 64);
+}
+
+#[tokio::test(start_paused = true)]
+async fn a_completed_request_starts_a_fresh_deadline() {
+    let (mut client, stream) = tokio::io::duplex(4_096);
+    let server = oracle().with_limits(Duration::from_secs(5), 1).unwrap();
+    let connection = tokio::spawn(async move { server.serve_connection(stream).await });
+    tokio::task::yield_now().await;
+    for _ in 0..2 {
+        advance(Duration::from_secs(4)).await;
+        send_request(&mut client).await;
+        read_response(&mut client).await;
+        assert!(!connection.is_finished());
+    }
+    advance(Duration::from_secs(5)).await;
+    assert_eq!(
+        connection.await.unwrap().unwrap_err().kind(),
+        ErrorKind::TimedOut
+    );
+}
+
+#[tokio::test]
+async fn peer_errors_do_not_stop_the_listener() {
+    let (address, server) = start_server(1).await;
+    for invalid_frame in [vec![], vec![0, 0, 0, 0], vec![0, 0, 0, 1, b'!']] {
+        let mut bad = TcpStream::connect(address).await.unwrap();
+        bad.write_all(&invalid_frame).await.unwrap();
+        drop(bad);
+        let mut healthy = TcpStream::connect(address).await.unwrap();
+        send_request(&mut healthy).await;
+        timeout(Duration::from_secs(2), read_response(&mut healthy))
+            .await
+            .unwrap();
+        assert!(!server.is_finished());
+    }
+    stop_server(server).await;
+}
+
+#[tokio::test]
+async fn capacity_is_reused_after_a_connection_closes() {
+    let (address, server) = start_server(1).await;
+    let mut first = TcpStream::connect(address).await.unwrap();
+    send_request(&mut first).await;
+    read_response(&mut first).await;
+
+    let mut waiting = TcpStream::connect(address).await.unwrap();
+    send_request(&mut waiting).await;
+    assert!(timeout(Duration::from_millis(50), waiting.peek(&mut [0]))
+        .await
+        .is_err());
+
+    drop(first);
+    timeout(Duration::from_secs(2), read_response(&mut waiting))
+        .await
+        .unwrap();
+    stop_server(server).await;
+}
+
+#[tokio::test]
+async fn cancelling_the_listener_closes_active_connections() {
+    let (address, server) = start_server(2).await;
+    let mut first = TcpStream::connect(address).await.unwrap();
+    let mut second = TcpStream::connect(address).await.unwrap();
+    for client in [&mut first, &mut second] {
+        send_request(client).await;
+        read_response(client).await;
+    }
+    stop_server(server).await;
+    for client in [&mut first, &mut second] {
+        assert_eq!(
+            timeout(Duration::from_secs(2), client.read(&mut [0]))
+                .await
+                .unwrap()
+                .unwrap(),
+            0
+        );
+    }
+}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -40,8 +40,8 @@ Run the native suite, feature checks, Clippy and API documentation build:
 bash contrib/test.sh
 ```
 
-The network integration test binds only to `127.0.0.1` on an automatically chosen
-port. A sandbox must permit loopback sockets to run it. No Bitcoin node or remote
+The network tests bind only to `127.0.0.1` on automatically chosen ports.
+A sandbox must permit loopback sockets to run them. No Bitcoin node or remote
 emulator is required. Clippy currently reports warnings from older code; removing
 that debt is a separate milestone, not a claim that this checkout is warning-free.
 
@@ -95,6 +95,7 @@ cargo test --locked -p sapio-base --test ctv_hash
 cargo test --locked -p sapio --test fees --test action_names --test ordinal_allocation
 cargo test --locked -p sapio-wasm-plugin --features host
 cargo test --locked -p sapio_integration_tests
+cargo test --locked -p ctv_emulators --lib
 cargo test --locked --manifest-path plugin-example/Cargo.toml --workspace
 cargo fmt --all -- --check
 cargo fmt --manifest-path plugin-example/Cargo.toml --all -- --check
@@ -146,7 +147,8 @@ Invalid pointers, lengths, JSON and UTF-8 return errors or trap the guest call.
 Plugin callbacks and metadata are registered together exactly once, without
 mutable global function pointers.
 Diagnostic logs go to stderr. Emulator protocol JSON frames are bounded to one
-million bytes, and failed connections are discarded before another request.
+million bytes; [emulator service limits](#emulator-service-limits) cover request
+I/O and admitted connections.
 
 The native host validates every actual call against the module's advertised
 JSON Schemas, including calls made through raw nested-module imports. It checks
@@ -203,7 +205,8 @@ only checked signature additions, just like native signing.
 
 These are guest execution limits, not a wall-clock deadline or a process memory
 limit. Native compilation, host serialization/schema work and emulator I/O are
-outside instruction metering. Wasmer may reserve substantially more virtual
+outside instruction metering. Emulator I/O has its own request deadlines below.
+Wasmer may reserve substantially more virtual
 address space than the accessible linear-memory limit. Evaluate those costs
 before exposing compilation as a service.
 
@@ -222,6 +225,41 @@ referring to their cached keys; the content hashes remain unchanged:
 ```sh
 sapio-cli contract load --workspace PATH --file MODULE.wasm
 ```
+
+## Emulator service limits
+
+Each HD client signing exchange has a 30-second elapsed allowance by default,
+including its wait for the connection mutex, connection setup, complete framing
+and response validation. The socket is cached only after a complete response
+passes the signature-additions check. Timeout, cancellation during an exchange
+or an invalid response drops that socket; the next request reconnects. A queued
+request that times out does not disturb the preceding request's connection.
+
+The CLI's `emulator_nodes.request_timeout_secs` configures that allowance and a
+separate deadline for awaiting resolution of the whole peer configuration; it
+defaults to 30 seconds. System resolver work can continue after this async wait
+times out and delay runtime shutdown. Direct library users configure exchanges with
+`HDOracleEmulatorConnection::with_request_timeout` and must bound the
+constructor's DNS resolution themselves. A federation applies the deadline to
+each peer in its sequential signing loop. N peers can therefore consume N times
+the configured request allowance across their exchanges.
+
+`HDOracleEmulator::new(root)` admits at most 64 live connections with a 30-second
+request allowance. `with_limits(request_timeout, max_connections)` overrides
+both values. At capacity the listener stops accepting; the operating system's
+backlog wait is outside the server deadline. For an admitted connection, each
+deadline covers idle time, the complete header/body and the response write.
+Dripping bytes cannot extend it; completing a response starts the next request's
+allowance. Peer errors close only their connection. The listener owns and reaps
+its connection tasks, and cancelling it aborts the active tasks.
+
+These I/O deadlines cannot preempt synchronous signing, JSON parsing or response
+validation. Native CPU budgets, process memory and deployment-level admission
+policy remain separate work. The tests use paused time for stalled frames,
+trickled responses, queue waits and blocked writes, plus loopback sockets for
+reconnection, server admission and cancellation. See the
+[emulator guide](../ctv_emulators/README.md) for the structural signing rule and
+configuration.
 
 ## Artifact boundaries
 

--- a/docs/MODERNIZATION.md
+++ b/docs/MODERNIZATION.md
@@ -63,6 +63,7 @@ with upstream crates would remove semantics, not complete a migration.
 | Module schemas | Validate actual inputs and successful outputs at the common host boundary, including raw nested calls; use offline Draft 7 validation, guard reference expansion and remove the no-op interface check |
 | Emulator protocol | Bound both directions of framed JSON, discard failed streams, reject malformed PSBT maps, support prebound listeners |
 | Emulator responses | Accept complete PSBT responses containing only signature additions; preserve existing signatures and every other field, including raw HD responses, each federation participant and the WASM signing import |
+| Emulator lifecycle | Bound each peer exchange and the async wait for CLI peer resolution; cap admitted server connections; discard incomplete exchanges, isolate peer errors and cancel owned connection tasks on shutdown |
 | Integration | Restore the suite to the workspace; compile, sign and finalize two contract steps and reject a modified output |
 | Contract examples | [Complete inventory](EXAMPLES.md): repaired and tested library families, restored PowSwap/TapBet, 18 real WASM fixtures, both native examples and explicit research assumptions |
 | Developer checks | Formatting, feature checks, native tests, complete WASM catalog with artifact/schema/repeatability checks, CLI smoke checks, and API documentation |
@@ -118,7 +119,7 @@ Define backend capability information before adding another covenant primitive:
 | Mode | Required claim in an artifact | Required validation |
 | --- | --- | --- |
 | Native CTV research | Exact opcode semantics and intended chain/deployment | Reference hash vectors and execution against a node implementing those semantics |
-| Signer-emulated covenant | Signer identities, threshold, authorization policy and availability assumptions | Allowed transitions sign and finalize; forbidden transitions fail |
+| Signer-emulated covenant | Signer identities, threshold, structural signing rule and availability assumptions | Allowed transitions sign and finalize; forbidden transitions fail |
 | Future primitive | Precisely named capability and assumptions | Its own lowering tests and execution evidence |
 
 The current CLI does not yet enforce this artifact-level distinction. A release
@@ -155,10 +156,17 @@ This is the next release blocker, before a broad dependency migration.
 - Extend the [guest execution limits](DEVELOPMENT.md) with service-level
   compilation deadlines, process memory and concurrency policy. Guest fuel,
   memory/table caps, nested-call bounds and authenticated source caching are
-  enforced; native compilation, schema work and emulator I/O still need their
-  own bounds. Benchmark real contracts before changing the fixed allowances.
-- Review emulator request timeouts, concurrency, authentication and authorization.
-  A signature service reachable over TCP is not automatically a safe oracle.
+  enforced. Emulator I/O now has elapsed request deadlines and bounded admitted
+  connections; native compilation, schema work and cryptography still need
+  CPU and process-memory budgets. Benchmark real contracts before changing
+  the fixed allowances.
+- Establish deployment and backend policy for emulator services, including key
+  custody, availability and operator admission controls. The existing HD signing
+  rule derives a key from the transaction's input-zero CTV hash and signs with
+  `SIGHASH_ALL`; its covenant restriction is structural and does not depend on
+  authenticating a requester. The [service limits](DEVELOPMENT.md#emulator-service-limits)
+  bound I/O waiting and admitted connections, without establishing a hard CPU
+  limit or proving a public deployment's availability.
 
 Acceptance: malformed inputs fail with attributable errors; adversarial guest execution
 traps at the documented bounds; the hash, script, signing and finalization

--- a/integration_tests/tests/integration_test.rs
+++ b/integration_tests/tests/integration_test.rs
@@ -56,7 +56,7 @@ async fn compiles_signs_and_finalizes_a_two_step_contract() {
     let pk_root = ExtendedPubKey::from_priv(&secp, &root);
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let address = listener.local_addr().unwrap();
-    let server = tokio::spawn(HDOracleEmulator::new(root, false).serve(listener));
+    let server = tokio::spawn(HDOracleEmulator::new(root).serve(listener));
 
     let contract_1 = TestEmulation {
         to_contract: Compiled::from_address(


### PR DESCRIPTION
A stalled emulator peer could block signing indefinitely, and the server spawned unlimited detached connections. Apply a 30-second deadline to each peer exchange and server request, bound the server to 64 admitted connections by default, and close unfinished exchanges so later requests can reconnect.

- Include client queue waits, connection setup, framing and response validation in one deadline. Partial progress does not restart it; a timeout while queued preserves the preceding request's connection.
- Own server tasks in a bounded `JoinSet`, reap completions, isolate peer errors and abort active connections when the service is cancelled.
- Add validated Rust and CLI limit overrides. Resolve CLI peers asynchronously, remove the CPU-spinning cleanup thread and announce readiness only after binding. Server and PSBT display commands no longer resolve unused peers.
- Add 20 regression tests covering stalls, trickles, queue accounting, recovery, admission, cancellation, configuration and real CLI startup.

API changes: `HDOracleEmulator::new(root)` replaces the debug-mode constructor; `--sync` is removed. `EmulatorConfig::get_emulator` is now async; its optional `request_timeout_secs` field defaults to 30. Existing signing and response-integrity rules are preserved.

These are I/O and admission limits. Federation deadlines apply separately to each sequential peer, server backlog waiting occurs before admission, and async timers cannot preempt synchronous CPU work. The configuration deadline stops awaiting DNS; system resolver work can outlive it and delay runtime shutdown. The documentation records these limits and the remaining deployment/backend work.

Validation: full native workspace tests; focused CLI/emulator tests; payment example; plugin feature checks; workspace Clippy; formatting; API docs; mdBook. Existing repository warnings remain. GitHub CI also runs Linux/macOS native suites and the complete WASM example catalog.
