### PR TITLE
Make contract declarations strict and preserve action authorization

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -93,6 +93,8 @@ Useful focused checks:
 cargo test --locked -p sapio-psbt
 cargo test --locked -p sapio-base --test ctv_hash
 cargo test --locked -p sapio --test fees --test action_names --test ordinal_allocation
+cargo test --locked -p sapio --test conditional_compilation --test guard_semantics --test macro_declarations
+cargo test --locked -p sapio --test template_semantics --test effect_names --test inscription_guards
 cargo test --locked -p sapio-wasm-plugin --features host
 cargo test --locked -p sapio_integration_tests
 cargo test --locked -p ctv_emulators --lib
@@ -225,6 +227,21 @@ referring to their cached keys; the content hashes remain unchanged:
 ```sh
 sapio-cli contract load --workspace PATH --file MODULE.wasm
 ```
+
+## Language core
+
+The [action semantics](LANGUAGE_SEMANTICS.md) describe declarations, conditional
+compilation, guard caching, metadata, effect paths and transaction deduplication.
+Unknown macro options are errors. Cached guards now take only `self`; their
+metadata still receives each attachment's context. Multi-guard conjunctions
+retain inscription effects and use valid Miniscript arity.
+
+Each action's policy is extracted before deduplicating its transaction. Compiled
+templates retain their complete alternative preconditions. Sharing a commitment
+requires identical funding requirements, metadata and child graphs; conflicts
+report the affected field and action/effect path. Reuse a common compiled child
+and metadata when intentionally returning the same transaction from multiple
+actions.
 
 ## Emulator service limits
 

--- a/docs/LANGUAGE_SEMANTICS.md
+++ b/docs/LANGUAGE_SEMANTICS.md
@@ -1,0 +1,115 @@
+# Contract action semantics
+
+Sapio's Rust frontend declares guarded transaction transitions and continuation
+entry points. The compiler must preserve their authorization through Bitcoin
+lowering, even when several transitions produce the same transaction.
+
+## Declarations
+
+`#[then]`, `#[continuation]`, `#[guard]` and `#[compile_if]` accept only their
+documented options. Unknown names, duplicates, malformed expressions and
+unsupported method signatures are compile errors at the declaration. In
+particular, misspelling `guarded_by` or `compile_if` cannot silently remove a
+restriction. Explicit return types, method visibility and attributes survive
+expansion. The shorthand `self` receiver becomes the shared reference required
+by the callback API.
+
+The `decl_*` trait macros declare the same callback interfaces as their matching
+attributes. An optional declaration returns `None` until implemented. Qualified
+`sapio::declare!` calls work without importing the macro. Continuation schema
+helpers preserve the method's case, and raw Rust identifiers use their ordinary
+name in effect paths.
+
+## Guards and transitions
+
+For a CTV action with action guard `A`, a returned template with additional guard
+`T` contributes the spending condition:
+
+```text
+A AND T AND covenant(template_hash)
+```
+
+Every action contributes its own condition before transaction storage is
+deduplicated. If Alice can authorize a transaction directly, while Bob needs
+Carol's approval for that same transaction, the result is:
+
+```text
+(Alice OR (Bob AND Carol)) AND covenant(template_hash)
+```
+
+Bob alone remains insufficient regardless of action order. Tests evaluate the
+lowered descriptor for every signer combination, with native CTV and an emulated
+covenant key, and with a matching or different template commitment.
+
+All listed guards are conjunctive. Zero effective guards mean true, one means
+that guard, and larger lists use valid binary or threshold policy nodes. Exact
+duplicate ordinary predicates and trivial clauses do not add requirements.
+Inscription clauses carry script data: conjunction preserves their order and
+multiplicity, including when nested inside another predicate. A continuation
+contributes its declared guards, while its returned transactions are suggestions;
+**every** suggested template is checked for forbidden additional guards before
+deduplication.
+
+The compiled template's `additional_preconditions` includes the action guards.
+For a shared transaction it records their complete alternative conditions in
+canonical policy order. The descriptor remains the authority for spending.
+
+## Duplicate transaction payloads
+
+A CTV hash does not commit to funding budgets, metadata or child continuation
+paths. Two templates can share a stored transaction only when their complete
+binding payloads agree: transaction, commitment index, funding/fee requirements,
+input metadata, template metadata and output contract graphs. A disagreement
+returns `ConflictingTemplate` with the hash, action/effect path and differing
+field. Authorizations may differ and are combined as alternatives.
+
+Authors intentionally sharing a transaction should reuse a common compiled
+destination and metadata. Equal child addresses alone are insufficient: their
+continuation APIs and source paths must also agree. The compiler never chooses
+a child graph, label or fee requirement solely because it appeared first.
+
+## Cached clauses and contextual metadata
+
+Fresh guards receive `(self, Context)` at each attachment. Cached guards use
+`#[guard(cached)] fn signed(self)`: their clause callback has no invocation
+context and is evaluated once per compilation of that contract. At the Rust API
+boundary this is `Guard::Cache(fn(&Self) -> Clause, ...)`.
+
+Guard metadata callbacks always receive their actual attachment context, for
+both cached and fresh clauses. Finish guards contribute metadata as well as
+spending conditions. Equal serialized metadata values for a clause/protocol
+are deduplicated; distinct values from different attachments are retained in
+declaration order. Allocation addresses never control metadata ordering.
+
+Caching does not make arbitrary Rust code pure. Reproducible compilation still
+requires contract authors to derive behavior from explicit inputs rather than
+mutable external state.
+
+## Conditional compilation and effect paths
+
+Conditions are evaluated in declaration order. Their path indexes preserve
+declared slots, including absent factories. Derivation failures are returned;
+the compiler does not search for another free path or skip an error.
+
+| Decision | Action behavior |
+| --- | --- |
+| NoConstraint / Required | Execute; a CTV action must produce a template |
+| Nullable | Execute; an empty CTV action contributes no spending branch |
+| Skippable / Never | Skip the action body and its guards |
+| Fail | Stop compilation with the supplied diagnostics |
+
+Across a condition list, `Required` overrides `Skippable` and `Nullable`, while
+`Never` conflicts with `Required`. Explicit failures retain declaration order;
+the complete list also reports that contradiction once. Decision kinds form an
+associative, commutative merge; ordered diagnostic lists do not.
+
+Named action/effect fragments use ASCII letters, digits and underscores.
+Reserved fragments and separators cannot be passed as user names. All effect
+names for a continuation are checked before its default or JSON callback runs,
+so the callback cannot observe a path that changes meaning after serialization.
+Repeated action names receive deterministic suffixes in the current declaration
+order; changing the set or order of action factories can change those paths.
+
+Effects augment the default continuation invocation. They do not replace it.
+These rules describe compiler behavior; use artifact validation and binding
+checks before consuming publicly constructed or deserialized compiled objects.

--- a/docs/MODERNIZATION.md
+++ b/docs/MODERNIZATION.md
@@ -53,6 +53,7 @@ with upstream crates would remove semantics, not complete a migration.
 | CTV finalization | Pin fork revision `04b69f69459fe3b043ca61fb649cf546d5a241b6`; establish legacy scriptSigs before native witness inputs, verify candidate scriptSigs and the completed transaction; regressions cover native WSH/Taproot with legacy inputs in either position |
 | Finalizer metadata | Validate PSBT structure and referenced non-witness output bounds; honor explicit ECDSA/Schnorr sighash types on partial and finalized signatures, permit valid non-ALL signatures when no type is declared |
 | Compiler termination | Advance duplicate-action suffixes; derive guard metadata beneath each guard branch and propagate errors; regressions compile repeated actions and a contract with two guards |
+| Language core | [Action semantics](LANGUAGE_SEMANTICS.md): strict macro options and trait interfaces, context-free cached clauses with per-attachment metadata, stable condition slots, original action authorization before transaction deduplication, conflicting binding payload errors and inscription-aware guard composition |
 | Inscriptions | Repair fork parsing, script-byte preservation, resource/key analysis and interpreter support; 51 fork inscription tests plus Sapio plugin artifact/signing and WASM checks, with checked ordinal ranges and fees |
 | Inscription node validation | Bitcoin Core 31.1 accepts five library-finalized ordinary Taproot reveals and rejects 21 invalid variants in isolated regtest checks; native CTV and Ord index/sat assignment remain separate |
 | Fees | Enforce the strongest requested minimum in virtual bytes against that template's reserved fees; reject overflow and unknown extra-input weights |
@@ -233,6 +234,11 @@ useful compiler API and improve errors before designing another syntax.
 - Define deterministic compilation: canonical inputs and effects, stable ordering,
   reproducible artifacts, and versioned semantics. Test repeated compilation and
   fixed golden examples before promising cross-platform byte identity.
+  Conditional paths now retain declared slots, guard metadata ordering no longer
+  depends on allocation addresses, and duplicate transactions retain their
+  authorization alternatives. Changes to the action factory list can still
+  change renamed action paths; arbitrary Rust callbacks can observe external
+  state. These remain explicit limits on reproducibility.
 - Write a compact semantic specification with worked examples and negative cases.
 - Evaluate a standalone DSL only against concrete authoring problems that Rust
   macros cannot solve well. Any additional frontend targets the same graph.

--- a/docs/learn-sapio/src/ch03-02-guard.md
+++ b/docs/learn-sapio/src/ch03-02-guard.md
@@ -6,17 +6,35 @@ miniscript logic.
 These guards can either be used standalone as unlocking conditions or as a
 requirement on a `continuation` or `then` function.
 
-If a `guard` is marked as cached, the compiler will make an effort to only
-invoke the `guard` once during compilation. This is helpful in contexts
-where a `guard` might be expensive to call, e.g. if it is programmed to
-retrieve a `Clause` from a remote server. It is not guaranteed that the
-`guard` is only invoked once.
+An ordinary guard receives the context of each attachment. Use it when the
+policy depends on the current path or other compilation context.
+
+A cached guard is evaluated once per guard declaration during a contract's
+compilation. It receives only `self`, so it cannot accidentally reuse the first
+attachment's context at a different path. Each compilation starts a new cache;
+compiling the same contract again evaluates the cached policy again.
 
 ## guard macro
 ```rust
-#[guard(
-    /// optional: if the compiler should attempt to only call this guard one time (not guaranteed)
-    cached)]
-fn name(self, ctx: Context) {/*Clause*/}
-decl_guard!{name};
+#[guard]
+fn contextual(self, ctx: Context) {
+    // Compute a Clause using this attachment's context.
+}
+
+#[guard(cached)]
+fn signed(self) {
+    Clause::Key(self.owner)
+}
 ```
+
+These methods belong inside the contract's implementation. Trait interfaces
+can declare their corresponding optional methods with
+`decl_guard! { contextual }` and `decl_guard! { cached signed }`.
+
+Guard metadata remains contextual even when the policy is cached. A
+`simps = "Some(Self::metadata)"` callback receives its own `Context` for every
+attachment, including standalone finish guards. Its errors abort compilation.
+The compiled artifact groups annotations by guard clause and protocol number,
+preserving distinct JSON values in attachment order and removing equal values.
+Metadata from different attachment paths therefore remains visible without
+duplicating identical annotations.

--- a/sapio-contrib/src/contracts/basic_examples.rs
+++ b/sapio-contrib/src/contracts/basic_examples.rs
@@ -28,7 +28,7 @@ impl ExampleA {
         Clause::And(vec![Clause::Key(self.bob), Clause::Older(100)])
     }
     #[guard(cached)]
-    fn signed(self, _ctx: sapio::Context) {
+    fn signed(self) {
         Clause::And(vec![Clause::Key(self.alice), Clause::Key(self.bob)])
     }
 }
@@ -73,7 +73,7 @@ struct ExampleB<T: BState> {
 
 impl<T: BState> ExampleB<T> {
     #[guard(cached)]
-    fn all_signed(self, _ctx: Context) {
+    fn all_signed(self) {
         Clause::Threshold(
             T::get_n(self.threshold as usize, self.participants.len()),
             self.participants.iter().map(|k| Clause::Key(*k)).collect(),
@@ -241,7 +241,7 @@ mod tests {
             bob: key(2),
         };
         assert_eq!(
-            a.guard_signed(context(0)),
+            a.guard_signed(),
             Clause::And(vec![Clause::Key(key(1)), Clause::Key(key(2))])
         );
         assert_eq!(
@@ -262,7 +262,7 @@ mod tests {
             1000
         );
         assert_eq!(
-            b.guard_all_signed(context(0)),
+            b.guard_all_signed(),
             Clause::Threshold(2, vec![Clause::Key(key(1)), Clause::Key(key(2))])
         );
     }
@@ -275,10 +275,7 @@ mod tests {
             amount: bitcoin::Amount::from_sat(1000).into(),
             pd: PhantomData,
         };
-        assert!(matches!(
-            b.guard_all_signed(context(0)),
-            Clause::Threshold(256, _)
-        ));
+        assert!(matches!(b.guard_all_signed(), Clause::Threshold(256, _)));
         b.threshold = 0;
         assert!(b.compile(context(1000)).is_err());
         b.threshold = 2;

--- a/sapio-contrib/src/contracts/channel.rs
+++ b/sapio-contrib/src/contracts/channel.rs
@@ -56,7 +56,7 @@ mod tests {
     fn cooperative_close_requires_both_keys_and_conserves_value() {
         let contract = channel();
         assert_eq!(
-            contract.guard_signed(context(1000)),
+            contract.guard_signed(),
             Clause::And(vec![Clause::Key(key(1)), Clause::Key(key(2))])
         );
         let update = |a, b| {
@@ -248,7 +248,7 @@ where
         Clause::Older(100)
     }
     #[guard(cached)]
-    fn signed(self, _ctx: Context) {
+    fn signed(self) {
         Clause::And(vec![Clause::Key(self.alice), Clause::Key(self.bob)])
     }
 

--- a/sapio-contrib/src/contracts/derivatives/signature_attested.rs
+++ b/sapio-contrib/src/contracts/derivatives/signature_attested.rs
@@ -16,7 +16,7 @@ use sapio::contract::*;
 use sapio::template::Template;
 use sapio::*;
 use sapio_base::Clause;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 
 /// Supplies an authenticated signing key for an event outcome.
 pub trait OutcomeOracle {
@@ -69,7 +69,7 @@ impl SignatureAttested {
     #[then]
     fn payout(self, mut ctx: Context) {
         let funds = ctx.funds();
-        let mut settlements = BTreeMap::new();
+        let mut settlements = vec![];
         for point in 0..=self.points {
             let keys = self
                 .oracles
@@ -89,31 +89,16 @@ impl SignatureAttested {
             let payouts = allocate(funds, &weights)?;
             let guard =
                 Clause::Threshold(self.oracles.0, keys.into_iter().map(Clause::Key).collect());
-            let mut builder = ctx.derive_num(point)?.template().add_guard(guard.clone());
+            let mut builder = ctx.derive_num(point)?.template().add_guard(guard);
             for (party, amount) in self.parties.iter().zip(payouts) {
                 if amount.as_sat() > 0 {
                     builder = builder.add_output(amount, party, None)?;
                 }
             }
             let template: Template = builder.into();
-            // Equal payout transactions have one CTV hash. Preserve every oracle
-            // authorization before the compiler deduplicates those transactions.
-            settlements
-                .entry(template.hash())
-                .and_modify(|existing: &mut Template| {
-                    if !existing.guards.contains(&guard) {
-                        existing.guards.push(guard.clone());
-                    }
-                })
-                .or_insert(template);
+            settlements.push(Ok(template));
         }
-        Ok(Box::new(settlements.into_values().map(|mut template| {
-            if template.guards.len() > 1 {
-                let alternatives = std::mem::take(&mut template.guards);
-                template.guards.push(Clause::Threshold(1, alternatives));
-            }
-            Ok(template)
-        })))
+        Ok(Box::new(settlements.into_iter()))
     }
 }
 impl Contract for SignatureAttested {
@@ -286,7 +271,12 @@ mod tests {
                 })
                 .collect(),
         );
-        assert_eq!(template.guards, vec![expected]);
+        use sapio_base::miniscript::policy::Liftable;
+        assert_eq!(template.guards.len(), 1);
+        let actual = template.guards[0].lift().unwrap();
+        let expected = expected.lift().unwrap();
+        assert!(actual.clone().entails(expected.clone()).unwrap());
+        assert!(expected.entails(actual).unwrap());
         let descriptor = serde_json::to_string(&compiled.descriptor).unwrap();
         for point in 0..=2 {
             for oracle in [10, 20] {

--- a/sapio/src/contract/abi/object/descriptors.rs
+++ b/sapio/src/contract/abi/object/descriptors.rs
@@ -16,7 +16,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// Multiple Types of Allowed Descriptor
-#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug)]
+#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug, PartialEq, Eq)]
 pub enum SupportedDescriptors {
     /// # ECDSA Descriptors
     Pk(Descriptor<PublicKey>),

--- a/sapio/src/contract/abi/object/mod.rs
+++ b/sapio/src/contract/abi/object/mod.rs
@@ -42,7 +42,7 @@ pub struct ObjectMetadata {
     pub extra: BTreeMap<String, serde_json::Value>,
     /// SIMP: Sapio Interactive Metadata Protocol
     pub simp: BTreeMap<i64, serde_json::Value>,
-    /// SIMPs for guards
+    /// Distinct SIMP values per guard and protocol, in attachment order.
     pub simps_for_guards: BTreeMap<Clause, BTreeMap<i64, Vec<serde_json::Value>>>,
 }
 impl ObjectMetadata {
@@ -73,31 +73,24 @@ impl ObjectMetadata {
             Vec<Arc<dyn SIMPAttachableAt<sapio_base::simp::GuardLT>>>,
         >,
     ) -> Result<ObjectMetadata, CompilationError> {
-        if self.simps_for_guards.is_empty() {
-            self.simps_for_guards = all_guard_simps
-                .into_iter()
-                .map(|(k, v)| {
-                    Ok((
-                        k,
-                        v.into_iter().fold(
-                            Ok(Default::default()),
-                            |ra: Result<BTreeMap<_, Vec<Value>>, CompilationError>, b| {
-                                let mut a = ra?;
-                                a.entry(b.get_protocol_number()).or_default().push(
-                                    b.to_json().map_err(CompilationError::SerializationError)?,
-                                );
-                                Ok(a)
-                            },
-                        )?,
-                    ))
-                })
-                .collect::<Result<_, CompilationError>>()?;
-            Ok(self)
-        } else {
-            Err(Err(CompilationError::Custom(
-                "Failed to add guard simps".into(),
-            ))?)
+        if !self.simps_for_guards.is_empty() {
+            return Err(CompilationError::Custom(
+                "Contract metadata cannot prepopulate guard SIMPs".into(),
+            ));
         }
+        for (clause, metadata) in all_guard_simps {
+            let protocols = self.simps_for_guards.entry(clause).or_default();
+            for simp in metadata {
+                let value = simp
+                    .to_json()
+                    .map_err(CompilationError::SerializationError)?;
+                let values = protocols.entry(simp.get_protocol_number()).or_default();
+                if !values.contains(&value) {
+                    values.push(value);
+                }
+            }
+        }
+        Ok(self)
     }
 }
 

--- a/sapio/src/contract/abi/object/mod.rs
+++ b/sapio/src/contract/abi/object/mod.rs
@@ -29,7 +29,6 @@ use sapio_base::simp::SIMPError;
 use sapio_base::Clause;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 pub use validation::{ArtifactError, ArtifactErrorKind};
@@ -97,10 +96,10 @@ impl ObjectMetadata {
 /// Object holds a contract's complete context required post-compilation
 /// Public fields and deserialization can produce inconsistent objects. Call
 /// [`Object::validate`] before using an artifact; binding performs this check.
-#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug)]
+#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug, PartialEq, Eq)]
 pub struct Object {
-    /// a map of template hashes to the corresponding template, that in the
-    /// policy are CTV protected
+    /// CTV-protected templates, deduplicated only when their binding payloads
+    /// agree. Each stored template retains all alternative preconditions.
     #[serde(
         rename = "template_hash_to_template_map",
         skip_serializing_if = "BTreeMap::is_empty",

--- a/sapio/src/contract/actions/conditional_compile.rs
+++ b/sapio/src/contract/actions/conditional_compile.rs
@@ -4,13 +4,16 @@
 //  License, v. 2.0. If a copy of the MPL was not distributed with this
 //  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-//! A decorator which can be used to skip clausesd based on a computation.
-use super::Context;
+//! Conditions controlling whether an action is compiled and may return no templates.
+use super::{CompilationError, Context};
 use sapio_base::effects::PathFragment;
 
 use std::collections::LinkedList;
+
+const REQUIRED_NEVER_CONFLICT: &str = "Never and Required incompatible";
 /// Conditional Compilation function has specified that compilation of this
 /// function should be required or not.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ConditionalCompileType {
     /// May proceed without calling this function at all
     Skippable,
@@ -29,7 +32,14 @@ pub enum ConditionalCompileType {
 }
 
 impl ConditionalCompileType {
-    /// Merge two `ConditionalCompileTypes` into one conditions.
+    /// Merge two conditional compilation decisions.
+    ///
+    /// Decision kinds are associative and commutative. Diagnostics preserve
+    /// operand order, so those properties do not apply to the message lists:
+    /// an existing `Fail` absorbs a later non-failing operand and its constraints.
+    /// Compilation assembles the full declared condition list separately so
+    /// an explicit failure cannot hide a `Required`/`Never` contradiction.
+    ///
     /// Precedence:
     ///     Fail > non-Fail ==> Fail
     ///     forall X. X > NoConstraint ==> X
@@ -48,7 +58,7 @@ impl ConditionalCompileType {
                     v
                 })
             }
-            // Fail ignored and overrides other conditions.
+            // Explicit failure overrides other conditions.
             (ConditionalCompileType::Fail(v), _) | (_, ConditionalCompileType::Fail(v)) => {
                 ConditionalCompileType::Fail(v)
             }
@@ -56,7 +66,7 @@ impl ConditionalCompileType {
             (ConditionalCompileType::Required, ConditionalCompileType::Never)
             | (ConditionalCompileType::Never, ConditionalCompileType::Required) => {
                 let mut l = LinkedList::new();
-                l.push_front(String::from("Never and Required incompatible"));
+                l.push_front(String::from(REQUIRED_NEVER_CONFLICT));
                 ConditionalCompileType::Fail(l)
             }
             // Never stays Never
@@ -103,15 +113,126 @@ pub type ConditionallyCompileIfList<'a, T> = &'a [fn() -> Option<ConditionallyCo
 pub(crate) struct CCILWrapper<'a, T>(pub ConditionallyCompileIfList<'a, T>);
 
 impl<'a, T> CCILWrapper<'a, T> {
-    /// Assembles the list by folding merge over it
-    pub fn assemble(&self, self_ref: &T, context: &mut Context) -> ConditionalCompileType {
-        self.0
-            .iter()
-            .filter_map(|compf| compf())
-            .zip((0..).flat_map(|i| context.derive(PathFragment::Branch(i)).ok()))
-            .fold(ConditionalCompileType::NoConstraint, |acc, (cond, c)| {
-                let ConditionallyCompileIf::Fresh(f) = cond;
-                acc.merge(f(self_ref, c))
-            })
+    /// Evaluate present conditions at their declared slots. Explicit errors
+    /// retain declaration order; a contradictory requirement is reported once,
+    /// after those errors, regardless of where an explicit failure appeared.
+    pub fn assemble(
+        &self,
+        self_ref: &T,
+        context: &mut Context,
+    ) -> Result<ConditionalCompileType, CompilationError> {
+        let mut decision = ConditionalCompileType::NoConstraint;
+        let mut required = false;
+        let mut never = false;
+        // Some(empty) still represents an explicit Fail with no diagnostics.
+        let mut errors: Option<LinkedList<String>> = None;
+        for (slot, factory) in self.0.iter().enumerate() {
+            let Some(ConditionallyCompileIf::Fresh(condition)) = factory() else {
+                continue;
+            };
+            let child = context.derive(PathFragment::Branch(slot as u64))?;
+            match condition(self_ref, child) {
+                ConditionalCompileType::Required => required = true,
+                ConditionalCompileType::Never => never = true,
+                ConditionalCompileType::Fail(mut messages) => {
+                    errors
+                        .get_or_insert_with(LinkedList::new)
+                        .append(&mut messages);
+                }
+                constraint => decision = decision.merge(constraint),
+            }
+        }
+        if required && never {
+            errors
+                .get_or_insert_with(LinkedList::new)
+                .push_back(REQUIRED_NEVER_CONFLICT.into());
+        }
+        Ok(match errors {
+            Some(messages) => ConditionalCompileType::Fail(messages),
+            None if required => ConditionalCompileType::Required,
+            None if never => ConditionalCompileType::Never,
+            None => decision,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::{Amount, Network};
+    use sapio_ctv_emulator_trait::CTVAvailable;
+    use std::cell::Cell;
+    use std::sync::Arc;
+
+    fn context() -> Context {
+        Context::new(
+            Network::Regtest,
+            Amount::ZERO,
+            Arc::new(CTVAvailable),
+            "conditions".try_into().unwrap(),
+            Arc::new(Default::default()),
+            None,
+        )
+    }
+
+    fn absent() -> Option<ConditionallyCompileIf<Cell<usize>>> {
+        None
+    }
+
+    fn counted() -> Option<ConditionallyCompileIf<Cell<usize>>> {
+        Some(ConditionallyCompileIf::Fresh(|calls, _| {
+            calls.set(calls.get() + 1);
+            ConditionalCompileType::NoConstraint
+        }))
+    }
+
+    fn failing() -> Option<ConditionallyCompileIf<Cell<usize>>> {
+        Some(ConditionallyCompileIf::Fresh(|calls, _| {
+            calls.set(calls.get() + 1);
+            ConditionalCompileType::Fail(LinkedList::new())
+        }))
+    }
+
+    #[test]
+    fn occupied_condition_slot_returns_its_derivation_error_without_skipping() {
+        let mut context = context();
+        context.derive_num(1u64).unwrap();
+        let calls = Cell::new(0);
+        let result = CCILWrapper(&[absent, counted, counted]).assemble(&calls, &mut context);
+        assert!(matches!(
+            result,
+            Err(CompilationError::ContexPathAlreadyDerived)
+        ));
+        assert_eq!(calls.get(), 0);
+        assert!(context.derive_num(0u64).is_ok());
+        assert!(context.derive_num(2u64).is_ok());
+    }
+
+    #[test]
+    fn explicit_failure_does_not_hide_a_later_derivation_error() {
+        let mut context = context();
+        context.derive_num(1u64).unwrap();
+        let calls = Cell::new(0);
+        let result = CCILWrapper(&[failing, counted]).assemble(&calls, &mut context);
+        assert!(matches!(
+            result,
+            Err(CompilationError::ContexPathAlreadyDerived)
+        ));
+        assert_eq!(calls.get(), 1);
+    }
+
+    #[test]
+    fn absent_factories_do_not_reserve_contexts() {
+        let mut context = context();
+        let calls = Cell::new(0);
+        assert_eq!(
+            CCILWrapper(&[absent, absent])
+                .assemble(&calls, &mut context)
+                .unwrap(),
+            ConditionalCompileType::NoConstraint
+        );
+        assert_eq!(calls.get(), 0);
+        assert!(context.derive_num(0u64).is_ok());
+        assert!(context.derive_num(1u64).is_ok());
     }
 }

--- a/sapio/src/contract/actions/guard.rs
+++ b/sapio/src/contract/actions/guard.rs
@@ -15,24 +15,22 @@ use sapio_base::{
     simp::{GuardLT, SIMPAttachableAt},
     Clause,
 };
-/// A Guard is a function which generates some condition that must be met to unlock a script.
-/// If bool = true, the computation of the guard is cached, which is useful if e.g. Guard
-/// must contact a remote server or it should be the same across calls *for a given contract
-/// instance*.
+/// A spending condition, evaluated freshly or cached during one compilation.
+///
+/// Cached policies depend on contract data alone. Contextual metadata is
+/// evaluated at every attachment, independently of whether the policy is cached.
 pub enum Guard<ContractSelf> {
-    /// Cache Variant should only be called one time per contract and the result saved
-    Cache(
-        fn(&ContractSelf, Context) -> Clause,
-        Option<SimpGen<ContractSelf>>,
-    ),
-    /// Fresh Variant may be called repeatedly
+    /// Evaluate the policy once per guard declaration during this compilation.
+    /// The policy cannot observe an attachment's path, effects or available funds.
+    Cache(fn(&ContractSelf) -> Clause, Option<SimpGen<ContractSelf>>),
+    /// Evaluate the policy with the context of each attachment.
     Fresh(
         fn(&ContractSelf, Context) -> Clause,
         Option<SimpGen<ContractSelf>>,
     ),
 }
 
-/// A Function that can be used to generate metadata for a Guard
+/// Generate guard metadata at its actual attachment context on every use.
 pub type SimpGen<ContractSelf> =
     fn(
         cself: &ContractSelf,

--- a/sapio/src/contract/actions/then.rs
+++ b/sapio/src/contract/actions/then.rs
@@ -68,13 +68,8 @@ impl<'a, ContractSelf, StatefulArgs> From<ThenFunc<'a, ContractSelf>>
 }
 
 fn ctv_clause_extractor(t: &Template, ctx: &Context) -> Result<Option<Clause>, CompilationError> {
-    let h = t.hash();
-    if t.guards.is_empty() {
-        ctx.ctv_emulator(h)
-    } else {
-        let mut g = t.guards.clone();
-        g.push(ctx.ctv_emulator(h)?);
-        Ok(Clause::And(g))
-    }
-    .map(Some)
+    let covenant = ctx.ctv_emulator(t.hash())?;
+    Ok(Some(crate::contract::compiler::conjoin_guards(
+        t.guards.iter().chain(std::iter::once(&covenant)),
+    )))
 }

--- a/sapio/src/contract/compiler/cache.rs
+++ b/sapio/src/contract/compiler/cache.rs
@@ -6,7 +6,6 @@
 
 //! Caches for guards
 use super::Context;
-use super::InternalCompilerTag;
 use crate::contract::actions::Guard;
 use crate::contract::actions::SimpGen;
 use crate::contract::CompilationError;
@@ -19,7 +18,7 @@ use std::sync::Arc;
 
 pub type GuardSimps = Vec<Arc<dyn SIMPAttachableAt<GuardLT>>>;
 pub(crate) enum CacheEntry<T> {
-    Cached(Clause, GuardSimps),
+    Cached(Clause, Option<SimpGen<T>>),
     Fresh(fn(&T, Context) -> Clause, Option<SimpGen<T>>),
 }
 
@@ -34,21 +33,6 @@ impl<T> GuardCache<T> {
             cache: BTreeMap::new(),
         }
     }
-    pub(crate) fn create_entry(
-        g: Option<Guard<T>>,
-        t: &T,
-        ctx: Context,
-        simp_ctx: Context,
-    ) -> Result<Option<CacheEntry<T>>, CompilationError> {
-        match g {
-            Some(Guard::Cache(f, Some(simp_gen))) => {
-                Ok(Some(CacheEntry::Cached(f(t, ctx), simp_gen(t, simp_ctx)?)))
-            }
-            Some(Guard::Cache(f, None)) => Ok(Some(CacheEntry::Cached(f(t, ctx), vec![]))),
-            Some(Guard::Fresh(f, simp_gen)) => Ok(Some(CacheEntry::Fresh(f, simp_gen))),
-            None => Ok(None),
-        }
-    }
     pub(crate) fn get(
         &mut self,
         t: &T,
@@ -56,31 +40,20 @@ impl<T> GuardCache<T> {
         ctx: Context,
         simp_ctx: Context,
     ) -> Result<Option<(Clause, GuardSimps)>, CompilationError> {
-        let mut entry = self.cache.entry(f as usize);
-        let r = match entry {
-            std::collections::btree_map::Entry::Vacant(v) => {
-                let ent = Self::create_entry(
-                    f(),
-                    t,
-                    ctx.internal_clone(InternalCompilerTag { _secret: () }),
-                    simp_ctx.internal_clone(InternalCompilerTag { _secret: () }),
-                )?;
-
-                v.insert(ent)
-            }
-            std::collections::btree_map::Entry::Occupied(ref mut o) => o.get_mut(),
+        let entry = self.cache.entry(f as usize).or_insert_with(|| match f()? {
+            Guard::Cache(policy, simps) => Some(CacheEntry::Cached(policy(t), simps)),
+            Guard::Fresh(policy, simps) => Some(CacheEntry::Fresh(policy, simps)),
+        });
+        let Some(entry) = entry else { return Ok(None) };
+        let (clause, simps) = match entry {
+            CacheEntry::Cached(clause, simps) => (clause.clone(), simps),
+            CacheEntry::Fresh(policy, simps) => (policy(t, ctx), simps),
         };
-        match r {
-            Some(CacheEntry::Cached(s, v)) => Ok(Some((s.clone(), v.to_vec()))),
-            Some(CacheEntry::Fresh(f, s)) => Ok(Some((
-                f(t, ctx),
-                match s {
-                    Some(f2) => f2(t, simp_ctx)?,
-                    None => vec![],
-                },
-            ))),
-            None => Ok(None),
-        }
+        let metadata = match simps {
+            Some(generate) => generate(t, simp_ctx)?,
+            None => vec![],
+        };
+        Ok(Some((clause, metadata)))
     }
 }
 
@@ -100,17 +73,5 @@ pub(crate) fn create_guards<T>(
         })
         .filter_map(Result::transpose)
         .collect::<Result<Vec<_>, _>>()?;
-    let mut clauses: Vec<_> = v
-        .iter()
-        .map(|x| &x.0)
-        .filter(|x| **x != Clause::Trivial)
-        .cloned()
-        .collect(); // no point in using any Trivials
-    if clauses.is_empty() {
-        Ok((Clause::Trivial, v))
-    } else if clauses.len() == 1 {
-        Ok((clauses.pop().unwrap(), v))
-    } else {
-        Ok((Clause::And(clauses), v))
-    }
+    Ok((super::conjoin_guards(v.iter().map(|x| &x.0)), v))
 }

--- a/sapio/src/contract/compiler/mod.rs
+++ b/sapio/src/contract/compiler/mod.rs
@@ -30,7 +30,7 @@ mod cache;
 mod util;
 use cache::*;
 use util::*;
-/// Used to prevent unintended callers to internal_clone.
+/// Grants the compiler access to effects at the current compilation path.
 pub struct InternalCompilerTag {
     _secret: (),
 }
@@ -76,12 +76,26 @@ enum Nullable {
     No,
 }
 
-const UNIQUE_DERIVE_PANIC_MSG: &str = "Must be a valid derivation or internal invariant not held";
 fn compute_all_effects<C, A: Default>(
     mut top_effect_ctx: Context,
     self_ref: &C,
     func: &dyn CallableAsFoF<C, A>,
 ) -> TxTmplIt {
+    // Reject malformed names before any continuation callback can observe an
+    // effect path that would change meaning when serialized.
+    if func.web_api() {
+        for (name, _) in top_effect_ctx
+            .get_effects(InternalCompilerTag { _secret: () })
+            .get_value(top_effect_ctx.path())
+        {
+            if !matches!(
+                PathFragment::try_from(name.clone())?,
+                PathFragment::Named(_)
+            ) {
+                return Err(CompilationError::InvalidPathName);
+            }
+        }
+    }
     let default_applied_effect_ctx = top_effect_ctx.derive(PathFragment::DefaultEffect)?;
     let def = func.call(self_ref, default_applied_effect_ctx, Default::default())?;
     if !func.web_api() {
@@ -95,9 +109,7 @@ fn compute_all_effects<C, A: Default>(
         // operating with the effects passed in through the Context Object.
         .try_fold(def, |a, (k, arg)| -> TxTmplIt {
             let v = a;
-            let c = applied_effects_ctx
-                .derive(PathFragment::Named(SArc(k.clone())))
-                .expect(UNIQUE_DERIVE_PANIC_MSG);
+            let c = applied_effects_ctx.derive_str(k.clone())?;
             let w = func.call_json(self_ref, c, arg.clone())?;
             Ok(Box::new(v.chain(w)))
         });
@@ -128,22 +140,6 @@ impl Renamer {
     }
 }
 
-#[derive(Default)]
-struct ContinueAPIs {
-    inner: BTreeMap<SArc<EffectPath>, ContinuationPoint>,
-}
-
-type ContinueAPIEntry = Option<(SArc<EffectPath>, ContinuationPoint)>;
-
-impl Extend<ContinueAPIEntry> for ContinueAPIs {
-    fn extend<T>(&mut self, iter: T)
-    where
-        T: IntoIterator<Item = ContinueAPIEntry>,
-    {
-        self.inner.extend(iter.into_iter().flatten())
-    }
-}
-
 impl<'a, T> Compilable for T
 where
     T: AnyContract + 'a,
@@ -171,165 +167,118 @@ where
         let ensured_amount = self.ensure_amount(amount_range_ctx)?;
         amount_range.update_range(ensured_amount);
 
-        // The code for then_fns and finish_or_fns is very similar, differing
-        // only in that then_fns have a CTV enforcing the contract and
-        // finish_or_fns do not. We can lazily chain iterators to process them
-        // in a row.
-        //
-        // we need a unique context for each.
+        // Extract each declared action's policy before deduplicating its
+        // transaction payload. Equal CTV hashes do not imply equal guards.
         let mut action_ctx = ctx.derive(PathFragment::Action)?;
         let mut renamer = Renamer::new();
-        let all_values = self
-            .then_fns()
+        let mut continue_apis = BTreeMap::new();
+        let mut action_branches = vec![];
+        let mut all_guard_simps: BTreeMap<Clause, GuardSimps> = BTreeMap::new();
+        let then_fns = self.then_fns();
+        let finish_or_fns = self.finish_or_fns();
+        let actions = then_fns
             .iter()
-            .filter_map(|func| func())
-            // We currently need to allocate for the the Callable as a
-            // trait object since it only exists temporarily.
-            // TODO: Without allocations?
-            .map(|x| -> Box<dyn CallableAsFoF<_, _>> { Box::new(x) })
-            .chain(self.finish_or_fns().iter().filter_map(|func| func()))
-            .map(|mut x| {
-                let new_name = Arc::new(renamer.get_name(x.get_name().as_ref()));
-                x.rename(new_name.clone());
-                let name = PathFragment::Named(SArc(new_name));
-                let f_ctx = action_ctx.derive(name).expect(UNIQUE_DERIVE_PANIC_MSG);
-                (f_ctx, x)
-            })
-            // flat_map will discard any
-            // skippable / never branches here
-            .flat_map(|(mut f_ctx, func)| {
-                let mut this_ctx = f_ctx
-                    // this should always be Ok(_)
-                    .derive(PathFragment::CondCompIf)
-                    .expect(UNIQUE_DERIVE_PANIC_MSG);
-                let condition = match CCILWrapper(func.get_conditional_compile_if())
-                    .assemble(self_ref, &mut this_ctx)
-                {
-                    Ok(condition) => condition,
-                    Err(error) => return Some(Err(error)),
-                };
-                match condition {
-                    // Throw errors
-                    ConditionalCompileType::Fail(errors) => {
-                        Some(Err(CompilationError::ConditionalCompilationFailed(errors)))
-                    }
-                    // Non nullable
-                    ConditionalCompileType::Required | ConditionalCompileType::NoConstraint => {
-                        Some(Ok((f_ctx, func, Nullable::No)))
-                    }
-                    // Nullable
-                    ConditionalCompileType::Nullable => Some(Ok((f_ctx, func, Nullable::Yes))),
-                    // Drop these
-                    ConditionalCompileType::Skippable | ConditionalCompileType::Never => None,
+            .filter_map(|factory| factory())
+            .map(|action| -> Box<dyn CallableAsFoF<_, _>> { Box::new(action) })
+            .chain(finish_or_fns.iter().filter_map(|factory| factory()));
+        for mut action in actions {
+            // Validate the source name before renaming: reserved fragments must
+            // never acquire a different meaning after a JSON round trip.
+            let original_name: PathFragment = action.get_name().clone().try_into()?;
+            if !matches!(original_name, PathFragment::Named(_)) {
+                return Err(CompilationError::InvalidPathName);
+            }
+            let name = Arc::new(renamer.get_name(action.get_name()));
+            action.rename(name.clone());
+            let mut action_context = action_ctx.derive_str(name)?;
+            let mut condition_context = action_context.derive(PathFragment::CondCompIf)?;
+            let nullability = match CCILWrapper(action.get_conditional_compile_if())
+                .assemble(self_ref, &mut condition_context)?
+            {
+                ConditionalCompileType::Fail(errors) => {
+                    return Err(CompilationError::ConditionalCompilationFailed(errors));
                 }
-            })
-            .map(|r| {
-                let (mut f_ctx, func, nullability) = r?;
-                let gctx = f_ctx.derive(PathFragment::Guard)?;
-                let simp_ctx = f_ctx.derive(PathFragment::Metadata)?;
-                // TODO: Suggested path frag?
-                let (guards, guard_metadata) =
-                    create_guards(self_ref, gctx, func.get_guard(), &mut guard_clauses)?;
-                let effect_ctx = f_ctx.derive(if func.get_returned_txtmpls_modify_guards() {
-                    PathFragment::Next
-                } else {
-                    PathFragment::Suggested
-                })?;
-                let effect_path = effect_ctx.path().clone();
-                let transactions = compute_all_effects(effect_ctx, self_ref, func.as_ref());
-                // If no guards and not CTV, then nothing gets added (not
-                // interpreted as Trivial True)
-                //   - If CTV and no guards, just CTV added.
-                //   - If CTV and guards, CTV & guards added.
-                // it would be an error if any of r_txtmpls is an error
-                // instead of just an empty iterator.
-                let txtmpl_clauses = transactions?
-                    .map(|r_txtmpl| {
-                        let txtmpl = r_txtmpl?;
-                        let h = txtmpl.hash();
-                        amount_range.update_range(txtmpl.required_input_amount);
-                        // Add the addition guards to these clauses
-                        let txtmpl = if func.get_returned_txtmpls_modify_guards() {
-                            &mut comitted_txns
-                        } else {
-                            &mut other_txns
-                        }
-                        .entry(h)
-                        .or_insert(txtmpl);
-
-                        let extractor = func.get_extract_clause_from_txtmpl();
-                        (extractor)(txtmpl, &ctx)
-                    })
-                    // Drop None values
-                    .filter_map(|s| s.transpose())
-                    // Forces any error to abort the whole thing
-                    .collect::<Result<Vec<Clause>, CompilationError>>()?;
-
-                // N.B. the order of the matches below is significant
-                Ok(if func.get_returned_txtmpls_modify_guards() {
-                    let r = (
-                        None,
-                        combine_txtmpls(nullability, txtmpl_clauses, guards)?,
-                        guard_metadata,
-                    );
-                    r
-                } else {
-                    let mut cp =
-                        ContinuationPoint::at(func.get_schema().clone(), effect_path.clone());
-                    for simp in func.gen_simps(self_ref, simp_ctx)? {
-                        cp = cp.add_simp(simp.as_ref())?;
-                    }
-                    let v = optimizer_flatten_and_compile(guards)?;
-                    (Some((SArc(effect_path), cp)), v, guard_metadata)
-                })
-            })
-            .collect::<Result<Vec<(_, Vec<Miniscript<XOnlyPublicKey, Tap>>, _)>, CompilationError>>(
+                ConditionalCompileType::Required | ConditionalCompileType::NoConstraint => {
+                    Nullable::No
+                }
+                ConditionalCompileType::Nullable => Nullable::Yes,
+                ConditionalCompileType::Skippable | ConditionalCompileType::Never => continue,
+            };
+            let guard_context = action_context.derive(PathFragment::Guard)?;
+            let metadata_context = action_context.derive(PathFragment::Metadata)?;
+            let (guards, guard_metadata) = create_guards(
+                self_ref,
+                guard_context,
+                action.get_guard(),
+                &mut guard_clauses,
             )?;
-
-        let mut continue_apis = ContinueAPIs::default();
-        let mut clause_accumulator = vec![];
-        let mut all_guard_simps: BTreeMap<Clause, GuardSimps> = Default::default();
-        for (v, b, c) in all_values {
-            continue_apis.extend(std::iter::once(v));
-            clause_accumulator.push(b);
-            for (pol, mut simps) in c {
-                all_guard_simps.entry(pol).or_default().append(&mut simps)
+            let committed = action.get_returned_txtmpls_modify_guards();
+            let effect_context = action_context.derive(if committed {
+                PathFragment::Next
+            } else {
+                PathFragment::Suggested
+            })?;
+            let effect_path = effect_context.path().clone();
+            let mut template_clauses = vec![];
+            for template in compute_all_effects(effect_context, self_ref, action.as_ref())? {
+                let mut template = template?;
+                // This also rejects forbidden guards on every suggested
+                // template, including duplicates of an earlier valid template.
+                let clause = (action.get_extract_clause_from_txtmpl())(&template, &ctx)?;
+                amount_range.update_range(template.required_input_amount);
+                if committed {
+                    template.guards = policy_as_guards(conjoin_guards(
+                        std::iter::once(&guards).chain(template.guards.iter()),
+                    ));
+                }
+                insert_template(
+                    if committed {
+                        &mut comitted_txns
+                    } else {
+                        &mut other_txns
+                    },
+                    template,
+                    &effect_path,
+                )?;
+                if let Some(clause) = clause {
+                    template_clauses.push(clause);
+                }
+            }
+            action_branches.extend(if committed {
+                combine_txtmpls(nullability, template_clauses, guards)?
+            } else {
+                let mut continuation =
+                    ContinuationPoint::at(action.get_schema().clone(), effect_path.clone());
+                for simp in action.gen_simps(self_ref, metadata_context)? {
+                    continuation = continuation.add_simp(simp.as_ref())?;
+                }
+                continue_apis.insert(SArc(effect_path), continuation);
+                optimizer_flatten_and_compile(guards)?
+            });
+            for (policy, mut simps) in guard_metadata {
+                all_guard_simps
+                    .entry(policy)
+                    .or_default()
+                    .append(&mut simps);
             }
         }
 
-        let branches: Vec<Miniscript<XOnlyPublicKey, Tap>> = {
-            let mut finish_fns_ctx = ctx.derive(PathFragment::FinishFn)?;
-            // Compute all finish_functions at this level, caching if requested.
-            let guards = self
-                .finish_fns()
-                .iter()
-                // note that this zip with would loop forever if there were to be a bug here
-                .zip((0..).filter_map(|i| {
-                    let mut new = finish_fns_ctx.derive(PathFragment::Branch(i as u64)).ok()?;
-                    let simp = new.derive(PathFragment::Metadata).ok()?;
-                    Some((new, simp))
-                }))
-                .filter_map(|(func, (c, simp_c))| {
-                    guard_clauses.get(self_ref, *func, c, simp_c).transpose()
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-            let all_g = guards
-                .into_iter()
-                .map(|(policy, mut simps)| {
-                    all_guard_simps
-                        .entry(policy.clone())
-                        .or_default()
-                        .append(&mut simps);
-                    optimizer_flatten_and_compile(policy)
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-
-            all_g
-                .into_iter()
-                .chain(clause_accumulator.into_iter())
-                .flatten()
-                .collect()
-        };
+        let mut finish_context = ctx.derive(PathFragment::FinishFn)?;
+        let mut branches = vec![];
+        for (index, factory) in self.finish_fns().iter().enumerate() {
+            let mut guard_context = finish_context.derive_num(index as u64)?;
+            let metadata_context = guard_context.derive(PathFragment::Metadata)?;
+            if let Some((policy, mut simps)) =
+                guard_clauses.get(self_ref, *factory, guard_context, metadata_context)?
+            {
+                all_guard_simps
+                    .entry(policy.clone())
+                    .or_default()
+                    .append(&mut simps);
+                branches.extend(optimizer_flatten_and_compile(policy)?);
+            }
+        }
+        branches.extend(action_branches);
         // TODO: Pick a better branch that is guaranteed to work!
         let some_key = pick_key_from_miniscripts(branches.iter());
         // Don't remove the key from the scripts in case it was bogus
@@ -370,7 +319,7 @@ where
             Ok(Compiled {
                 ctv_to_tx: comitted_txns,
                 suggested_txs: other_txns,
-                continue_apis: continue_apis.inner,
+                continue_apis,
                 root_path,
                 address,
                 descriptor,
@@ -411,6 +360,67 @@ pub(crate) fn conjoin_guards<'a>(guards: impl Iterator<Item = &'a Clause>) -> Cl
         2 => Clause::And(combined),
         count => Clause::Threshold(count, combined),
     }
+}
+
+fn policy_as_guards(policy: Clause) -> Vec<Clause> {
+    if policy == Clause::Trivial {
+        vec![]
+    } else {
+        vec![policy]
+    }
+}
+
+fn insert_template(
+    templates: &mut BTreeMap<bitcoin::hashes::sha256::Hash, crate::template::Template>,
+    template: crate::template::Template,
+    path: &EffectPath,
+) -> Result<(), CompilationError> {
+    use std::collections::btree_map::Entry;
+    let hash = template.hash();
+    match templates.entry(hash) {
+        Entry::Vacant(entry) => {
+            entry.insert(template);
+        }
+        Entry::Occupied(mut entry) => {
+            let existing = entry.get_mut();
+            // A CTV hash commits to transaction fields, not funding budgets,
+            // metadata or child continuation paths. None may be chosen by
+            // whichever action happens to be visited first.
+            macro_rules! same {
+                ($($field:ident),+ $(,)?) => { $(
+                    if existing.$field != template.$field {
+                        return Err(CompilationError::ConflictingTemplate {
+                            hash, at: path.clone(), field: stringify!($field),
+                        });
+                    }
+                )+ };
+            }
+            same!(
+                ctv_index,
+                tx,
+                max,
+                required_input_amount,
+                min_feerate_sats_vbyte,
+                metadata_map_s2s,
+                inputs,
+                outputs
+            );
+            let alternatives = optimizer_flatten_policy(conjoin_guards(existing.guards.iter()))
+                .into_iter()
+                .chain(optimizer_flatten_policy(conjoin_guards(
+                    template.guards.iter(),
+                )))
+                .collect::<BTreeSet<_>>();
+            existing.guards = if alternatives.contains(&Clause::Trivial) {
+                vec![]
+            } else if alternatives.len() == 1 {
+                alternatives.into_iter().collect()
+            } else {
+                vec![Clause::Threshold(1, alternatives.into_iter().collect())]
+            };
+        }
+    }
+    Ok(())
 }
 
 fn optimizer_flatten_and_compile(

--- a/sapio/src/contract/compiler/mod.rs
+++ b/sapio/src/contract/compiler/mod.rs
@@ -296,10 +296,6 @@ where
                 all_guard_simps.entry(pol).or_default().append(&mut simps)
             }
         }
-        for guard_simps in all_guard_simps.values_mut() {
-            guard_simps.sort_by_key(|k| k as *const _ as usize);
-            guard_simps.dedup_by(|a, b| std::ptr::eq(a, b))
-        }
 
         let branches: Vec<Miniscript<XOnlyPublicKey, Tap>> = {
             let mut finish_fns_ctx = ctx.derive(PathFragment::FinishFn)?;
@@ -319,7 +315,13 @@ where
                 .collect::<Result<Vec<_>, _>>()?;
             let all_g = guards
                 .into_iter()
-                .map(|(policy, _m)| optimizer_flatten_and_compile(policy))
+                .map(|(policy, mut simps)| {
+                    all_guard_simps
+                        .entry(policy.clone())
+                        .or_default()
+                        .append(&mut simps);
+                    optimizer_flatten_and_compile(policy)
+                })
                 .collect::<Result<Vec<_>, _>>()?;
 
             all_g
@@ -376,6 +378,38 @@ where
                 metadata,
             })
         }
+    }
+}
+
+pub(crate) fn conjoin_guards<'a>(guards: impl Iterator<Item = &'a Clause>) -> Clause {
+    fn contains_inscription(guard: &Clause) -> bool {
+        match guard {
+            Clause::Inscribe(..) => true,
+            Clause::And(guards) | Clause::Threshold(_, guards) => {
+                guards.iter().any(contains_inscription)
+            }
+            Clause::Or(guards) => guards.iter().any(|(_, guard)| contains_inscription(guard)),
+            _ => false,
+        }
+    }
+
+    let mut combined = vec![];
+    for guard in guards {
+        if *guard == Clause::Unsatisfiable {
+            return Clause::Unsatisfiable;
+        }
+        // Inscription envelopes are script effects. Neither their order nor
+        // their multiplicity follows Boolean idempotence, including when they
+        // occur below another policy node.
+        if *guard != Clause::Trivial && (contains_inscription(guard) || !combined.contains(guard)) {
+            combined.push(guard.clone());
+        }
+    }
+    match combined.len() {
+        0 => Clause::Trivial,
+        1 => combined.pop().unwrap(),
+        2 => Clause::And(combined),
+        count => Clause::Threshold(count, combined),
     }
 }
 

--- a/sapio/src/contract/compiler/mod.rs
+++ b/sapio/src/contract/compiler/mod.rs
@@ -202,9 +202,13 @@ where
                     // this should always be Ok(_)
                     .derive(PathFragment::CondCompIf)
                     .expect(UNIQUE_DERIVE_PANIC_MSG);
-                match CCILWrapper(func.get_conditional_compile_if())
+                let condition = match CCILWrapper(func.get_conditional_compile_if())
                     .assemble(self_ref, &mut this_ctx)
                 {
+                    Ok(condition) => condition,
+                    Err(error) => return Some(Err(error)),
+                };
+                match condition {
                     // Throw errors
                     ConditionalCompileType::Fail(errors) => {
                         Some(Err(CompilationError::ConditionalCompilationFailed(errors)))

--- a/sapio/src/contract/context.rs
+++ b/sapio/src/contract/context.rs
@@ -135,20 +135,6 @@ impl Context {
             })
         }
     }
-    /// Method is unsafe, but may (provably!) be only called from within
-    /// compiler.rs where the `InternalCompilerTag` may be generated.
-    pub(crate) fn internal_clone(&self, _i: InternalCompilerTag) -> Self {
-        Context {
-            available_funds: self.available_funds,
-            emulator: self.emulator.clone(),
-            path: self.path.clone(),
-            network: self.network,
-            already_derived: self.already_derived.clone(),
-            effects: self.effects.clone(),
-            ordinals_info: self.ordinals_info.clone(),
-        }
-    }
-
     /// return the available funds
     pub fn funds(&self) -> Amount {
         self.available_funds

--- a/sapio/src/contract/error.rs
+++ b/sapio/src/contract/error.rs
@@ -42,6 +42,15 @@ pub enum CompilationError {
     PathFragmentError(ValidFragmentError),
     /// Error when a `ThenFunc` returns no Templates.
     MissingTemplates,
+    /// The same commitment was returned with incompatible binding data.
+    ConflictingTemplate {
+        /// Commitment shared by the two templates.
+        hash: bitcoin::hashes::sha256::Hash,
+        /// Action/effect path at which the conflict was found.
+        at: EffectPath,
+        /// Binding field that differs.
+        field: &'static str,
+    },
     /// Error if a Policy is empty
     EmptyPolicy,
     /// Error if a contract does not have sufficient funds available

--- a/sapio/src/contract/macros.rs
+++ b/sapio/src/contract/macros.rs
@@ -5,6 +5,34 @@
 //  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 //! macros for making defining Sapio contracts less verbose.
+//!
+//! Action options are checked at the declaration. A typo cannot silently omit
+//! an authorization guard:
+//! ```compile_fail
+//! use sapio::{Context, contract::Contract};
+//! struct Payment;
+//! impl Payment {
+//!     #[sapio::then(guarded_byy = "[Self::signed]")]
+//!     fn pay(self, _ctx: Context) { sapio::contract::empty() }
+//! }
+//! impl Contract for Payment { sapio::declare! {non updatable} }
+//! ```
+//! Cached clauses have no invocation context:
+//! ```compile_fail
+//! struct Payment;
+//! impl Payment {
+//!     #[sapio::guard(cached)]
+//!     fn signed(self, _ctx: sapio::Context) { sapio::sapio_base::Clause::Trivial }
+//! }
+//! ```
+//! Explicit return types are checked rather than discarded:
+//! ```compile_fail
+//! struct Payment;
+//! impl Payment {
+//!     #[sapio::guard]
+//!     fn signed(self, _ctx: sapio::Context) -> bool { sapio::sapio_base::Clause::Trivial }
+//! }
+//! ```
 
 use core::any::TypeId;
 pub use paste::paste;
@@ -28,7 +56,7 @@ macro_rules! declare {
     {then $(,$a:expr)*} => {
         /// binds the list of `ThenFunc`'s to this impl.
         /// Any fn() which returns None is ignored (useful for type-level state machines)
-        const THEN_FNS: &'static [fn() -> Option<$crate::contract::actions::ThenFuncAsFinishOrFunc<'static, Self, Self::StatefulArguments>>] = &[$($a,)*];
+        const THEN_FNS: &'static [fn() -> ::std::option::Option<$crate::contract::actions::ThenFuncAsFinishOrFunc<'static, Self, Self::StatefulArguments>>] = &[$($a,)*];
     };
     [state $i:ty]  => {
         type StatefulArguments = $i;
@@ -41,11 +69,11 @@ macro_rules! declare {
     {updatable<$($i:ty)?> $(,$a:expr)*} => {
         /// binds the list of `FinishOrFunc`'s to this impl.
         /// Any fn() which returns None is ignored (useful for type-level state machines)
-        const FINISH_OR_FUNCS: &'static [fn() -> Option<Box<dyn $crate::contract::actions::CallableAsFoF<Self, Self::StatefulArguments>>>] = &[$($a,)*];
-        declare![state $($i)?];
+        const FINISH_OR_FUNCS: &'static [fn() -> ::std::option::Option<::std::boxed::Box<dyn $crate::contract::actions::CallableAsFoF<Self, Self::StatefulArguments>>>] = &[$($a,)*];
+        $crate::declare![state $($i)?];
     };
     {non updatable} => {
-        declare![state ()];
+        $crate::declare![state ()];
     };
     {finish $(,$a:expr)*} => {
         /// binds the list of `Gurard`'s to this impl as unlocking conditions.
@@ -53,24 +81,14 @@ macro_rules! declare {
         /// sufficient to unlock funds, a `Guard` should not be bound if it is
         /// intended to be used with a `ThenFunc`.
         /// Any fn() which returns None is ignored (useful for type-level state machines)
-        const FINISH_FNS: &'static [fn() -> Option<$crate::contract::actions::Guard<Self>>] = &[$($a,)*];
+        const FINISH_FNS: &'static [fn() -> ::std::option::Option<$crate::contract::actions::Guard<Self>>] = &[$($a,)*];
     };
 
 
 }
 
-/// The then macro is used to define a `ThenFunc`
-/// formats for calling are:
-/// ```ignore
-/// /// A Guarded CTV Function
-/// then!(guarded_by: [guard_1, ... guard_n] fn name(self, ctx) {/*Result<Box<Iterator<TransactionTemplate>>>*/} );
-/// /// A Conditional CTV Function
-/// then!(compile_if: [compile_if_1, ... compile_if_n] fn name(self, ctx) {/*Result<Box<Iterator<TransactionTemplate>>>*/} );
-/// /// An Unguarded CTV Function
-/// then!(fn name(self, ctx) {/*Result<Box<Iterator<TransactionTemplate>>>*/} );
-/// /// Null Implementation
-/// then!(name);
-/// ```
+/// Declare an optional CTV action in a contract interface: `decl_then! { name }`.
+/// Its default factory returns `None`; implement it with `#[then]` to enable it.
 #[macro_export]
 macro_rules! decl_then {
     {
@@ -86,7 +104,7 @@ macro_rules! decl_then {
                 unimplemented!();
             }
             $(#[$meta])*
-            fn $name<'a>() -> Option<$crate::contract::actions::ThenFuncAsFinishOrFunc<'a, Self, <Self as sapio::contract::Contract>::StatefulArguments>> {None}
+            fn $name<'a>() -> ::std::option::Option<$crate::contract::actions::ThenFuncAsFinishOrFunc<'a, Self, <Self as $crate::contract::Contract>::StatefulArguments>> {::std::option::Option::None}
         }
     };
 }
@@ -112,17 +130,26 @@ pub fn get_schema_for<T: schemars::JsonSchema + 'static + Sized>() -> Arc<Value>
         .clone()
 }
 
-/// Internal Helper for finish! macro, not to be used directly.
+/// The optional JSON schema of a continuation's specific argument type.
+pub type ContinuationSchema = Option<Arc<Value>>;
+
+/// Internal schema declaration helper for `decl_continuation!`.
 #[macro_export]
 macro_rules! web_api {
-    {$name:ident,$type:ty,{}} => {
+    {$(#[$meta:meta])* $name:ident,$type:ty,{}} => {
         $crate::contract::macros::paste!{
-            const [<CONTINUE_SCHEMA_FOR_ $name:upper >] : Option<&'static dyn Fn() -> std::sync::Arc<serde_json::Value>> = Some(&|| $crate::contract::macros::get_schema_for::<$type>());
+            $(#[$meta])*
+            fn [<__sapio_schema_for_ $name>]() -> $crate::contract::macros::ContinuationSchema {
+                ::std::option::Option::Some($crate::contract::macros::get_schema_for::<$type>())
+            }
         }
     };
-    {$name:ident,$type:ty} => {
+    {$(#[$meta:meta])* $name:ident,$type:ty} => {
         $crate::contract::macros::paste!{
-            const [<CONTINUE_SCHEMA_FOR_ $name:upper >] : Option<&'static dyn Fn() -> std::sync::Arc<serde_json::Value>> = None;
+            $(#[$meta])*
+            fn [<__sapio_schema_for_ $name>]() -> $crate::contract::macros::ContinuationSchema {
+                ::std::option::Option::None
+            }
         }
     }
 }
@@ -140,17 +167,10 @@ macro_rules! is_web_api_type {
         $crate::contract::actions::WebAPIDisabled
     };
 }
-/// The finish macro is used to define a `FinishFunc` or a `FinishOrFunc`
-/// formats for calling are:
-/// ```ignore
-/// /// A Guarded CTV Function
-/// finish!(guarded_by: [guard_1, ... guard_n] fn name(self, ctx, o) {/*Result<Box<Iterator<TransactionTemplate>>>*/} );
-/// /// A Conditional CTV Function
-/// finish!(compile_if: [compile_if_1, ... compile_if_n] guarded_by: [guard_1, ..., guard_n] fn name(self, ctx, o) {/*Result<Box<Iterator<TransactionTemplate>>>*/} );
-/// /// Null Implementation
-/// finish!(name);
-/// ```
-/// Unlike a `then!`, `finish!` must always have guards.
+/// Declare an optional continuation in a contract interface:
+/// `decl_continuation! { name<SpecificArgs> }`.
+/// Add `<web={}>` before the name to declare its JSON schema as well.
+/// Its default factory returns `None`; implement it with `#[continuation]`.
 #[macro_export]
 macro_rules! decl_continuation {
     {
@@ -159,7 +179,7 @@ macro_rules! decl_continuation {
         $name:ident<$arg_type:ty>
     } => {
         $crate::contract::macros::paste!{
-            $crate::contract::macros::web_api!($name,$arg_type$(,$web_enable)*);
+            $crate::contract::macros::web_api!($(#[$meta])* $name,$arg_type$(,$web_enable)*);
             $(#[$meta])*
             fn [<continue_ $name>](&self, _ctx:$crate::contract::Context, _o: $arg_type)-> $crate::contract::TxTmplIt
             {
@@ -167,24 +187,36 @@ macro_rules! decl_continuation {
             }
             $(#[$meta])*
             fn $name<'a>() ->
-            Option<Box<dyn
+            ::std::option::Option<::std::boxed::Box<dyn
             $crate::contract::actions::CallableAsFoF<Self, <Self as $crate::contract::Contract>::StatefulArguments>>>
             {
-                None
+                ::std::option::Option::None
             }
         }
     };
 }
 
-/// The guard macro is used to define a `Guard`. Guards may be cached or uncached.
-/// formats for calling are:
-/// ```ignore
-/// guard!(fn name(self, ctx) {/*Clause*/})
-/// /// The guard should only be invoked once
-/// guard!(cached fn name(self, ctx) {/*Clause*/})
-/// ```
+/// Declare an optional guard in a contract interface: `decl_guard! { name }`.
+/// Use `decl_guard! { cached name }` for a context-free cached clause.
+/// Implement these with `#[guard] fn name(self, ctx: Context)` and
+/// `#[guard(cached)] fn name(self)` respectively.
 #[macro_export]
 macro_rules! decl_guard {
+    {
+        $(#[$meta:meta])*
+        cached $name:ident
+    } => {
+        $crate::contract::macros::paste! {
+            $(#[$meta])*
+            fn [<guard_ $name>](&self) -> $crate::sapio_base::Clause {
+                unimplemented!();
+            }
+            $(#[$meta])*
+            fn $name() -> ::std::option::Option<$crate::contract::actions::Guard<Self>> {
+                ::std::option::Option::None
+            }
+        }
+    };
     {
         $(#[$meta:meta])*
         $name:ident} => {
@@ -194,8 +226,8 @@ macro_rules! decl_guard {
                     unimplemented!();
                 }
                 $(#[$meta])*
-                fn $name() -> Option<$crate::contract::actions::Guard<Self>> {
-                    None
+                fn $name() -> ::std::option::Option<$crate::contract::actions::Guard<Self>> {
+                    ::std::option::Option::None
                 }
             }
      };
@@ -210,12 +242,12 @@ macro_rules! decl_compile_if {
     } => {
             $crate::contract::macros::paste!{
                 $(#[$meta])*
-                fn [<compile_if $name>](&self, _ctx: $crate::contract::Context) -> $crate::contract::actions::ConditionalCompileType {
+                fn [<compile_if_ $name>](&self, _ctx: $crate::contract::Context) -> $crate::contract::actions::ConditionalCompileType {
                     unimplemented!()
                 }
                 $(#[$meta])*
-                fn $name() -> Option<$crate::contract::actions::ConditionallyCompileIf<Self>> {
-                    None
+                fn $name() -> ::std::option::Option<$crate::contract::actions::ConditionallyCompileIf<Self>> {
+                    ::std::option::Option::None
                 }
             }
      };

--- a/sapio/src/template/mod.rs
+++ b/sapio/src/template/mod.rs
@@ -111,9 +111,11 @@ impl TemplateMetadata {
 
 /// Template holds the data needed to construct a Transaction for CTV Purposes, along with relevant
 /// metadata
-#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug)]
+#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug, PartialEq, Eq)]
 pub struct Template {
-    /// additional restrictions placed on this template
+    /// Additional restrictions on a builder's template. After contract
+    /// compilation, these include the action guards; duplicate transactions
+    /// retain their complete alternative authorizations here.
     #[serde(rename = "additional_preconditions")]
     pub guards: Vec<Clause>,
     /// the precomputed template hash for this Template

--- a/sapio/src/template/output.rs
+++ b/sapio/src/template/output.rs
@@ -61,7 +61,7 @@ impl<const N: usize> From<[(&str, serde_json::Value); N]> for OutputMeta {
 
 /// An Output is not a literal Bitcoin Output, but contains data needed to construct one, and
 /// metadata for linking & ABI building
-#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug)]
+#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug, PartialEq, Eq)]
 pub struct Output {
     /// the amount of sats being sent to this contract
     #[serde(with = "bitcoin::util::amount::serde::as_sat")]

--- a/sapio/src/util/amountrange.rs
+++ b/sapio/src/util/amountrange.rs
@@ -66,7 +66,7 @@ impl From<AmountU64> for u64 {
 }
 /// `AmountRange` makes it simple to track and update the range of allowed values
 /// for a contract to receive.
-#[derive(Serialize, Deserialize, JsonSchema, Clone, Copy, Debug)]
+#[derive(Serialize, Deserialize, JsonSchema, Clone, Copy, Debug, PartialEq, Eq)]
 pub struct AmountRange {
     #[serde(rename = "min_btc", skip_serializing_if = "Option::is_none", default)]
     min: Option<AmountF64>,

--- a/sapio/src/util/extended_address.rs
+++ b/sapio/src/util/extended_address.rs
@@ -18,7 +18,7 @@ use std::convert::TryFrom;
 
 /// A type that handles (gracefully) the fact that certain widely used
 /// output types do not have an address
-#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug)]
+#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum ExtendedAddress {
     /// A regular standard address type
@@ -47,7 +47,7 @@ impl ExtendedAddress {
 }
 
 /// Internal type for processing OpReturn through serde
-#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug)]
+#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug, PartialEq, Eq)]
 #[serde(try_from = "Script")]
 #[serde(into = "Script")]
 pub struct OpReturn(Script);

--- a/sapio/tests/conditional_compilation.rs
+++ b/sapio/tests/conditional_compilation.rs
@@ -1,0 +1,359 @@
+use bitcoin::secp256k1::{Keypair, Secp256k1, SecretKey};
+use bitcoin::{Amount, Network, XOnlyPublicKey};
+use sapio::contract::actions::{
+    ConditionalCompileType as Condition, ConditionallyCompileIf, Guard, ThenFunc,
+    ThenFuncAsFinishOrFunc, ThenFuncTypeTag,
+};
+use sapio::contract::{empty, Compilable, CompilationError, Context, DynamicContract, TxTmplIt};
+use sapio_base::Clause;
+use sapio_ctv_emulator_trait::CTVAvailable;
+use std::cell::{Cell, RefCell};
+use std::collections::LinkedList;
+use std::sync::Arc;
+
+fn failure(messages: &[&str]) -> Condition {
+    Condition::Fail(messages.iter().map(|message| (*message).into()).collect())
+}
+
+fn kind(condition: &Condition) -> usize {
+    match condition {
+        Condition::Skippable => 0,
+        Condition::Nullable => 1,
+        Condition::Required => 2,
+        Condition::Never => 3,
+        Condition::NoConstraint => 4,
+        Condition::Fail(_) => 5,
+    }
+}
+
+fn cases() -> [Condition; 6] {
+    [
+        Condition::Skippable,
+        Condition::Nullable,
+        Condition::Required,
+        Condition::Never,
+        Condition::NoConstraint,
+        failure(&["explicit error"]),
+    ]
+}
+
+#[test]
+fn complete_merge_truth_table_and_ordered_failure_aggregation() {
+    // Rows and columns: Skippable, Nullable, Required, Never, NoConstraint, Fail.
+    let expected = [
+        [0, 0, 2, 3, 0, 5],
+        [0, 1, 2, 3, 1, 5],
+        [2, 2, 2, 5, 2, 5],
+        [3, 3, 5, 3, 3, 5],
+        [0, 1, 2, 3, 4, 5],
+        [5, 5, 5, 5, 5, 5],
+    ];
+    for (row, left) in cases().iter().enumerate() {
+        for (column, right) in cases().iter().enumerate() {
+            let merged = left.clone().merge(right.clone());
+            assert_eq!(kind(&merged), expected[row][column], "{left:?} + {right:?}");
+            if let Condition::Fail(messages) = merged {
+                let expected_messages = match (row, column) {
+                    (5, 5) => vec!["explicit error", "explicit error"],
+                    (5, _) | (_, 5) => vec!["explicit error"],
+                    (2, 3) | (3, 2) => vec!["Never and Required incompatible"],
+                    _ => unreachable!("only failures have messages"),
+                };
+                assert_eq!(
+                    messages.iter().map(String::as_str).collect::<Vec<_>>(),
+                    expected_messages
+                );
+            }
+        }
+    }
+    assert_eq!(
+        failure(&["second", "first"]).merge(failure(&["third"])),
+        failure(&["second", "first", "third"])
+    );
+    assert_eq!(failure(&[]).merge(Condition::Nullable), failure(&[]));
+}
+
+#[test]
+fn merge_decisions_are_commutative_and_associative_including_failures() {
+    let mut values = cases().to_vec();
+    values.extend([failure(&[]), failure(&["another error"])]);
+    for left in &values {
+        for middle in &values {
+            assert_eq!(
+                kind(&left.clone().merge(middle.clone())),
+                kind(&middle.clone().merge(left.clone()))
+            );
+            for right in &values {
+                let lhs = left.clone().merge(middle.clone()).merge(right.clone());
+                let rhs = left.clone().merge(middle.clone().merge(right.clone()));
+                assert_eq!(kind(&lhs), kind(&rhs), "{left:?}, {middle:?}, {right:?}");
+            }
+        }
+    }
+    // Ordered diagnostics deliberately have different algebra from decisions.
+    assert_eq!(
+        failure(&["first"])
+            .merge(Condition::Required)
+            .merge(Condition::Never),
+        failure(&["first"])
+    );
+    assert_eq!(
+        failure(&["first"]).merge(Condition::Required.merge(Condition::Never)),
+        failure(&["first", "Never and Required incompatible"])
+    );
+}
+
+struct State {
+    conditions: [Condition; 4],
+    paths: RefCell<Vec<(usize, String)>>,
+    guard_calls: Cell<usize>,
+    body_calls: Cell<usize>,
+    empty: bool,
+    body_error: bool,
+}
+
+fn key(byte: u8) -> XOnlyPublicKey {
+    Keypair::from_secret_key(
+        &Secp256k1::new(),
+        &SecretKey::from_slice(&[byte; 32]).unwrap(),
+    )
+    .x_only_public_key()
+    .0
+}
+
+fn context() -> Context {
+    Context::new(
+        Network::Regtest,
+        Amount::from_sat(1000),
+        Arc::new(CTVAvailable),
+        "conditional".try_into().unwrap(),
+        Arc::new(Default::default()),
+        None,
+    )
+}
+
+fn evaluate<const INDEX: usize>(state: &State, context: Context) -> Condition {
+    state
+        .paths
+        .borrow_mut()
+        .push((INDEX, context.path().as_ref().clone().into()));
+    state.conditions[INDEX].clone()
+}
+
+fn condition<const INDEX: usize>() -> Option<ConditionallyCompileIf<State>> {
+    Some(ConditionallyCompileIf::Fresh(evaluate::<INDEX>))
+}
+
+fn absent() -> Option<ConditionallyCompileIf<State>> {
+    None
+}
+
+fn branch_guard() -> Option<Guard<State>> {
+    Some(Guard::Fresh(
+        |state, _| {
+            state.guard_calls.set(state.guard_calls.get() + 1);
+            Clause::Key(key(2))
+        },
+        None,
+    ))
+}
+
+fn finish_guard() -> Option<Guard<State>> {
+    Some(Guard::Fresh(|_, _| Clause::Key(key(1)), None))
+}
+
+fn body(state: &State, context: Context, _: ThenFuncTypeTag) -> TxTmplIt {
+    state.body_calls.set(state.body_calls.get() + 1);
+    if state.body_error {
+        return Err(CompilationError::TerminateWith("body error".into()));
+    }
+    if state.empty {
+        empty()
+    } else {
+        context
+            .template()
+            .add_output(Amount::from_sat(1000), &key(3), None)?
+            .into()
+    }
+}
+
+fn action() -> Option<ThenFuncAsFinishOrFunc<'static, State, ()>> {
+    Some(
+        ThenFunc {
+            guard: &[branch_guard],
+            conditional_compile_if: &[
+                condition::<0>,
+                condition::<1>,
+                condition::<2>,
+                condition::<3>,
+            ],
+            func: body,
+            name: Arc::new("candidate".into()),
+        }
+        .into(),
+    )
+}
+
+fn sparse_action() -> Option<ThenFuncAsFinishOrFunc<'static, State, ()>> {
+    Some(
+        ThenFunc {
+            guard: &[branch_guard],
+            conditional_compile_if: &[absent, condition::<0>, absent, condition::<1>],
+            func: body,
+            name: Arc::new("candidate".into()),
+        }
+        .into(),
+    )
+}
+
+fn contract(conditions: [Condition; 4]) -> DynamicContract<'static, (), State> {
+    DynamicContract {
+        then: vec![action],
+        finish_or: vec![],
+        finish: vec![finish_guard],
+        metadata_f: Box::new(|_, _| Ok(Default::default())),
+        ensure_amount_f: Box::new(|_, context| Ok(context.funds())),
+        data: State {
+            conditions,
+            paths: RefCell::new(vec![]),
+            guard_calls: Cell::new(0),
+            body_calls: Cell::new(0),
+            empty: false,
+            body_error: false,
+        },
+    }
+}
+
+fn single_condition(condition: Condition) -> DynamicContract<'static, (), State> {
+    contract([
+        condition,
+        Condition::NoConstraint,
+        Condition::NoConstraint,
+        Condition::NoConstraint,
+    ])
+}
+
+#[test]
+fn absent_factories_preserve_declared_condition_context_slots() {
+    let mut contract = single_condition(Condition::NoConstraint);
+    contract.then = vec![sparse_action];
+    let compiled = contract.compile(context()).unwrap();
+    assert_eq!(
+        *contract.data.paths.borrow(),
+        vec![
+            (0, "conditional/@action/candidate/@cond_comp_if/#1".into()),
+            (1, "conditional/@action/candidate/@cond_comp_if/#3".into()),
+        ]
+    );
+    assert_eq!(contract.data.guard_calls.get(), 1);
+    assert_eq!(contract.data.body_calls.get(), 1);
+    assert_eq!(compiled.ctv_to_tx.len(), 1);
+    let template = compiled.ctv_to_tx.values().next().unwrap();
+    assert_eq!(template.tx.output.len(), 1);
+    assert_eq!(template.tx.output[0].value, 1000);
+    assert_eq!(
+        template.tx.output[0].script_pubkey,
+        bitcoin::Script::from(&key(3).compile(context()).unwrap().address)
+    );
+}
+
+#[test]
+fn never_and_skippable_do_not_execute_the_guard_or_action() {
+    for condition in [Condition::Never, Condition::Skippable] {
+        let mut contract = single_condition(condition);
+        contract.data.body_error = true;
+        let compiled = contract.compile(context()).unwrap();
+        assert!(compiled.ctv_to_tx.is_empty());
+        assert_eq!(contract.data.guard_calls.get(), 0);
+        assert_eq!(contract.data.body_calls.get(), 0);
+        assert_eq!(contract.data.paths.borrow().len(), 4);
+    }
+}
+
+#[test]
+fn nullable_allows_no_templates_but_does_not_suppress_action_errors() {
+    let mut nullable = single_condition(Condition::Nullable);
+    nullable.data.empty = true;
+    assert!(nullable.compile(context()).unwrap().ctv_to_tx.is_empty());
+    assert_eq!(nullable.data.guard_calls.get(), 1);
+    assert_eq!(nullable.data.body_calls.get(), 1);
+    for condition in [Condition::Required, Condition::NoConstraint] {
+        let mut required = single_condition(condition);
+        required.data.empty = true;
+        assert!(matches!(
+            required.compile(context()),
+            Err(CompilationError::MissingTemplates)
+        ));
+        assert_eq!(required.data.body_calls.get(), 1);
+    }
+    let mut error = single_condition(Condition::Nullable);
+    error.data.body_error = true;
+    assert!(
+        matches!(error.compile(context()), Err(CompilationError::TerminateWith(message)) if message == "body error")
+    );
+}
+
+#[test]
+fn condition_errors_are_ordered_and_do_not_hide_required_never_conflicts() {
+    for conditions in [
+        [
+            failure(&["second", "first"]),
+            Condition::Required,
+            Condition::Never,
+            failure(&["third"]),
+        ],
+        [
+            Condition::Required,
+            failure(&["second", "first"]),
+            failure(&["third"]),
+            Condition::Never,
+        ],
+        [
+            Condition::Never,
+            Condition::Required,
+            failure(&["second", "first"]),
+            failure(&["third"]),
+        ],
+    ] {
+        let contract = contract(conditions);
+        let result = contract.compile(context());
+        let Err(CompilationError::ConditionalCompilationFailed(messages)) = result else {
+            panic!("expected conditional-compilation diagnostics");
+        };
+        assert_eq!(
+            messages,
+            [
+                "second",
+                "first",
+                "third",
+                "Never and Required incompatible"
+            ]
+            .into_iter()
+            .map(String::from)
+            .collect::<LinkedList<_>>()
+        );
+        assert_eq!(contract.data.paths.borrow().len(), 4);
+        assert_eq!(contract.data.guard_calls.get(), 0);
+        assert_eq!(contract.data.body_calls.get(), 0);
+    }
+    let empty_failure = single_condition(failure(&[]));
+    assert!(
+        matches!(empty_failure.compile(context()), Err(CompilationError::ConditionalCompilationFailed(messages)) if messages.is_empty())
+    );
+}
+
+#[test]
+fn repeated_contradictory_conditions_produce_one_diagnostic() {
+    let contract = contract([
+        Condition::Required,
+        Condition::Never,
+        Condition::Never,
+        Condition::Required,
+    ]);
+    assert!(
+        matches!(contract.compile(context()), Err(CompilationError::ConditionalCompilationFailed(messages))
+        if messages == ["Never and Required incompatible".to_owned()].into_iter().collect())
+    );
+    assert_eq!(contract.data.paths.borrow().len(), 4);
+    assert_eq!(contract.data.body_calls.get(), 0);
+}

--- a/sapio/tests/effect_names.rs
+++ b/sapio/tests/effect_names.rs
@@ -1,0 +1,109 @@
+use bitcoin::{Amount, Network};
+use sapio::contract::{empty, Compilable, Compiled, Contract, DynamicContract};
+use sapio::{continuation, declare, guard, Context};
+use sapio_base::{effects::MapEffectDB, Clause};
+use sapio_ctv_emulator_trait::CTVAvailable;
+use std::cell::RefCell;
+use std::sync::Arc;
+
+#[derive(Default)]
+struct Updates {
+    calls: RefCell<Vec<String>>,
+}
+impl Updates {
+    #[guard]
+    fn signed(self, _ctx: Context) {
+        Clause::Key(
+            bitcoin::XOnlyPublicKey::from_slice(&[
+                0x79, 0xbe, 0x66, 0x7e, 0xf9, 0xdc, 0xbb, 0xac, 0x55, 0xa0, 0x62, 0x95, 0xce, 0x87,
+                0x0b, 0x07, 0x02, 0x9b, 0xfc, 0xdb, 0x2d, 0xce, 0x28, 0xd9, 0x59, 0xf2, 0x81, 0x5b,
+                0x16, 0xf8, 0x17, 0x98,
+            ])
+            .unwrap(),
+        )
+    }
+    #[continuation(guarded_by = "[Self::signed]", coerce_args = "Ok", web_api)]
+    fn update(self, ctx: Context, _args: Option<u64>) {
+        self.calls
+            .borrow_mut()
+            .push(String::from(ctx.path().as_ref().clone()));
+        empty()
+    }
+}
+impl Contract for Updates {
+    declare! {updatable<Option<u64>>, Self::update}
+}
+
+fn context(name: &str) -> Context {
+    let effects: MapEffectDB = serde_json::from_value(serde_json::json!({
+        "effects": {"updates/@action/update/@suggested": {name: 7}}
+    }))
+    .unwrap();
+    Context::new(
+        Network::Regtest,
+        Amount::ZERO,
+        Arc::new(CTVAvailable),
+        "updates".try_into().unwrap(),
+        Arc::new(effects),
+        None,
+    )
+}
+
+#[test]
+fn malformed_effect_names_fail_before_continuation_callbacks() {
+    for name in ["a/b", "@guard", "#7", "not a name"] {
+        let contract = Updates::default();
+        assert!(contract.compile(context(name)).is_err(), "{name}");
+        assert!(contract.calls.borrow().is_empty(), "{name}");
+    }
+}
+
+#[test]
+fn valid_effect_and_continuation_paths_survive_artifact_round_trips() {
+    let contract = Updates::default();
+    let compiled = contract.compile(context("request_1")).unwrap();
+    assert_eq!(
+        *contract.calls.borrow(),
+        [
+            "updates/@action/update/@suggested/@default_effect",
+            "updates/@action/update/@suggested/@effects/request_1",
+        ]
+    );
+    let restored: Compiled =
+        serde_json::from_str(&serde_json::to_string(&compiled).unwrap()).unwrap();
+    assert_eq!(restored, compiled);
+    assert_eq!(restored.continue_apis.len(), 1);
+    assert_eq!(
+        String::from(
+            restored
+                .continue_apis
+                .values()
+                .next()
+                .unwrap()
+                .path
+                .as_ref()
+                .clone()
+        ),
+        "updates/@action/update/@suggested"
+    );
+}
+
+fn bad_name() -> Option<Box<dyn sapio::contract::actions::CallableAsFoF<Updates, Option<u64>>>> {
+    let mut action = Updates::update()?;
+    action.rename(Arc::new("bad/name".into()));
+    Some(action)
+}
+
+#[test]
+fn invalid_dynamic_action_names_are_rejected_before_execution() {
+    let contract = DynamicContract {
+        then: vec![],
+        finish: vec![],
+        finish_or: vec![bad_name],
+        data: Updates::default(),
+        metadata_f: Box::new(|_, _| Ok(Default::default())),
+        ensure_amount_f: Box::new(|_, _| Ok(Amount::ZERO)),
+    };
+    assert!(contract.compile(context("request_1")).is_err());
+    assert!(contract.data.calls.borrow().is_empty());
+}

--- a/sapio/tests/guard_semantics.rs
+++ b/sapio/tests/guard_semantics.rs
@@ -1,0 +1,338 @@
+use bitcoin::secp256k1::{Keypair, Secp256k1, SecretKey};
+use bitcoin::{Amount, Network, XOnlyPublicKey};
+use sapio::contract::{Compilable, CompilationError, Context, Contract};
+use sapio::{continuation, declare, guard, then};
+use sapio_base::effects::EffectPath;
+use sapio_base::miniscript::policy::Liftable;
+use sapio_base::miniscript::Descriptor;
+use sapio_base::simp::{GuardLT, SIMPAttachableAt, SIMP};
+use sapio_base::Clause;
+use sapio_ctv_emulator_trait::CTVAvailable;
+use serde_json::{json, Value};
+use std::cell::{Cell, RefCell};
+use std::sync::Arc;
+
+const PROTOCOL: i64 = -17;
+
+fn key(byte: u8) -> XOnlyPublicKey {
+    let secp = Secp256k1::new();
+    Keypair::from_secret_key(&secp, &SecretKey::from_slice(&[byte; 32]).unwrap())
+        .x_only_public_key()
+        .0
+}
+
+enum Annotation {
+    Json(Value),
+    Invalid,
+}
+
+impl SIMP for Annotation {
+    fn static_get_protocol_number() -> i64 {
+        PROTOCOL
+    }
+
+    fn get_protocol_number(&self) -> i64 {
+        PROTOCOL
+    }
+
+    fn to_json(&self) -> Result<Value, serde_json::Error> {
+        match self {
+            Self::Json(value) => Ok(value.clone()),
+            Self::Invalid => Err(serde_json::Error::io(std::io::Error::other(
+                "guard annotation cannot serialize",
+            ))),
+        }
+    }
+
+    fn from_json(value: Value) -> Result<Self, serde_json::Error> {
+        Ok(Self::Json(value))
+    }
+}
+
+impl SIMPAttachableAt<GuardLT> for Annotation {}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum MetadataMode {
+    Paths,
+    RepeatedValues,
+    FailCachedFinish,
+    FailFreshFinish,
+    InvalidCachedFinish,
+}
+
+struct ObservedGuards {
+    cached_key: XOnlyPublicKey,
+    fresh_key: XOnlyPublicKey,
+    cached_calls: Cell<usize>,
+    fresh_contexts: RefCell<Vec<String>>,
+    cached_metadata_paths: RefCell<Vec<String>>,
+    fresh_metadata_paths: RefCell<Vec<String>>,
+    metadata_mode: MetadataMode,
+}
+
+impl ObservedGuards {
+    fn new(metadata_mode: MetadataMode) -> Self {
+        Self {
+            cached_key: key(1),
+            fresh_key: key(2),
+            cached_calls: Cell::new(0),
+            fresh_contexts: RefCell::new(vec![]),
+            cached_metadata_paths: RefCell::new(vec![]),
+            fresh_metadata_paths: RefCell::new(vec![]),
+            metadata_mode,
+        }
+    }
+
+    #[guard(cached, simps = "Some(Self::cached_metadata)")]
+    fn cached(self) {
+        self.cached_calls.set(self.cached_calls.get() + 1);
+        Clause::Key(self.cached_key)
+    }
+
+    #[guard(simps = "Some(Self::fresh_metadata)")]
+    fn fresh(self, ctx: Context) {
+        self.fresh_contexts
+            .borrow_mut()
+            .push(String::from(ctx.path().as_ref().clone()));
+        Clause::Key(self.fresh_key)
+    }
+
+    fn cached_metadata(
+        &self,
+        ctx: Context,
+    ) -> Result<Vec<Arc<dyn SIMPAttachableAt<GuardLT>>>, CompilationError> {
+        let path = String::from(ctx.path().as_ref().clone());
+        self.cached_metadata_paths.borrow_mut().push(path.clone());
+        if path.contains("/@finish_fn/") {
+            match self.metadata_mode {
+                MetadataMode::FailCachedFinish => {
+                    return Err(CompilationError::TerminateWith(
+                        "cached finish metadata failed".into(),
+                    ));
+                }
+                MetadataMode::InvalidCachedFinish => {
+                    return Ok(vec![Arc::new(Annotation::Invalid)])
+                }
+                _ => {}
+            }
+        }
+        Ok(self.annotations(path))
+    }
+
+    fn fresh_metadata(
+        &self,
+        ctx: Context,
+    ) -> Result<Vec<Arc<dyn SIMPAttachableAt<GuardLT>>>, CompilationError> {
+        let path = String::from(ctx.path().as_ref().clone());
+        self.fresh_metadata_paths.borrow_mut().push(path.clone());
+        if path.contains("/@finish_fn/") && self.metadata_mode == MetadataMode::FailFreshFinish {
+            return Err(CompilationError::TerminateWith(
+                "fresh finish metadata failed".into(),
+            ));
+        }
+        Ok(self.annotations(path))
+    }
+
+    fn annotations(&self, path: String) -> Vec<Arc<dyn SIMPAttachableAt<GuardLT>>> {
+        let values = if self.metadata_mode == MetadataMode::RepeatedValues {
+            vec![
+                json!("first"),
+                json!("first"),
+                json!("second"),
+                json!("first"),
+            ]
+        } else {
+            vec![json!({"path": path})]
+        };
+        values
+            .into_iter()
+            .map(|value| Arc::new(Annotation::Json(value)) as Arc<dyn SIMPAttachableAt<GuardLT>>)
+            .collect()
+    }
+
+    #[then(guarded_by = "[Self::cached, Self::fresh]")]
+    fn pay(self, ctx: Context) {
+        ctx.template()
+            .add_output(Amount::from_sat(1_000), &self.cached_key, None)?
+            .into()
+    }
+
+    #[continuation(
+        guarded_by = "[Self::cached, Self::fresh]",
+        coerce_args = "identity",
+        web_api
+    )]
+    fn suggest(self, _ctx: Context, _args: Option<()>) {
+        sapio::contract::empty()
+    }
+}
+
+fn identity(args: Option<()>) -> Result<Option<()>, CompilationError> {
+    Ok(args)
+}
+
+impl Contract for ObservedGuards {
+    declare! {then, Self::pay}
+    declare! {updatable<Option<()>>, Self::suggest}
+    declare! {finish, Self::cached, Self::fresh}
+}
+
+fn context() -> Context {
+    Context::new(
+        Network::Regtest,
+        Amount::from_sat(1_000),
+        Arc::new(CTVAvailable),
+        EffectPath::try_from("guards").unwrap(),
+        Arc::new(Default::default()),
+        None,
+    )
+}
+
+#[test]
+fn policies_and_metadata_use_their_declared_lifetimes_and_contexts() {
+    let contract = ObservedGuards::new(MetadataMode::Paths);
+    let compiled = contract.compile(context()).unwrap();
+    compiled.validate().unwrap();
+    assert_eq!(contract.cached_calls.get(), 1);
+    assert_eq!(
+        *contract.fresh_contexts.borrow(),
+        [
+            "guards/@action/pay/@guard/#1",
+            "guards/@action/suggest/@guard/#1",
+            "guards/@finish_fn/#1",
+        ]
+    );
+    for (key, recorded, index) in [
+        (contract.cached_key, &contract.cached_metadata_paths, 0),
+        (contract.fresh_key, &contract.fresh_metadata_paths, 1),
+    ] {
+        let paths = vec![
+            format!("guards/@action/pay/@guard/#{index}/@metadata"),
+            format!("guards/@action/suggest/@guard/#{index}/@metadata"),
+            format!("guards/@finish_fn/#{index}/@metadata"),
+        ];
+        assert_eq!(*recorded.borrow(), paths);
+        assert_eq!(
+            compiled.metadata.simps_for_guards[&Clause::Key(key)][&PROTOCOL],
+            paths
+                .into_iter()
+                .map(|path| json!({"path": path}))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    let repeated = contract.compile(context()).unwrap();
+    assert_eq!(contract.cached_calls.get(), 2);
+    assert_eq!(contract.fresh_contexts.borrow().len(), 6);
+    assert_eq!(
+        serde_json::to_value(compiled).unwrap(),
+        serde_json::to_value(repeated).unwrap()
+    );
+}
+
+#[test]
+fn equal_json_annotations_deduplicate_without_losing_distinct_values() {
+    let contract = ObservedGuards::new(MetadataMode::RepeatedValues);
+    let compiled = contract.compile(context()).unwrap();
+    for key in [contract.cached_key, contract.fresh_key] {
+        assert_eq!(
+            compiled.metadata.simps_for_guards[&Clause::Key(key)][&PROTOCOL],
+            vec![json!("first"), json!("second")]
+        );
+    }
+    assert_eq!(contract.cached_metadata_paths.borrow().len(), 3);
+    assert_eq!(contract.fresh_metadata_paths.borrow().len(), 3);
+}
+
+#[test]
+fn errors_at_later_metadata_attachments_abort_compilation() {
+    for (mode, expected) in [
+        (
+            MetadataMode::FailCachedFinish,
+            "cached finish metadata failed",
+        ),
+        (
+            MetadataMode::FailFreshFinish,
+            "fresh finish metadata failed",
+        ),
+    ] {
+        let contract = ObservedGuards::new(mode);
+        assert!(matches!(
+            contract.compile(context()),
+            Err(CompilationError::TerminateWith(message)) if message == expected
+        ));
+        assert_eq!(contract.cached_calls.get(), 1);
+    }
+}
+
+#[test]
+fn finish_metadata_serialization_errors_are_not_discarded() {
+    let contract = ObservedGuards::new(MetadataMode::InvalidCachedFinish);
+    assert!(matches!(
+        contract.compile(context()),
+        Err(CompilationError::SerializationError(error))
+            if error.to_string().contains("guard annotation cannot serialize")
+    ));
+}
+
+struct ManyGuards {
+    keys: [XOnlyPublicKey; 4],
+}
+
+impl ManyGuards {
+    #[guard]
+    fn first(self, _ctx: Context) {
+        Clause::Key(self.keys[0])
+    }
+
+    #[guard]
+    fn second(self, _ctx: Context) {
+        Clause::Key(self.keys[1])
+    }
+
+    #[guard(cached)]
+    fn third(self) {
+        Clause::Key(self.keys[2])
+    }
+
+    #[guard(cached)]
+    fn fourth(self) {
+        Clause::Key(self.keys[3])
+    }
+
+    #[then(guarded_by = "[Self::first, Self::second, Self::third, Self::fourth, Self::first]")]
+    fn pay(self, ctx: Context) {
+        ctx.template()
+            .add_output(Amount::from_sat(1_000), &self.keys[0], None)?
+            .into()
+    }
+}
+
+impl Contract for ManyGuards {
+    declare! {then, Self::pay}
+    declare! {non updatable}
+}
+
+#[test]
+fn more_than_two_guards_require_every_distinct_signer() {
+    let contract = ManyGuards {
+        keys: [key(1), key(2), key(3), key(4)],
+    };
+    let compiled = contract.compile(context()).unwrap();
+    compiled.validate().unwrap();
+    let Some(sapio::contract::abi::object::SupportedDescriptors::XOnly(Descriptor::Tr(tree))) =
+        compiled.descriptor
+    else {
+        panic!("expected a Taproot descriptor");
+    };
+    let leaves: Vec<_> = tree.iter_scripts().collect();
+    assert_eq!(leaves.len(), 1);
+    let policy = leaves[0].1.lift().unwrap();
+    assert_eq!(policy.minimum_n_keys(), Some(4));
+    for key in contract.keys {
+        assert!(policy
+            .clone()
+            .entails(Clause::Key(key).lift().unwrap())
+            .unwrap());
+    }
+}

--- a/sapio/tests/inscription_guards.rs
+++ b/sapio/tests/inscription_guards.rs
@@ -1,0 +1,166 @@
+use bitcoin::secp256k1::{Secp256k1, SecretKey};
+use bitcoin::{Amount, Network, XOnlyPublicKey};
+use sapio::contract::actions::ThenFuncAsFinishOrFunc;
+use sapio::contract::object::SupportedDescriptors;
+use sapio::contract::{Compilable, Context, Contract};
+use sapio::miniscript::ord::{envelope::Envelope, Inscription};
+use sapio::miniscript::Descriptor;
+use sapio::{declare, guard, then};
+use sapio_base::Clause;
+use sapio_ctv_emulator_trait::CTVAvailable;
+use std::sync::Arc;
+
+fn inscription(body: &[u8]) -> Inscription {
+    Inscription::new(Some(b"text/plain".to_vec()), Some(body.to_vec()))
+}
+
+fn effect(body: &[u8]) -> Clause {
+    Clause::Inscribe(Box::new(inscription(body)), Box::new(Clause::Trivial))
+}
+
+fn destination() -> XOnlyPublicKey {
+    SecretKey::from_slice(&[1; 32])
+        .unwrap()
+        .keypair(&Secp256k1::new())
+        .x_only_public_key()
+        .0
+}
+
+fn context() -> Context {
+    Context::new(
+        Network::Regtest,
+        Amount::from_sat(1_000),
+        Arc::new(CTVAvailable),
+        "inscriptions".try_into().unwrap(),
+        Arc::new(Default::default()),
+        None,
+    )
+}
+
+fn encoded_inscriptions(compiled: &sapio::contract::Compiled) -> Vec<Inscription> {
+    compiled.validate().unwrap();
+    let Some(SupportedDescriptors::XOnly(Descriptor::Tr(tree))) = &compiled.descriptor else {
+        panic!("expected a Taproot descriptor");
+    };
+    let scripts: Vec<_> = tree.iter_scripts().collect();
+    assert_eq!(scripts.len(), 1);
+    let script = scripts[0].1.encode();
+    Envelope::from_tapscript(&script, 0)
+        .unwrap()
+        .into_iter()
+        .map(|raw| {
+            let parsed: Envelope<Inscription> = raw.into();
+            parsed.payload
+        })
+        .collect()
+}
+
+struct Repeated<const IN_TEMPLATE: bool> {
+    nested: bool,
+}
+
+impl<const IN_TEMPLATE: bool> Repeated<IN_TEMPLATE> {
+    fn clause(&self) -> Clause {
+        let inscription = effect(b"repeated");
+        if self.nested {
+            Clause::And(vec![Clause::Trivial, inscription])
+        } else {
+            inscription
+        }
+    }
+
+    #[guard]
+    fn inscribe(self, _ctx: Context) {
+        self.clause()
+    }
+
+    #[then(guarded_by = "[Self::inscribe, Self::inscribe]")]
+    fn action_guards(self, ctx: Context) {
+        ctx.template()
+            .add_output(Amount::from_sat(1_000), &destination(), None)?
+            .into()
+    }
+
+    #[then]
+    fn template_guards(self, ctx: Context) {
+        ctx.template()
+            .add_guard(self.clause())
+            .add_guard(self.clause())
+            .add_output(Amount::from_sat(1_000), &destination(), None)?
+            .into()
+    }
+}
+
+impl<const IN_TEMPLATE: bool> Contract for Repeated<IN_TEMPLATE> {
+    const THEN_FNS: &'static [fn() -> Option<ThenFuncAsFinishOrFunc<'static, Self, ()>>] =
+        if IN_TEMPLATE {
+            &[Self::template_guards]
+        } else {
+            &[Self::action_guards]
+        };
+    declare! {non updatable}
+}
+
+#[test]
+fn repeated_action_guards_keep_direct_and_nested_inscription_envelopes() {
+    for nested in [false, true] {
+        let compiled = Repeated::<false> { nested }.compile(context()).unwrap();
+        assert_eq!(
+            encoded_inscriptions(&compiled),
+            vec![inscription(b"repeated"); 2],
+            "nested={nested}"
+        );
+    }
+}
+
+#[test]
+fn repeated_template_guards_keep_direct_and_nested_inscription_envelopes() {
+    for nested in [false, true] {
+        let compiled = Repeated::<true> { nested }.compile(context()).unwrap();
+        assert_eq!(
+            encoded_inscriptions(&compiled),
+            vec![inscription(b"repeated"); 2],
+            "nested={nested}"
+        );
+    }
+}
+
+struct Ordered;
+
+impl Ordered {
+    #[then]
+    fn pay(self, ctx: Context) {
+        ctx.template()
+            .add_guard(effect(b"z"))
+            .add_guard(effect(b"a"))
+            .add_guard(effect(b"z"))
+            .add_output(Amount::from_sat(1_000), &destination(), None)?
+            .into()
+    }
+}
+
+impl Contract for Ordered {
+    declare! {then, Self::pay}
+    declare! {non updatable}
+}
+
+#[test]
+fn conjunction_keeps_effect_order_and_nonadjacent_duplicates() {
+    let compiled = Ordered.compile(context()).unwrap();
+    let template = compiled.ctv_to_tx.values().next().unwrap();
+    assert_eq!(
+        template.guards,
+        vec![Clause::Threshold(
+            3,
+            vec![effect(b"z"), effect(b"a"), effect(b"z")]
+        )]
+    );
+    let mut inscriptions = encoded_inscriptions(&compiled);
+    // Miniscript chooses the final instruction order while compiling the
+    // conjunction; every declared envelope must still appear in the script.
+    inscriptions.sort();
+    assert_eq!(
+        inscriptions,
+        vec![inscription(b"a"), inscription(b"z"), inscription(b"z")]
+    );
+}

--- a/sapio/tests/macro_declarations.rs
+++ b/sapio/tests/macro_declarations.rs
@@ -1,0 +1,247 @@
+use bitcoin::secp256k1::{Keypair, Secp256k1, SecretKey};
+use bitcoin::{Amount, Network, XOnlyPublicKey};
+use sapio::contract::actions::{ConditionalCompileType, Guard};
+use sapio::contract::{Compilable, CompilationError, Context, Contract, TxTmplIt};
+use sapio_base::effects::EffectPath;
+use sapio_base::Clause;
+use sapio_ctv_emulator_trait::CTVAvailable;
+use std::sync::Arc;
+
+fn context() -> Context {
+    Context::new(
+        Network::Regtest,
+        Amount::from_sat(1_000),
+        Arc::new(CTVAvailable),
+        EffectPath::try_from("macro_declarations").unwrap(),
+        Arc::new(Default::default()),
+        None,
+    )
+}
+
+fn key(byte: u8) -> XOnlyPublicKey {
+    Keypair::from_secret_key(
+        &Secp256k1::new(),
+        &SecretKey::from_slice(&[byte; 32]).unwrap(),
+    )
+    .x_only_public_key()
+    .0
+}
+
+struct OfflineArgs(u64);
+
+trait Actions: Contract {
+    sapio::decl_guard! { signed }
+    sapio::decl_guard! { cached cached_signed }
+    sapio::decl_compile_if! { allowed }
+    sapio::decl_then! { pay }
+    sapio::decl_continuation! { <web={}> update<u64> }
+    sapio::decl_continuation! { offline<OfflineArgs> }
+}
+
+struct Policy;
+
+impl Actions for Policy {
+    #[sapio::guard]
+    fn signed(&self, _ctx: Context) -> Clause {
+        Clause::Key(key(1))
+    }
+
+    #[sapio::guard(cached)]
+    fn cached_signed(self) {
+        Clause::Key(key(2))
+    }
+
+    #[sapio::compile_if]
+    fn allowed(self, _ctx: Context) -> ConditionalCompileType {
+        ConditionalCompileType::Required
+    }
+
+    #[sapio::then(
+        guarded_by = "[Self::signed, Self::cached_signed]",
+        compile_if = "[Self::allowed]"
+    )]
+    fn pay(self, ctx: Context) -> TxTmplIt {
+        ctx.template()
+            .add_output(Amount::from_sat(1_000), &key(1), None)?
+            .into()
+    }
+
+    #[sapio::continuation(
+        guarded_by = "[Self::signed]",
+        compile_if = "[Self::allowed]",
+        coerce_args = "|value: Option<u64>| Ok(value.unwrap_or(900))",
+        web_api
+    )]
+    fn update(self, ctx: Context, amount: u64) -> TxTmplIt {
+        ctx.template()
+            .add_output(Amount::from_sat(amount), &key(1), None)?
+            .into()
+    }
+
+    #[sapio::continuation(
+        guarded_by = "[Self::cached_signed]",
+        coerce_args = "|value: Option<u64>| Ok(OfflineArgs(value.unwrap_or(800)))"
+    )]
+    fn offline(self, ctx: Context, OfflineArgs(amount): OfflineArgs) {
+        ctx.template()
+            .add_output(Amount::from_sat(amount), &key(2), None)?
+            .into()
+    }
+}
+
+impl Contract for Policy {
+    sapio::declare! {then, Self::pay}
+    sapio::declare! {updatable<Option<u64>>, Self::update, Self::offline}
+}
+
+#[test]
+fn declared_traits_and_attribute_implementations_compile_real_actions() {
+    assert!(matches!(Policy::signed(), Some(Guard::Fresh(..))));
+    assert!(matches!(Policy::cached_signed(), Some(Guard::Cache(..))));
+    let artifact = Policy.compile(context()).unwrap();
+    artifact.validate().unwrap();
+    assert_eq!(artifact.ctv_to_tx.len(), 1);
+    assert_eq!(artifact.suggested_txs.len(), 2);
+    assert_eq!(artifact.continue_apis.len(), 2);
+
+    let update = Policy::update().unwrap();
+    assert!(update.web_api());
+    assert!(update.get_schema().is_some());
+    let templates = update
+        .call_json(&Policy, context(), serde_json::json!(700))
+        .unwrap();
+    let template = templates.into_iter().next().unwrap().unwrap();
+    assert_eq!(template.tx.output[0].value, 700);
+    assert!(update
+        .call_json(&Policy, context(), serde_json::json!("bad"))
+        .is_err());
+
+    let offline = Policy::offline().unwrap();
+    assert!(!offline.web_api());
+    assert!(offline.get_schema().is_none());
+    assert!(matches!(
+        offline.call_json(&Policy, context(), serde_json::json!(800)),
+        Err(CompilationError::WebAPIDisabled)
+    ));
+}
+
+struct Absent;
+impl Actions for Absent {}
+impl Contract for Absent {
+    sapio::declare! {non updatable}
+}
+
+#[test]
+fn interface_defaults_leave_actions_absent() {
+    assert!(Absent::signed().is_none());
+    assert!(Absent::cached_signed().is_none());
+    assert!(Absent::allowed().is_none());
+    assert!(Absent::pay().is_none());
+    assert!(Absent::update().is_none());
+    assert!(Absent::offline().is_none());
+}
+
+#[allow(non_snake_case)]
+trait CaseSensitive: Contract {
+    sapio::decl_guard! { cached signed }
+    sapio::decl_continuation! { <web={}> update<u64> }
+    sapio::decl_continuation! { <web={}> UPDATE<String> }
+    sapio::decl_continuation! { <web={}> r#type<bool> }
+}
+
+struct Cases;
+impl Contract for Cases {
+    sapio::declare! {updatable<()>, Self::update, Self::UPDATE, Self::r#type}
+}
+
+#[allow(non_snake_case)]
+impl CaseSensitive for Cases {
+    #[sapio::guard(cached)]
+    fn signed(self) {
+        Clause::Key(key(3))
+    }
+
+    #[sapio::continuation(guarded_by = "[Self::signed]", coerce_args = "|()| Ok(1)", web_api)]
+    fn update(self, _ctx: Context, _value: u64) {
+        sapio::contract::empty()
+    }
+
+    #[sapio::continuation(
+        guarded_by = "[Self::signed]",
+        coerce_args = "|()| Ok(String::new())",
+        web_api
+    )]
+    fn UPDATE(self, _ctx: Context, _value: String) {
+        sapio::contract::empty()
+    }
+
+    #[sapio::continuation(guarded_by = "[Self::signed]", coerce_args = "|()| Ok(true)", web_api)]
+    fn r#type(self, _ctx: Context, _value: bool) {
+        sapio::contract::empty()
+    }
+}
+
+#[test]
+fn continuation_schema_helpers_distinguish_case_and_support_raw_names() {
+    for (action, expected) in [
+        (Cases::update(), "integer"),
+        (Cases::UPDATE(), "string"),
+        (Cases::r#type(), "boolean"),
+    ] {
+        assert_eq!(
+            action.unwrap().get_schema().as_ref().unwrap()["type"],
+            expected
+        );
+    }
+    assert_eq!(Cases::r#type().unwrap().get_name().as_str(), "type");
+    let artifact = Cases.compile(context()).unwrap();
+    artifact.validate().unwrap();
+    let paths: std::collections::BTreeSet<_> = artifact
+        .continue_apis
+        .keys()
+        .map(|path| String::from(path.0.as_ref().clone()))
+        .collect();
+    assert_eq!(
+        paths,
+        std::collections::BTreeSet::from([
+            "macro_declarations/@action/update/@suggested".into(),
+            "macro_declarations/@action/UPDATE/@suggested".into(),
+            "macro_declarations/@action/type/@suggested".into(),
+        ])
+    );
+}
+
+#[allow(dead_code)]
+mod hygiene {
+    use ::sapio as language;
+
+    // Generated code must resolve its own dependencies despite local names.
+    mod sapio {}
+    mod std {}
+    struct Option;
+    struct Box;
+
+    pub struct Visible;
+    impl Visible {
+        /// The visibility and must-use annotation apply to the action factory.
+        #[::sapio::guard(cached)]
+        #[must_use]
+        pub fn signed(self) -> ::sapio::sapio_base::Clause {
+            ::sapio::sapio_base::Clause::Key(super::key(3))
+        }
+    }
+    impl language::contract::Contract for Visible {
+        language::declare! {non updatable}
+        language::declare! {finish, Self::signed}
+    }
+}
+
+#[test]
+fn generated_actions_preserve_visibility_and_resolve_qualified_declarations() {
+    assert!(hygiene::Visible::signed().is_some());
+    hygiene::Visible
+        .compile(context())
+        .unwrap()
+        .validate()
+        .unwrap();
+}

--- a/sapio/tests/template_semantics.rs
+++ b/sapio/tests/template_semantics.rs
@@ -1,0 +1,263 @@
+use bitcoin::hashes::{sha256, Hash};
+use bitcoin::secp256k1::{Secp256k1, SecretKey};
+use bitcoin::{Amount, Network, XOnlyPublicKey};
+use sapio::contract::actions::ThenFuncAsFinishOrFunc;
+use sapio::contract::object::SupportedDescriptors;
+use sapio::contract::{Compilable, CompilationError, Contract};
+use sapio::miniscript::policy::{semantic::Policy, Liftable};
+use sapio::miniscript::MiniscriptKey;
+use sapio::template::Template;
+use sapio::{continuation, declare, guard, then, Context};
+use sapio_base::Clause;
+use sapio_ctv_emulator_trait::{CTVAvailable, CTVEmulator, EmulatorError};
+use std::sync::Arc;
+
+fn key(index: u8) -> XOnlyPublicKey {
+    SecretKey::from_slice(&[index; 32])
+        .unwrap()
+        .keypair(&Secp256k1::new())
+        .x_only_public_key()
+        .0
+}
+
+struct Emulated;
+impl CTVEmulator for Emulated {
+    fn get_signer_for(&self, _: sha256::Hash) -> Result<Clause, EmulatorError> {
+        Ok(Clause::Key(key(4)))
+    }
+    fn sign(
+        &self,
+        _: bitcoin::util::psbt::PartiallySignedTransaction,
+    ) -> Result<bitcoin::util::psbt::PartiallySignedTransaction, EmulatorError> {
+        unreachable!("compilation must not sign")
+    }
+}
+
+fn context(emulated: bool) -> Context {
+    Context::new(
+        Network::Regtest,
+        Amount::from_sat(2_000),
+        if emulated {
+            Arc::new(Emulated)
+        } else {
+            Arc::new(CTVAvailable)
+        },
+        "payments".try_into().unwrap(),
+        Arc::new(Default::default()),
+        None,
+    )
+}
+
+fn payment(ctx: Context, guards: &[Clause]) -> Result<Template, CompilationError> {
+    let mut builder = ctx
+        .template()
+        .add_output(Amount::from_sat(1_000), &key(9), None)?;
+    for guard in guards {
+        builder = builder.add_guard(guard.clone());
+    }
+    Ok(builder.into())
+}
+
+struct Payments<const REVERSED: bool>;
+impl<const REVERSED: bool> Payments<REVERSED> {
+    #[guard]
+    fn alice(self, _ctx: Context) {
+        Clause::Key(key(1))
+    }
+    #[guard]
+    fn bob(self, _ctx: Context) {
+        Clause::Key(key(2))
+    }
+    #[then(guarded_by = "[Self::alice]")]
+    fn alice_payment(self, ctx: Context) {
+        Ok(Box::new(std::iter::once(payment(ctx, &[]))))
+    }
+    #[then(guarded_by = "[Self::bob]")]
+    fn bob_carol_payment(self, ctx: Context) {
+        Ok(Box::new(std::iter::once(payment(
+            ctx,
+            &[Clause::Key(key(3))],
+        ))))
+    }
+}
+impl<const REVERSED: bool> Contract for Payments<REVERSED> {
+    const THEN_FNS: &'static [fn() -> Option<ThenFuncAsFinishOrFunc<'static, Self, ()>>] =
+        if REVERSED {
+            &[Self::bob_carol_payment, Self::alice_payment]
+        } else {
+            &[Self::alice_payment, Self::bob_carol_payment]
+        };
+    declare! {non updatable}
+}
+
+fn accepts(policy: &Policy<XOnlyPublicKey>, mask: u8, commitment: sha256::Hash) -> bool {
+    match policy {
+        Policy::Unsatisfiable => false,
+        Policy::Trivial => true,
+        Policy::KeyHash(hash) => (1..=4)
+            .any(|index| mask & (1 << (index - 1)) != 0 && key(index).to_pubkeyhash() == *hash),
+        Policy::Threshold(required, children) => {
+            children
+                .iter()
+                .filter(|child| accepts(child, mask, commitment))
+                .count()
+                >= *required
+        }
+        Policy::TxTemplate(hash) => *hash == commitment,
+        _ => panic!("unexpected policy in authorization fixture"),
+    }
+}
+
+#[test]
+fn duplicate_transactions_preserve_every_authorization_and_its_action_guard() {
+    for emulated in [false, true] {
+        let forward = Payments::<false>.compile(context(emulated)).unwrap();
+        let reverse = Payments::<true>.compile(context(emulated)).unwrap();
+        assert_eq!(forward.descriptor, reverse.descriptor);
+        assert_eq!(forward.ctv_to_tx, reverse.ctv_to_tx);
+        assert_eq!(forward.ctv_to_tx.len(), 1);
+        forward.validate().unwrap();
+        let template = forward.ctv_to_tx.values().next().unwrap();
+        let Some(SupportedDescriptors::XOnly(descriptor)) = &forward.descriptor else {
+            panic!()
+        };
+        let compiled_policy = descriptor.lift().unwrap();
+        assert_eq!(template.guards.len(), 1);
+        let stored_guards = template.guards[0].lift().unwrap();
+        for mask in 0..16 {
+            let authorized = mask & 1 != 0 || mask & 6 == 6;
+            assert_eq!(accepts(&stored_guards, mask, template.hash()), authorized);
+            for hash in [template.hash(), sha256::Hash::hash(b"another transaction")] {
+                let covenant = if emulated {
+                    mask & 8 != 0
+                } else {
+                    hash == template.hash()
+                };
+                assert_eq!(
+                    accepts(&compiled_policy, mask, hash),
+                    authorized && covenant,
+                    "emulated={emulated}, signers={mask}, hash={hash}"
+                );
+            }
+        }
+    }
+}
+
+struct RepeatedTemplates {
+    alter: fn(&mut Template),
+}
+impl RepeatedTemplates {
+    #[then]
+    fn pay(self, ctx: Context) {
+        let first = payment(ctx, &[])?;
+        let mut second = first.clone();
+        (self.alter)(&mut second);
+        Ok(Box::new([Ok(first), Ok(second)].into_iter()))
+    }
+}
+impl Contract for RepeatedTemplates {
+    declare! {then, Self::pay}
+    declare! {non updatable}
+}
+
+#[test]
+fn duplicate_commitments_reject_conflicting_binding_payloads() {
+    type Alteration = fn(&mut Template);
+    let alterations: [(Alteration, &str); 6] = [
+        (|t| t.max += Amount::from_sat(1), "max"),
+        (
+            |t| t.required_input_amount += Amount::from_sat(1),
+            "required_input_amount",
+        ),
+        (
+            |t| t.min_feerate_sats_vbyte = Some(Amount::from_sat(1)),
+            "min_feerate_sats_vbyte",
+        ),
+        (
+            |t| t.metadata_map_s2s.label = Some("different label".into()),
+            "metadata_map_s2s",
+        ),
+        (
+            |t| {
+                t.inputs[0].extra.insert("input".into(), true.into());
+            },
+            "inputs",
+        ),
+        (
+            |t| {
+                t.outputs[0].contract.root_path = sapio_base::serialization_helpers::SArc(Arc::new(
+                    "different_continuation".try_into().unwrap(),
+                ))
+            },
+            "outputs",
+        ),
+    ];
+    for (alter, expected_field) in alterations {
+        let error = RepeatedTemplates { alter }
+            .compile(context(false))
+            .unwrap_err();
+        let CompilationError::ConflictingTemplate { at, field, .. } = error else {
+            panic!("{error:?}")
+        };
+        assert_eq!(field, expected_field);
+        assert_eq!(String::from(at), "payments/@action/pay/@next");
+    }
+}
+
+struct Suggested;
+impl Suggested {
+    #[guard]
+    fn signed(self, _ctx: Context) {
+        Clause::Key(key(1))
+    }
+    #[continuation(guarded_by = "[Self::signed]", coerce_args = "Ok")]
+    fn update(self, ctx: Context, _args: ()) {
+        let first = payment(ctx, &[])?;
+        let mut second = first.clone();
+        second.guards.push(Clause::Key(key(2)));
+        Ok(Box::new([Ok(first), Ok(second)].into_iter()))
+    }
+}
+impl Contract for Suggested {
+    declare! {updatable<()>, Self::update}
+}
+
+#[test]
+fn suggested_template_duplicates_cannot_hide_forbidden_guards() {
+    assert!(matches!(
+        Suggested.compile(context(false)),
+        Err(CompilationError::AdditionalGuardsNotAllowedHere)
+    ));
+}
+
+struct ManyGuards;
+impl ManyGuards {
+    #[then]
+    fn pay(self, ctx: Context) {
+        Ok(Box::new(std::iter::once(payment(
+            ctx,
+            &[
+                Clause::Key(key(1)),
+                Clause::Key(key(2)),
+                Clause::Key(key(3)),
+            ],
+        ))))
+    }
+}
+impl Contract for ManyGuards {
+    declare! {then, Self::pay}
+    declare! {non updatable}
+}
+
+#[test]
+fn multiple_template_guards_all_remain_required() {
+    let compiled = ManyGuards.compile(context(false)).unwrap();
+    let Some(SupportedDescriptors::XOnly(descriptor)) = &compiled.descriptor else {
+        panic!()
+    };
+    let policy = descriptor.lift().unwrap();
+    let hash = compiled.ctv_to_tx.keys().next().copied().unwrap();
+    for mask in 0..8 {
+        assert_eq!(accepts(&policy, mask, hash), mask == 7);
+    }
+}

--- a/sapio_macros/src/lib.rs
+++ b/sapio_macros/src/lib.rs
@@ -1,314 +1,190 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}
+// Copyright Judica, Inc 2021
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+//  License, v. 2.0. If a copy of the MPL was not distributed with this
+//  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use core::ops::Index;
+//! Attribute macros for Sapio contract actions.
+
 use proc_macro::TokenStream;
+use proc_macro2::TokenStream as Tokens;
 use quote::{format_ident, quote};
-use std::str::FromStr;
-use syn::Lit;
-use syn::{parse_macro_input, AttributeArgs, ItemFn, Meta, NestedMeta};
-/// The compile_if macro is used to define a `ConditionallyCompileIf`.
-/// formats for calling are:
-/// ```ignore
-/// #[compile_if]
-/// fn name(self, ctx: Context) {
-///     /*ConditionallyCompileType*/
-/// }
-/// ```
+use syn::{
+    ext::IdentExt, parse_macro_input, parse_quote, AttributeArgs, FnArg, ItemFn, ReturnType,
+};
+
+mod parse;
+use parse::{Action, Options};
+
+/// Declare a conditional-compilation action with `(self, ctx: Context)`.
+///
+/// The body returns `ConditionalCompileType`. No options are accepted.
 #[proc_macro_attribute]
 pub fn compile_if(args: TokenStream, input: TokenStream) -> TokenStream {
-    let _args = parse_macro_input!(args as AttributeArgs);
-    let input = parse_macro_input!(input as ItemFn);
-    if input.sig.inputs.len() != 2 {
-        panic!("Too may Arguments to function");
-    }
-    let context_arg = input.sig.inputs.index(1);
-    let name = input.sig.ident;
-    let compile_if_name = format_ident!("compile_if_{}", name);
-    let block = input.block;
-    proc_macro::TokenStream::from(quote! {
-        fn #compile_if_name(&self, #context_arg) -> sapio::contract::actions::ConditionalCompileType
-        #block
-        fn #name() -> Option<sapio::contract::actions::ConditionallyCompileIf<Self>> {
-            Some(sapio::contract::actions::ConditionallyCompileIf::Fresh(Self::#compile_if_name))
-        }
-    })
+    expand_attribute(Action::CompileIf, args, input)
 }
 
-/// The guard macro is used to define a `Guard`. Guards may be cached or uncached.
-/// formats for calling are:
-/// ```ignore
-/// #[guard(
-///     /// optional, if desired to only be invoked once
-///     cached
-/// )]
-/// fn name(self, ctx) {
-///     /*Clause*/
-/// }
-/// ```
+/// Declare a guard with `(self, ctx: Context)` and a `Clause` body.
+///
+/// `#[guard(cached)]` instead accepts only `self`: a cached clause cannot depend
+/// on its invocation context. `simps = "Some(Self::metadata)"` optionally supplies
+/// a metadata callback, evaluated with the context of each guard attachment.
 #[proc_macro_attribute]
 pub fn guard(args: TokenStream, input: TokenStream) -> TokenStream {
-    let args = parse_macro_input!(args as AttributeArgs);
-    let input = parse_macro_input!(input as ItemFn);
-    if input.sig.inputs.len() != 2 {
-        panic!("Too may Arguments to function");
-    }
-    let context_arg = input.sig.inputs.index(1);
-    let name = input.sig.ident;
-    let guard_name = format_ident!("guard_{}", name);
-    let block = input.block;
-    let mut ty = format_ident!("Fresh");
-    let simp_gen_f = simp_at(&args).unwrap_or(TokenStream::from_str("None").unwrap().into());
-    for arg in args {
-        match arg {
-            NestedMeta::Meta(Meta::NameValue(v)) if v.path.is_ident("cached") => {
-                ty = format_ident!("Cached");
-            }
-            _ => {}
-        }
-    }
-    proc_macro::TokenStream::from(quote! {
-        fn #guard_name(&self, #context_arg) -> sapio::sapio_base::Clause
-        #block
-        fn  #name() -> Option<sapio::contract::actions::Guard<Self>> {
-            Some(sapio::contract::actions::Guard::#ty(Self::#guard_name, #simp_gen_f))
-        }
-    })
+    expand_attribute(Action::Guard, args, input)
 }
 
-fn get_arrays(args: &Vec<NestedMeta>) -> (proc_macro2::TokenStream, proc_macro2::TokenStream) {
-    let mut compile_if_array = None;
-    let mut guarded_by_array = None;
-    for arg in args {
-        match (&compile_if_array, &guarded_by_array, arg) {
-            (_, None, NestedMeta::Meta(Meta::NameValue(v))) if v.path.is_ident("guarded_by") => {
-                match &v.lit {
-                    Lit::Str(l) => {
-                        guarded_by_array = Some(l.parse().expect("Token Stream Parsing"));
-                    }
-                    _ => panic!("Improperly Formatted {:?}", v),
-                }
-            }
-            (_, Some(_), NestedMeta::Meta(Meta::NameValue(v))) if v.path.is_ident("guarded_by") => {
-                panic!("Repeated guarded_by arguments");
-            }
-            (None, _, NestedMeta::Meta(Meta::NameValue(v))) if v.path.is_ident("compile_if") => {
-                match &v.lit {
-                    Lit::Str(l) => {
-                        compile_if_array = Some(l.parse().expect("Token Stream Parsing"))
-                    }
-                    _ => panic!("Improperly Formatted {:?}", v),
-                }
-            }
-            (Some(_), _, NestedMeta::Meta(Meta::NameValue(v))) if v.path.is_ident("compile_if") => {
-                panic!("Repeated compile_if arguments");
-            }
-            _v => {}
-        }
-    }
-    (
-        compile_if_array.unwrap_or(quote! {[]}),
-        guarded_by_array.unwrap_or(quote! {[]}),
-    )
-}
-
-/// The then macro is used to define a `ThenFunction`.
-/// formats for calling are:
-/// ```ignore
-/// /// A Conditional + Guarded CTV Function
-/// #[then(
-///     /// optional: only compile these branches if these compile_if statements permit
-///     compile_if= "[compile_if_1, ... compile_if_n]",
-///     /// optional: protect these branches with the conjunction (and) of these clauses
-///     guarded_by= "[guard_1, ... guard_n]"
-/// )]
-/// fn name(self, ctx) {
-///     /*Result<Box<Iterator<TransactionTemplate>>>*/
-/// }
-/// ```
+/// Declare a CTV action with `(self, ctx: Context)` and a `TxTmplIt` body.
+///
+/// Optional `guarded_by = "[Self::guard]"` and
+/// `compile_if = "[Self::condition]"` arrays supply guard and condition factories.
+/// Unknown or repeated options are errors, including misspelled guard names.
 #[proc_macro_attribute]
 pub fn then(args: TokenStream, input: TokenStream) -> TokenStream {
-    let args = parse_macro_input!(args as AttributeArgs);
-    let input = parse_macro_input!(input as ItemFn);
-    if input.sig.inputs.len() != 2 {
-        panic!("Too may Arguments to function");
-    }
-    let context_arg = input.sig.inputs.index(1);
-    let name = input.sig.ident;
-    let then_fn_name = format_ident!("then_{}", name);
-    let block = input.block;
-    let (cia, gba) = get_arrays(&args);
-    proc_macro::TokenStream::from(quote! {
-            /// (missing docs fix)
-            fn #name<'a>() -> Option<sapio::contract::actions::ThenFuncAsFinishOrFunc<'a, Self, <Self as sapio::contract::Contract>::StatefulArguments>>{
-                Some(sapio::contract::actions::ThenFunc{
-                    guard: &#gba,
-                    conditional_compile_if: &#cia,
-                    func: Self::#then_fn_name,
-                    name: std::sync::Arc::new(std::stringify!(#name).into()),
-                }.into())
-            }
-            /// (missing docs fix)
-            fn #then_fn_name(&self, #context_arg, _: sapio::contract::actions::ThenFuncTypeTag) -> sapio::contract::TxTmplIt
-            #block
-    })
+    expand_attribute(Action::Then, args, input)
 }
 
-fn web_api(args: &Vec<NestedMeta>) -> proc_macro2::TokenStream {
-    for arg in args {
-        match arg {
-            NestedMeta::Meta(Meta::Path(v)) if v.is_ident("web_api") => {
-                return quote! { sapio::contract::actions::WebAPIEnabled};
-            }
-            _ => continue,
-        }
-    }
-    quote! { sapio::contract::actions::WebAPIDisabled}
-}
-fn coerce_args(args: &Vec<NestedMeta>) -> proc_macro2::TokenStream {
-    for arg in args {
-        match arg {
-            NestedMeta::Meta(Meta::NameValue(v)) if v.path.is_ident("coerce_args") => {
-                match &v.lit {
-                    Lit::Str(l) => {
-                        return l.parse().expect("Token Stream Parsing");
-                    }
-                    _ => panic!("Improperly Formatted {:?}", v),
-                }
-            }
-            _ => continue,
-        }
-    }
-    panic!("No Coerce Arguments found");
-}
-fn simp_at(args: &Vec<NestedMeta>) -> Option<proc_macro2::TokenStream> {
-    for arg in args {
-        match arg {
-            NestedMeta::Meta(Meta::NameValue(v)) if v.path.is_ident("simps") => match &v.lit {
-                Lit::Str(l) => {
-                    return Some(l.parse().expect("Token Stream Parsing"));
-                }
-                _ => panic!("Improperly Formatted {:?}", v),
-            },
-            _ => continue,
-        }
-    }
-    None
-}
-
-fn web_api_schema(
-    args: &Vec<NestedMeta>,
-    name: &syn::Ident,
-    typ: &syn::FnArg,
-) -> proc_macro2::TokenStream {
-    if let syn::FnArg::Typed(v) = typ {
-        let ty = &v.ty;
-        for arg in args {
-            match arg {
-                NestedMeta::Meta(Meta::Path(v)) if v.is_ident("web_api") => {
-                    return quote! {
-                    const #name : Option<&'static dyn Fn() -> std::sync::Arc<serde_json::Value>> =
-                        Some(&|| sapio::contract::macros::get_schema_for::<#ty>());
-                    };
-                }
-                _ => continue,
-            }
-        }
-    } else {
-        panic!("Wrong type: {:?}", typ);
-    }
-    quote! {
-        const #name : Option<&'static dyn Fn() -> std::sync::Arc<serde_json::Value>> = None;
-    }
-}
+/// Declare a continuation with `(self, ctx: Context, args: SpecificArgs)`.
 ///
-///
-/// The `continuation` macro generates a static `fn() -> Option<FinishOrFunc>` method for a given impl.
-///
-/// There are a few variants of how you can create a `continuation`.
-///
-/// ```ignore
-/// struct UpdateType;
-/// /// Helper
-/// fn default_coerce(
-///     k: <T as Contract>::StatefulArguments,
-/// ) -> Result<UpdateType, CompilationError> {
-///     Ok(k)
-/// }
-/// impl MyContract {
-///     fn simp_gen(&self, ctx:Context)
-/// -> Result<Vec<Box<dyn SIMPAttachableAt<ContinuationPointLT>>>, CompilationError> {}
-///
-///     /// A Guarded CTV Function
-///     #[continuation(
-///         /// required: guards for the miniscript clauses required
-///         guarded_by = "[Self::guard_1,... Self::guard_n]",
-///         /// optional: Conditional compilation
-///         compile_if = "[Self::compile_if_1, ... Self::compile_if_n]",
-///         ///  optional: Enables compiling this for a json callable continuation
-///         web_api,
-///         /// helper for coercing args for json api, could be arbitrary
-///         coerce_args = "default_coerce",
-///         /// simps
-///         simps = "simp_gen",
-///     )]
-///     fn name(self, ctx:Context, o:UpdateType) {
-///         /*Result<Box<Iterator<TransactionTemplate>>>*/
-///     }
-/// }
-/// /// Null Implementation
-/// decl_finish!(name);
-/// ```
+/// `coerce_args = "Self::coerce"` is required. Optional `guarded_by` and
+/// `compile_if` arrays work as on `then`; `web_api` enables JSON calls and
+/// `simps = "Some(Self::metadata)"` supplies continuation metadata.
 #[proc_macro_attribute]
 pub fn continuation(args: TokenStream, input: TokenStream) -> TokenStream {
+    expand_attribute(Action::Continuation, args, input)
+}
+
+fn expand_attribute(action: Action, args: TokenStream, input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(args as AttributeArgs);
     let input = parse_macro_input!(input as ItemFn);
-    let name = input.sig.ident;
-    let continue_name = format_ident!("continue_{}", name);
-    let block = input.block;
-    if input.sig.inputs.len() != 3 {
-        panic!("Too may Arguments to function");
-    }
-    let arg_type = input
-        .sig
-        .inputs
-        .last()
-        .expect("Must have at least one argument");
-    let context_arg = input.sig.inputs.index(1);
-    let (cia, gba) = get_arrays(&args);
-    let web_api_type = web_api(&args);
-    let continue_schema_for_name =
-        format_ident!("CONTINUE_SCHEMA_FOR_{}", name.to_string().to_uppercase());
-    let web_api_schema_s = web_api_schema(&args, &continue_schema_for_name, arg_type);
-    let coerce_args_f = coerce_args(&args);
-    let simp_gen_f = simp_at(&args).unwrap_or(TokenStream::from_str("None").unwrap().into());
-    proc_macro::TokenStream::from(quote! {
-            #web_api_schema_s
-            /// (missing docs fix)
-            fn #continue_name(&self, #context_arg, #arg_type) -> sapio::contract::TxTmplIt
-            #block
-            /// (missing docs fix)
-            fn #name<'a>() -> Option<Box<dyn
-                sapio::contract::actions::CallableAsFoF<Self, <Self as sapio::contract::Contract>::StatefulArguments>>>
-            {
-                let f : sapio::contract::actions::FinishOrFunc<_, _, _, #web_api_type>= sapio::contract::actions::FinishOrFunc{
-                    simp_gen: #simp_gen_f,
-                    coerce_args: #coerce_args_f,
-                    guard: &#gba,
-                    conditional_compile_if: &#cia,
-                    func: Self::#continue_name,
-                    schema: Self::#continue_schema_for_name.map(|f|f()),
-                    name: std::sync::Arc::new(std::stringify!(#name).into()),
-                    f: std::default::Default::default(),
-                    returned_txtmpls_modify_guards: false,
-                    extract_clause_from_txtmpl: sapio::contract::actions::default_extract_clause_from_txtmpl
-                };
-                Some(Box::new(f))
-            }
-    })
+    expand(action, args, input)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
 }
+
+fn expand(action: Action, args: AttributeArgs, mut input: ItemFn) -> syn::Result<Tokens> {
+    let options = Options::parse(action, args, input.sig.ident.span())?;
+    parse::validate_signature(action, &options, &input.sig)?;
+    let name = input.sig.ident.clone();
+    let action_name = name.unraw().to_string();
+    let attrs = input.attrs.clone();
+    let vis = input.vis.clone();
+    let helper = format_ident!("{}_{}", action.helper_prefix(), name);
+    input.sig.ident = helper.clone();
+    // The authoring syntax permits `self` as shorthand for the shared receiver
+    // required by action callbacks. Other receiver forms are validated above.
+    if let Some(FnArg::Receiver(receiver)) = input.sig.inputs.first_mut() {
+        receiver.reference = Some((Default::default(), None));
+    }
+    if matches!(input.sig.output, ReturnType::Default) {
+        input.sig.output = match action {
+            Action::CompileIf => {
+                parse_quote!(-> ::sapio::contract::actions::ConditionalCompileType)
+            }
+            Action::Guard => parse_quote!(-> ::sapio::sapio_base::Clause),
+            Action::Then | Action::Continuation => parse_quote!(-> ::sapio::contract::TxTmplIt),
+        };
+    }
+    input
+        .attrs
+        .push(parse_quote!(#[doc = "Implementation of the contract action."]));
+
+    let Options {
+        cached,
+        guarded_by,
+        compile_if,
+        coerce_args,
+        simps,
+        web_api,
+    } = options;
+    let factory = match action {
+        Action::CompileIf => quote! {
+            #(#attrs)*
+            #[doc = "Conditional-compilation action declaration."]
+            #vis fn #name() -> ::std::option::Option<::sapio::contract::actions::ConditionallyCompileIf<Self>> {
+                ::std::option::Option::Some(
+                    ::sapio::contract::actions::ConditionallyCompileIf::Fresh(Self::#helper)
+                )
+            }
+        },
+        Action::Guard => {
+            let variant = if cached { quote!(Cache) } else { quote!(Fresh) };
+            quote! {
+                #(#attrs)*
+                #[doc = "Guard action declaration."]
+                #vis fn #name() -> ::std::option::Option<::sapio::contract::actions::Guard<Self>> {
+                    ::std::option::Option::Some(
+                        ::sapio::contract::actions::Guard::#variant(Self::#helper, #simps)
+                    )
+                }
+            }
+        }
+        Action::Then => {
+            input
+                .sig
+                .inputs
+                .push(parse_quote!(_: ::sapio::contract::actions::ThenFuncTypeTag));
+            quote! {
+                #(#attrs)*
+                #[doc = "CTV action declaration."]
+                #vis fn #name<'a>() -> ::std::option::Option<::sapio::contract::actions::ThenFuncAsFinishOrFunc<'a, Self, <Self as ::sapio::contract::Contract>::StatefulArguments>> {
+                    ::std::option::Option::Some(::sapio::contract::actions::ThenFunc {
+                        guard: &#guarded_by,
+                        conditional_compile_if: &#compile_if,
+                        func: Self::#helper,
+                        name: ::std::sync::Arc::new(#action_name.into()),
+                    }.into())
+                }
+            }
+        }
+        Action::Continuation => {
+            let schema_helper = format_ident!("__sapio_schema_for_{}", name);
+            let FnArg::Typed(argument) = &input.sig.inputs[2] else {
+                unreachable!("validated continuation argument")
+            };
+            let ty = &argument.ty;
+            let (web_api_type, schema) = if web_api {
+                (
+                    quote!(::sapio::contract::actions::WebAPIEnabled),
+                    quote!(::std::option::Option::Some(::sapio::contract::macros::get_schema_for::<#ty>())),
+                )
+            } else {
+                (
+                    quote!(::sapio::contract::actions::WebAPIDisabled),
+                    quote!(::std::option::Option::None),
+                )
+            };
+            quote! {
+                #(#attrs)*
+                #[doc = "JSON schema for the continuation's specific arguments."]
+                #vis fn #schema_helper() -> ::sapio::contract::macros::ContinuationSchema {
+                    #schema
+                }
+                #(#attrs)*
+                #[doc = "Continuation action declaration."]
+                #vis fn #name<'a>() -> ::std::option::Option<::std::boxed::Box<dyn
+                    ::sapio::contract::actions::CallableAsFoF<Self, <Self as ::sapio::contract::Contract>::StatefulArguments>>>
+                {
+                    let action: ::sapio::contract::actions::FinishOrFunc<_, _, _, #web_api_type> =
+                        ::sapio::contract::actions::FinishOrFunc {
+                            simp_gen: #simps,
+                            coerce_args: #coerce_args,
+                            guard: &#guarded_by,
+                            conditional_compile_if: &#compile_if,
+                            func: Self::#helper,
+                            schema: Self::#schema_helper(),
+                            name: ::std::sync::Arc::new(#action_name.into()),
+                            f: ::std::default::Default::default(),
+                            returned_txtmpls_modify_guards: false,
+                            extract_clause_from_txtmpl: ::sapio::contract::actions::default_extract_clause_from_txtmpl,
+                        };
+                    ::std::option::Option::Some(::std::boxed::Box::new(action))
+                }
+            }
+        }
+    };
+    Ok(quote!(#input #factory))
+}
+
+#[cfg(test)]
+mod tests;

--- a/sapio_macros/src/parse.rs
+++ b/sapio_macros/src/parse.rs
@@ -1,0 +1,203 @@
+use proc_macro2::Span;
+use std::collections::BTreeSet;
+use syn::{
+    parse_quote, spanned::Spanned, AttributeArgs, Expr, ExprArray, FnArg, Lit, LitStr, Meta,
+    NestedMeta, Signature,
+};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Action {
+    CompileIf,
+    Guard,
+    Then,
+    Continuation,
+}
+
+impl Action {
+    pub(crate) fn helper_prefix(self) -> &'static str {
+        match self {
+            Self::CompileIf => "compile_if",
+            Self::Guard => "guard",
+            Self::Then => "then",
+            Self::Continuation => "continue",
+        }
+    }
+
+    fn accepts(self, name: &str) -> bool {
+        match name {
+            "cached" => self == Self::Guard,
+            "guarded_by" | "compile_if" => matches!(self, Self::Then | Self::Continuation),
+            "coerce_args" | "web_api" => self == Self::Continuation,
+            "simps" => matches!(self, Self::Guard | Self::Continuation),
+            _ => false,
+        }
+    }
+}
+
+pub(crate) struct Options {
+    pub cached: bool,
+    pub guarded_by: ExprArray,
+    pub compile_if: ExprArray,
+    pub coerce_args: Option<Expr>,
+    pub simps: Expr,
+    pub web_api: bool,
+}
+
+impl Options {
+    pub(crate) fn parse(action: Action, args: AttributeArgs, span: Span) -> syn::Result<Self> {
+        let mut options = Self {
+            cached: false,
+            guarded_by: parse_quote!([]),
+            compile_if: parse_quote!([]),
+            coerce_args: None,
+            simps: parse_quote!(::std::option::Option::None),
+            web_api: false,
+        };
+        let mut seen = BTreeSet::new();
+        for arg in args {
+            let NestedMeta::Meta(meta) = arg else {
+                return Err(syn::Error::new_spanned(
+                    arg,
+                    "expected a named action option",
+                ));
+            };
+            let name = meta.path().get_ident().map(ToString::to_string);
+            let Some(name) = name.filter(|name| action.accepts(name)) else {
+                return Err(syn::Error::new_spanned(
+                    meta.path(),
+                    "unknown option for this action",
+                ));
+            };
+            if !seen.insert(name.clone()) {
+                return Err(syn::Error::new_spanned(
+                    meta.path(),
+                    format!("duplicate `{name}` option"),
+                ));
+            }
+            match name.as_str() {
+                "cached" | "web_api" => {
+                    if !matches!(meta, Meta::Path(_)) {
+                        return Err(syn::Error::new_spanned(
+                            meta,
+                            format!("`{name}` is a flag; use `{name}` without a value"),
+                        ));
+                    }
+                    if name == "cached" {
+                        options.cached = true;
+                    } else {
+                        options.web_api = true;
+                    }
+                }
+                "guarded_by" | "compile_if" => {
+                    let literal = string_value(&meta)?;
+                    let array = literal.parse::<ExprArray>().map_err(|_| {
+                        syn::Error::new(literal.span(), format!("`{name}` must contain an array expression such as `[Self::action]`"))
+                    })?;
+                    if name == "guarded_by" {
+                        options.guarded_by = array;
+                    } else {
+                        options.compile_if = array;
+                    }
+                }
+                "coerce_args" => options.coerce_args = Some(string_value(&meta)?.parse()?),
+                "simps" => options.simps = string_value(&meta)?.parse()?,
+                _ => unreachable!("validated action option"),
+            }
+        }
+        if action == Action::Continuation && options.coerce_args.is_none() {
+            return Err(syn::Error::new(
+                span,
+                "continuation requires `coerce_args = \"Self::coerce\"`",
+            ));
+        }
+        Ok(options)
+    }
+}
+
+fn string_value(meta: &Meta) -> syn::Result<&LitStr> {
+    if let Meta::NameValue(value) = meta {
+        if let Lit::Str(literal) = &value.lit {
+            return Ok(literal);
+        }
+    }
+    Err(syn::Error::new_spanned(
+        meta,
+        "expected `option = \"expression\"`",
+    ))
+}
+
+pub(crate) fn validate_signature(
+    action: Action,
+    options: &Options,
+    sig: &Signature,
+) -> syn::Result<()> {
+    if let Some(token) = &sig.asyncness {
+        return Err(syn::Error::new(
+            token.span(),
+            "contract actions cannot be async",
+        ));
+    }
+    if let Some(token) = &sig.constness {
+        return Err(syn::Error::new(
+            token.span(),
+            "contract actions cannot be const",
+        ));
+    }
+    if let Some(token) = &sig.unsafety {
+        return Err(syn::Error::new(
+            token.span(),
+            "contract actions cannot be unsafe",
+        ));
+    }
+    if let Some(abi) = &sig.abi {
+        return Err(syn::Error::new_spanned(
+            abi,
+            "contract actions cannot specify an ABI",
+        ));
+    }
+    if !sig.generics.params.is_empty() || sig.generics.where_clause.is_some() {
+        return Err(syn::Error::new_spanned(&sig.generics, "contract actions cannot declare method generics or where clauses; put them on the impl"));
+    }
+    if let Some(variadic) = &sig.variadic {
+        return Err(syn::Error::new_spanned(
+            variadic,
+            "contract actions cannot be variadic",
+        ));
+    }
+    let count = if options.cached {
+        1
+    } else if action == Action::Continuation {
+        3
+    } else {
+        2
+    };
+    if sig.inputs.len() != count {
+        let expected = if options.cached {
+            "a cached guard takes only `self`; cached clauses cannot depend on Context"
+        } else if action == Action::Continuation {
+            "a continuation takes `self, ctx: Context, args: SpecificArgs`"
+        } else {
+            "this action takes `self, ctx: Context`"
+        };
+        return Err(syn::Error::new_spanned(&sig.inputs, expected));
+    }
+    match sig.inputs.first() {
+        Some(FnArg::Receiver(receiver))
+            if receiver.mutability.is_none() && receiver.lifetime().is_none() => {}
+        _ => {
+            return Err(syn::Error::new_spanned(
+                &sig.inputs[0],
+                "contract actions require `self` or `&self` as their first argument",
+            ))
+        }
+    }
+    for argument in sig.inputs.iter().skip(1) {
+        if !matches!(argument, FnArg::Typed(_)) {
+            return Err(syn::Error::new_spanned(
+                argument,
+                "expected a typed action argument",
+            ));
+        }
+    }
+    Ok(())
+}

--- a/sapio_macros/src/tests.rs
+++ b/sapio_macros/src/tests.rs
@@ -1,0 +1,245 @@
+use super::*;
+use syn::{
+    parse::Parser, punctuated::Punctuated, ImplItem, ItemImpl, NestedMeta, Token, Visibility,
+};
+
+fn arguments(tokens: Tokens) -> AttributeArgs {
+    Punctuated::<NestedMeta, Token![,]>::parse_terminated
+        .parse2(tokens)
+        .unwrap()
+        .into_iter()
+        .collect()
+}
+
+fn options(action: Action, tokens: Tokens) -> syn::Result<Options> {
+    Options::parse(action, arguments(tokens), proc_macro2::Span::call_site())
+}
+
+fn option_error(action: Action, tokens: Tokens) -> String {
+    match options(action, tokens) {
+        Ok(_) => panic!("invalid options were accepted"),
+        Err(error) => error.to_string(),
+    }
+}
+
+#[test]
+fn unknown_options_fail_instead_of_removing_contract_conditions() {
+    for action in [
+        Action::CompileIf,
+        Action::Guard,
+        Action::Then,
+        Action::Continuation,
+    ] {
+        for tokens in [
+            quote!(guarded_byy = "[Self::signed]"),
+            quote!(compile_iff = "[Self::allowed]"),
+            quote!(unknown),
+        ] {
+            assert_eq!(
+                option_error(action, tokens),
+                "unknown option for this action"
+            );
+        }
+    }
+    for (action, tokens) in [
+        (Action::CompileIf, quote!(cached)),
+        (Action::Guard, quote!(guarded_by = "[]")),
+        (Action::Then, quote!(web_api)),
+        (Action::Then, quote!(simps = "None")),
+        (Action::Continuation, quote!(cached)),
+    ] {
+        assert_eq!(
+            option_error(action, tokens),
+            "unknown option for this action"
+        );
+    }
+}
+
+#[test]
+fn duplicate_options_are_always_errors() {
+    for (action, tokens, name) in [
+        (Action::Guard, quote!(cached, cached), "cached"),
+        (
+            Action::Guard,
+            quote!(simps = "None", simps = "None"),
+            "simps",
+        ),
+        (
+            Action::Then,
+            quote!(guarded_by = "[]", guarded_by = "[]"),
+            "guarded_by",
+        ),
+        (
+            Action::Then,
+            quote!(compile_if = "[]", compile_if = "[]"),
+            "compile_if",
+        ),
+        (Action::Continuation, quote!(web_api, web_api), "web_api"),
+        (
+            Action::Continuation,
+            quote!(coerce_args = "one", coerce_args = "two"),
+            "coerce_args",
+        ),
+    ] {
+        assert_eq!(
+            option_error(action, tokens),
+            format!("duplicate `{name}` option")
+        );
+    }
+}
+
+#[test]
+fn options_require_their_documented_syntax() {
+    for tokens in [
+        quote!(cached = true),
+        quote!(cached = false),
+        quote!(cached()),
+    ] {
+        assert!(option_error(Action::Guard, tokens).contains("`cached` is a flag"));
+    }
+    for tokens in [
+        quote!(guarded_by = 1),
+        quote!(guarded_by),
+        quote!(guarded_by(Self::signed)),
+    ] {
+        assert!(option_error(Action::Then, tokens).contains("expected `option ="));
+    }
+    for tokens in [
+        quote!(guarded_by = "Self::signed"),
+        quote!(guarded_by = "[Self::signed; 2]"),
+        quote!(guarded_by = "[Self::signed] junk"),
+    ] {
+        assert!(option_error(Action::Then, tokens).contains("array expression"));
+    }
+    assert!(option_error(Action::Continuation, quote!()).contains("requires `coerce_args"));
+    assert!(options(Action::Continuation, quote!(coerce_args = "{")).is_err());
+    assert!(options(Action::Guard, quote!(simps = "Some(")).is_err());
+    let valid = options(
+        Action::Continuation,
+        quote!(
+            guarded_by = "[Self::signed, Self::timeout]",
+            compile_if = "[Self::enabled]",
+            coerce_args = "default_coerce::<Self>",
+            simps = "Some(Self::metadata)",
+            web_api,
+        ),
+    )
+    .unwrap();
+    assert_eq!(valid.guarded_by.elems.len(), 2);
+    assert_eq!(valid.compile_if.elems.len(), 1);
+    assert!(valid.web_api);
+}
+
+#[test]
+fn unsupported_signatures_are_rejected_before_expansion() {
+    for (source, message) in [
+        ("async fn signed(self, ctx: Context) {}", "cannot be async"),
+        ("const fn signed(self, ctx: Context) {}", "cannot be const"),
+        (
+            "unsafe fn signed(self, ctx: Context) {}",
+            "cannot be unsafe",
+        ),
+        (
+            "extern \"C\" fn signed(self, ctx: Context) {}",
+            "specify an ABI",
+        ),
+        ("fn signed<T>(self, ctx: Context) {}", "method generics"),
+        (
+            "fn signed(self, ctx: Context) where Self: Clone {}",
+            "where clauses",
+        ),
+        ("fn signed(ctx: Context, unused: ()) {}", "first argument"),
+        (
+            "fn signed(self: Box<Self>, ctx: Context) {}",
+            "first argument",
+        ),
+        ("fn signed(&mut self, ctx: Context) {}", "first argument"),
+        ("fn signed(mut self, ctx: Context) {}", "first argument"),
+        (
+            "fn signed(&'static self, ctx: Context) {}",
+            "first argument",
+        ),
+        ("fn signed() {}", "takes `self, ctx"),
+        (
+            "fn signed(self, ctx: Context, extra: ()) {}",
+            "takes `self, ctx",
+        ),
+    ] {
+        let error = expand(Action::Guard, vec![], syn::parse_str(source).unwrap()).unwrap_err();
+        assert!(error.to_string().contains(message), "{source}: {error}");
+    }
+    let error = expand(
+        Action::Guard,
+        arguments(quote!(cached)),
+        parse_quote!(
+            fn signed(self, ctx: Context) {}
+        ),
+    )
+    .unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("cached clauses cannot depend on Context"));
+    for receiver in [quote!(self), quote!(&self)] {
+        let input = syn::parse2(quote!(fn signed(#receiver) {})).unwrap();
+        assert!(expand(Action::Guard, arguments(quote!(cached)), input).is_ok());
+    }
+}
+
+#[test]
+fn expansion_preserves_attributes_visibility_patterns_and_return_types() {
+    let expansion = expand(
+        Action::Then,
+        vec![],
+        parse_quote! {
+            #[doc = "A documented action."]
+            #[cfg(feature = "payments")]
+            #[allow(unused_variables)]
+            pub(crate) fn pay(&self, mut context: Context) -> CustomResult { body(context) }
+        },
+    )
+    .unwrap();
+    let generated: ItemImpl = syn::parse2(quote!(impl Contract { #expansion })).unwrap();
+    assert_eq!(generated.items.len(), 2);
+    for item in generated.items {
+        let ImplItem::Method(method) = item else {
+            panic!("expected a method")
+        };
+        assert!(matches!(method.vis, Visibility::Restricted(_)));
+        for attr in ["doc", "cfg", "allow"] {
+            assert!(method.attrs.iter().any(|a| a.path.is_ident(attr)));
+        }
+        if method.sig.ident == "then_pay" {
+            assert_eq!(method.sig.output, parse_quote!(-> CustomResult));
+            assert_eq!(method.sig.inputs[1], parse_quote!(mut context: Context));
+            assert_eq!(method.block, parse_quote!({ body(context) }));
+        }
+    }
+}
+
+#[test]
+fn continuation_helpers_preserve_case_and_raw_identifiers() {
+    let mut names = std::collections::BTreeSet::new();
+    for ident in [quote!(pay), quote!(PAY), quote!(r#type)] {
+        let expansion = expand(
+            Action::Continuation,
+            arguments(quote!(coerce_args = "Ok", web_api)),
+            syn::parse2(quote! {
+                #[allow(non_snake_case)]
+                fn #ident(self, ctx: Context, args: ()) {}
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        let generated: ItemImpl = syn::parse2(quote!(impl Contract { #expansion })).unwrap();
+        for item in generated.items {
+            let ImplItem::Method(method) = item else {
+                panic!("expected a method")
+            };
+            assert!(names.insert(method.sig.ident.to_string()));
+            assert!(method.attrs.iter().any(|a| a.path.is_ident("allow")));
+        }
+    }
+    assert!(names.contains("__sapio_schema_for_pay"));
+    assert!(names.contains("__sapio_schema_for_PAY"));
+    assert!(names.contains("__sapio_schema_for_type"));
+}


### PR DESCRIPTION
Contract compilation could lose authorization requirements before Bitcoin lowering: a misspelled `guarded_by` option was silently ignored, and deduplicating transaction templates by CTV hash could discard a later template's additional guards. If Alice can authorize a transaction alone but Bob needs Carol, sharing that transaction must preserve `Alice OR (Bob AND Carol)` in either declaration order.

This cleans up the declaration-to-policy compiler in four commits:

- Preserve declared conditional-compilation slots, propagate path derivation failures, and collect explicit failures plus `Required`/`Never` contradictions consistently.
- Parse action attributes strictly and preserve method signatures, visibility and attributes. Align trait declaration helpers with generated methods. Make cached clauses context-free while evaluating their metadata at every actual attachment, including finish guards.
- Extract each action's full policy before sharing transaction storage. Require shared templates to agree on funding requirements, metadata and child contract graphs. Preserve all guard conjunctions and inscription envelope multiplicity, and validate action/effect names before callbacks can observe ambiguous paths.
- Document these rules in `docs/LANGUAGE_SEMANTICS.md` and update the guard guide. Remove the derivative example's local template-deduplication workaround.

Intentional API changes: cached guards use `#[guard(cached)] fn name(self)` and `Guard::Cache(fn(&Self) -> Clause, ...)`; unknown or misplaced macro options are compile errors; equal transaction commitments with different binding payloads return `ConflictingTemplate`. Existing cached examples are migrated. Shared transactions should reuse a common compiled destination and metadata.

Validation:

- 271 native workspace tests pass with all features, including signer/commitment truth tables under native and emulated CTV, actual inscription script envelopes, conditional failures, contextual metadata and macro declarations.
- The first two commits also pass their relevant tests in isolated checkouts.
- 21 plugin workspace tests and all optimized WASM module builds pass.
- Both plugin feature configurations, formatting, workspace Clippy, API documentation and the book build pass.
- All 18 WASM modules pass the real host catalog, including repeatable artifacts and schema rejection; both shared interfaces are inventoried. CLI direct/cross-module compilation, inscription compilation and mock binding pass.
- [GitHub CI](https://github.com/sapio-lang/sapio/actions/runs/34306566808) is green for all four jobs: Linux tests, macOS tests, quality and WASM.
