### PR TITLE
Add extensible policy backends and harden script lowering

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,6 +27,25 @@ jobs:
         run: rustup show
       - run: cargo test --workspace --all-features --locked
       - run: cargo test -p sapio --example payment --locked
+      - name: Install pinned Bitcoin Core
+        if: runner.os == 'Linux'
+        run: |
+          curl --fail --location --retry 3 --max-time 120 \
+            --output "$RUNNER_TEMP/bitcoin.tar.gz" \
+            https://bitcoincore.org/bin/bitcoin-core-31.1/bitcoin-31.1-x86_64-linux-gnu.tar.gz
+          echo "b80d9c3e04da78fb6f0569685673418cf686fadba9042d926d13fb87ff503f9e  $RUNNER_TEMP/bitcoin.tar.gz" | sha256sum --check
+          tar -xzf "$RUNNER_TEMP/bitcoin.tar.gz" -C "$RUNNER_TEMP"
+      - name: Build custom policy spend vectors
+        if: runner.os == 'Linux'
+        run: cargo build --locked -p sapio --example custom_policy_vectors
+      - name: Validate custom policy witnesses with Bitcoin Core
+        if: runner.os == 'Linux'
+        timeout-minutes: 5
+        run: >-
+          python3 contrib/check_custom_policy.py
+          "$RUNNER_TEMP/bitcoin-31.1/bin/bitcoind"
+          "$RUNNER_TEMP/bitcoin-31.1/bin/bitcoin-cli"
+          target/debug/examples/custom_policy_vectors
 
   quality:
     runs-on: ubuntu-24.04

--- a/contrib/check_custom_policy.py
+++ b/contrib/check_custom_policy.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Execute Sapio's raw-policy witnesses against isolated Bitcoin Core regtest.
+
+Usage: check_custom_policy.py BITCOIND BITCOIN_CLI CUSTOM_POLICY_VECTORS
+The vector executable comes from `cargo build -p sapio --example
+custom_policy_vectors`. No existing node, wallet, or user funds are accessed.
+"""
+
+import json
+from pathlib import Path
+import socket
+import subprocess
+import sys
+import tempfile
+
+
+def main():
+    if len(sys.argv) != 4:
+        raise SystemExit(__doc__)
+    bitcoind, bitcoin_cli, vectors = [str(Path(arg).resolve()) for arg in sys.argv[1:]]
+    initial = json.loads(subprocess.check_output([vectors], text=True, timeout=30))
+    with tempfile.TemporaryDirectory(prefix="sapio-custom-policy-") as directory:
+        data = Path(directory)
+        with socket.socket() as reservation:
+            reservation.bind(("127.0.0.1", 0))
+            port = reservation.getsockname()[1]
+        with (data / "node.log").open("w") as log:
+            node = subprocess.Popen(
+                [bitcoind, "-regtest", "-server=1", f"-datadir={data}",
+                 f"-rpcport={port}", "-listen=0", "-connect=0", "-dnsseed=0",
+                 "-discover=0", "-fallbackfee=0.00001", "-printtoconsole=1"],
+                stdout=log, stderr=subprocess.STDOUT,
+            )
+
+            def rpc(method, *arguments, wallet=False):
+                command = [bitcoin_cli, "-regtest", f"-datadir={data}",
+                           f"-rpcport={port}", "-rpcwait", "-rpcwaittimeout=30"]
+                if wallet:
+                    command.append("-rpcwallet=custom-policy")
+                command.append(method)
+                command.extend(
+                    json.dumps(argument, separators=(",", ":"))
+                    if isinstance(argument, (dict, list, bool)) else str(argument)
+                    for argument in arguments
+                )
+                output = subprocess.check_output(command, text=True, timeout=40).strip()
+                if not output:
+                    return None
+                try:
+                    return json.loads(output)
+                except json.JSONDecodeError:
+                    return output
+
+            try:
+                rpc("getblockchaininfo")
+                rpc("createwallet", "custom-policy")
+                miner = rpc("getnewaddress", "", "bech32m", wallet=True)
+                rpc("generatetoaddress", 101, miner)
+                funding = {}
+                for group in initial["groups"]:
+                    amount = group["funding_amount_sats"]
+                    coins = f"{amount // 100_000_000}.{amount % 100_000_000:08d}"
+                    txid = rpc("sendtoaddress", group["address"], coins, wallet=True)
+                    raw = rpc("gettransaction", txid, wallet=True)["hex"]
+                    transaction = rpc("decoderawtransaction", raw)
+                    matches = [output for output in transaction["vout"]
+                               if output["scriptPubKey"].get("address") == group["address"]]
+                    assert len(matches) == 1, (group["name"], matches)
+                    funding[group["name"]] = f"{txid}:{matches[0]['n']}"
+                rpc("generatetoaddress", 1, miner)
+                funding_file = data / "funding.json"
+                funding_file.write_text(json.dumps(funding))
+                signed = json.loads(subprocess.check_output(
+                    [vectors, str(funding_file)], text=True, timeout=30,
+                ))
+                accepted, rejected = 0, 0
+                for group in signed["groups"]:
+                    for case in group["cases"]:
+                        result = rpc("testmempoolaccept", [case["transaction"]])[0]
+                        assert result["allowed"] == case["allowed"], (
+                            group["name"], case["name"], result,
+                        )
+                        if case["allowed"]:
+                            accepted += 1
+                        else:
+                            rejected += 1
+                            # A missing funding input would reject everything;
+                            # require each negative to reach script validation.
+                            assert "script" in result.get("reject-reason", "").lower(), result
+                        print(f"{group['name']}/{case['name']}: "
+                              f"{'accepted' if result['allowed'] else 'rejected'}", flush=True)
+                assert (accepted, rejected) == (2, 10), (accepted, rejected)
+                print(f"Bitcoin Core accepted {accepted} valid raw-policy spends and "
+                      f"rejected {rejected} invalid spends. Native CTV was not tested.")
+            finally:
+                if node.poll() is None:
+                    try:
+                        rpc("stop")
+                    except subprocess.SubprocessError:
+                        node.terminate()
+                    try:
+                        node.wait(timeout=30)
+                    except subprocess.TimeoutExpired:
+                        node.kill()
+                        node.wait(timeout=5)
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/vectors/examples/catalog.json
+++ b/contrib/vectors/examples/catalog.json
@@ -195,6 +195,17 @@
       "continuation_count": 2
     }
   },
+  "custom-policy": {
+    "wasm": "sapio_wasm_custom_policy.wasm",
+    "input": "custom-policy.json",
+    "dependencies": [],
+    "expect": {
+      "ctv_count": 1,
+      "root_output_values": [9000],
+      "root_required_input_amount": 10000,
+      "raw_taproot": true
+    }
+  },
   "ordinal-inscription": {
     "wasm": "sapio_wasm_ordinal_inscription.wasm",
     "input": "ordinal-inscription.json",

--- a/contrib/vectors/examples/custom-policy.json
+++ b/contrib/vectors/examples/custom-policy.json
@@ -1,0 +1,10 @@
+{
+  "arguments": {
+    "owner": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+    "co_signer": "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5"
+  },
+  "context": {
+    "amount": 10000,
+    "network": "Regtest"
+  }
+}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -53,7 +53,7 @@ bash contrib/sapio_wasm.sh
 ```
 
 This requires Python 3. The catalog checks that every workspace guest has a
-fixture, compiles all 18 modules with their actual schemas, validates complete
+fixture, compiles all 19 modules with their actual schemas, validates complete
 artifacts, checks payment/timing expectations, compares fresh-instance results,
 and rejects malformed arguments. The two shared interface crates are inventoried
 separately. A CLI smoke test additionally covers cross-module calls, a 521-byte
@@ -76,6 +76,9 @@ five valid transactions are accepted and 21 invalid variants are rejected.
 These ordinary Taproot checks run in the fork repository and do not require a
 node for Sapio's commands above. The [fork's validation guide][fork-inscriptions]
 provides the fixture build and isolated regtest commands.
+Sapio also has [custom-policy node checks](POLICY_BACKENDS.md#node-validation):
+two valid composed Taproot spends and ten invalid variants, with their own
+fixture exporter and isolated Core driver. The Ubuntu native CI job runs them.
 
 For a faster native compiler example:
 
@@ -95,6 +98,7 @@ cargo test --locked -p sapio-base --test ctv_hash
 cargo test --locked -p sapio --test fees --test action_names --test ordinal_allocation
 cargo test --locked -p sapio --test conditional_compilation --test guard_semantics --test macro_declarations
 cargo test --locked -p sapio --test template_semantics --test effect_names --test inscription_guards
+cargo test --locked -p sapio --test custom_policy --test raw_artifacts --test contract_policy_limits
 cargo test --locked -p sapio-wasm-plugin --features host
 cargo test --locked -p sapio_integration_tests
 cargo test --locked -p ctv_emulators --lib
@@ -242,6 +246,18 @@ requires identical funding requirements, metadata and child graphs; conflicts
 report the affected field and action/effect path. Reuse a common compiled child
 and metadata when intentionally returning the same transaction from multiple
 actions.
+
+Custom languages implement `PolicyCompiler` and use `#[guard(policy)]` or
+`Builder::add_policy`. The [policy backend guide](POLICY_BACKENDS.md) describes
+ordered script composition, lowering budgets, checked Taproot artifacts,
+external witness construction and the artifact schema migration. Opaque scripts
+have no inferred satisfaction-weight bound; a requested minimum feerate is an
+error for these contracts.
+
+Native policies are validated before simplification. Fixed transaction templates
+are checked against their known CLTV, CSV and CTV requirements. Taproot keys and
+identical complete scripts are selected deterministically; raw fragment and
+inscription order within a script remain significant.
 
 ## Emulator service limits
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -1,6 +1,6 @@
 # Contract examples
 
-This inventory covers every contract family in `sapio-contrib`, all 18 WASM
+This inventory covers every contract family in `sapio-contrib`, all 19 WASM
 modules and both shared interfaces in `plugin-example`, and the two native
 executables. The examples demonstrate contract construction and have behavioral
 regressions for their supported paths. They remain research examples: compiling
@@ -113,6 +113,7 @@ native mocks.
 | [clause-module-trampoline](../plugin-example/clause-module-trampoline) | Obtains that clause from the real `clause-module` child and returns the same policy. The catalog asserts the exact result. |
 | [ordinal-example](../plugin-example/ordinal-example) | Owner-authorized ordinal sales with direct and planner-based construction. Native regressions check actual ordinal positions, payout destinations, fees, malformed ranges and auxiliary funding; the catalog checks both exposed continuations. |
 | [ordinal-inscription](../plugin-example/ordinal-inscription) | Constructs and carries an inscription through a signed continuation. Native regressions check envelope/payload preservation, ownership and funding; the catalog compiles the artifact and checks its fee-adjusted output. |
+| [custom-policy](../plugin-example/custom-policy) | Implements `PolicyCompiler` with an arithmetic signature predicate outside Miniscript. The catalog validates the raw Taproot artifact and its committed payout; native tests check the payment and reject underfunding. |
 
 The two remaining workspace members are interfaces, not WASM entry points:
 
@@ -137,6 +138,11 @@ known input sats have been allocated and must cover fees when present.
 | --- | --- |
 | [payment](../sapio/examples/payment.rs) | Compiles a fixed 1,000-satoshi payment with a 500-satoshi fee reserve. The test checks the destination, value, one-input shape, 1,500-satoshi input requirement and underfunding. |
 | [dcf_mining_pool](../examples/dcf_mining_pool) | Compiles an offline mining reward payout tree from JSON or a deterministic demonstration. Sorted unique keys receive equal shares after every tree transaction's fee is reserved; remainder sats go to the first keys. Tests traverse all levels, check each P2TR recipient exactly once, conserve the full reward and fees, enforce fanout, and reject invalid radix, duplicates, overflow and insufficient rewards. It replaces the unfinished RPC coordinator; share verification, networking and coinbase coordination are not implemented. |
+
+The [custom policy vector exporter](../sapio/examples/custom_policy_vectors.rs)
+is also an executable test fixture. Its [isolated node driver](../contrib/check_custom_policy.py)
+funds actual regtest outputs and checks custom witnesses against Bitcoin Core.
+See [policy backend validation](POLICY_BACKENDS.md#node-validation).
 
 See the [native example instructions](../examples/README.md) for commands and
 the mining request format.

--- a/docs/LANGUAGE_SEMANTICS.md
+++ b/docs/LANGUAGE_SEMANTICS.md
@@ -3,6 +3,9 @@
 Sapio's Rust frontend declares guarded transaction transitions and continuation
 entry points. The compiler must preserve their authorization through Bitcoin
 lowering, even when several transitions produce the same transaction.
+Native Miniscript clauses and custom policy backends share those action rules;
+see [policy backends](POLICY_BACKENDS.md) for the extension API, raw-script
+obligations, compilation budgets and artifact schema changes.
 
 ## Declarations
 
@@ -42,17 +45,38 @@ lowered descriptor for every signer combination, with native CTV and an emulated
 covenant key, and with a matching or different template commitment.
 
 All listed guards are conjunctive. Zero effective guards mean true, one means
-that guard, and larger lists use valid binary or threshold policy nodes. Exact
-duplicate ordinary predicates and trivial clauses do not add requirements.
-Inscription clauses carry script data: conjunction preserves their order and
-multiplicity, including when nested inside another predicate. A continuation
+that guard, and larger native lists use valid binary or threshold policy nodes.
+Exact duplicate ordinary native predicates and trivial clauses do not add
+requirements. Inscription clauses carry script data: conjunction preserves their
+order and multiplicity, including when nested inside another predicate. Raw
+policy fragments also preserve order and multiplicity; Sapio combines them with
+verification instructions between predicates. A continuation
 contributes its declared guards, while its returned transactions are suggestions;
 **every** suggested template is checked for forbidden additional guards before
 deduplication.
 
 The compiled template's `additional_preconditions` includes the action guards.
 For a shared transaction it records their complete alternative conditions in
-canonical policy order. The descriptor remains the authority for spending.
+canonical policy order. The committed descriptor or raw Taproot tree remains the
+authority for spending.
+
+## Source validity and possible transitions
+
+Native policy nodes are validated before simplification or alternative
+splitting. Invalid arities, thresholds, time constants and inscription fields
+remain errors even when another predicate would make their branch unreachable.
+Keys may occur in separate alternatives such as `(A AND B) OR (A AND C)`;
+Miniscript checks each eventual native script. General `ScriptPolicy::And` and
+`ScriptPolicy::Or` permit n-ary lists, while native `Clause::And` and `Clause::Or`
+require binary nodes. A contract that produces no spending branches returns
+`EmptyPolicy`.
+
+For a committed transition, native constraints must at least be possible for
+the template's fixed transaction fields. Contradictions involving the committed
+input's version, sequence, locktime or CTV hash produce `ImpossibleTemplate`
+with its hash and action path. Keys and preimages are treated as potentially
+available. This check does not establish chain maturity, funding availability
+or complete satisfiability, and it does not infer the meaning of raw scripts.
 
 ## Duplicate transaction payloads
 
@@ -75,11 +99,18 @@ Fresh guards receive `(self, Context)` at each attachment. Cached guards use
 context and is evaluated once per compilation of that contract. At the Rust API
 boundary this is `Guard::Cache(fn(&Self) -> Clause, ...)`.
 
+Custom guards opt in with `#[guard(policy)]` and an explicit backend return
+type. Adding `cached` likewise removes `Context`; the helper and its backend
+translation run once per contract compilation. Fresh backend guards translate
+at every attachment. Backend failures propagate as compilation errors.
+
 Guard metadata callbacks always receive their actual attachment context, for
 both cached and fresh clauses. Finish guards contribute metadata as well as
-spending conditions. Equal serialized metadata values for a clause/protocol
+spending conditions. Equal serialized metadata values for a policy/protocol
 are deduplicated; distinct values from different attachments are retained in
 declaration order. Allocation addresses never control metadata ordering.
+The artifact stores these as ordered policy records with per-protocol values,
+so native and custom guard sources retain the same metadata semantics.
 
 Caching does not make arbitrary Rust code pure. Reproducible compilation still
 requires contract authors to derive behavior from explicit inputs rather than

--- a/docs/MODERNIZATION.md
+++ b/docs/MODERNIZATION.md
@@ -54,6 +54,8 @@ with upstream crates would remove semantics, not complete a migration.
 | Finalizer metadata | Validate PSBT structure and referenced non-witness output bounds; honor explicit ECDSA/Schnorr sighash types on partial and finalized signatures, permit valid non-ALL signatures when no type is declared |
 | Compiler termination | Advance duplicate-action suffixes; derive guard metadata beneath each guard branch and propagate errors; regressions compile repeated actions and a contract with two guards |
 | Language core | [Action semantics](LANGUAGE_SEMANTICS.md): strict macro options and trait interfaces, context-free cached clauses with per-attachment metadata, stable condition slots, original action authorization before transaction deduplication, conflicting binding payload errors and inscription-aware guard composition |
+| Policy lowering | Validate source before simplification, reject fixed templates incompatible with known native CLTV/CSV/CTV requirements, and canonicalize bare-key selection and identical leaf scripts |
+| Custom policy languages | [PolicyCompiler API](POLICY_BACKENDS.md), checked ordered raw fragments, bounded expansion, reconstructed Taproot spending proofs, a real WASM guest and explicit external-finalization diagnostics; carries forward PR #269 |
 | Inscriptions | Repair fork parsing, script-byte preservation, resource/key analysis and interpreter support; 51 fork inscription tests plus Sapio plugin artifact/signing and WASM checks, with checked ordinal ranges and fees |
 | Inscription node validation | Bitcoin Core 31.1 accepts five library-finalized ordinary Taproot reveals and rejects 21 invalid variants in isolated regtest checks; native CTV and Ord index/sat assignment remain separate |
 | Fees | Enforce the strongest requested minimum in virtual bytes against that template's reserved fees; reject overflow and unknown extra-input weights |
@@ -66,7 +68,7 @@ with upstream crates would remove semantics, not complete a migration.
 | Emulator responses | Accept complete PSBT responses containing only signature additions; preserve existing signatures and every other field, including raw HD responses, each federation participant and the WASM signing import |
 | Emulator lifecycle | Bound each peer exchange and the async wait for CLI peer resolution; cap admitted server connections; discard incomplete exchanges, isolate peer errors and cancel owned connection tasks on shutdown |
 | Integration | Restore the suite to the workspace; compile, sign and finalize two contract steps and reject a modified output |
-| Contract examples | [Complete inventory](EXAMPLES.md): repaired and tested library families, restored PowSwap/TapBet, 18 real WASM fixtures, both native examples and explicit research assumptions |
+| Contract examples | [Complete inventory](EXAMPLES.md): repaired and tested library families, restored PowSwap/TapBet, 19 real WASM fixtures, both native examples and explicit research assumptions |
 | Developer checks | Formatting, feature checks, native tests, complete WASM catalog with artifact/schema/repeatability checks, CLI smoke checks, and API documentation |
 
 The [development guide](DEVELOPMENT.md) gives reproducible commands. This list is

--- a/docs/POLICY_BACKENDS.md
+++ b/docs/POLICY_BACKENDS.md
@@ -1,0 +1,320 @@
+# Policy backends and raw Tapscript
+
+Sapio accepts custom policy languages through `sapio::policy::PolicyCompiler`.
+A backend translates its language into immutable `ScriptPolicy` source; Sapio
+then combines that source with action guards, template preconditions and the
+transaction covenant. The existing `sapio_base::Clause` alias remains the native
+Miniscript policy language.
+
+This follows the custom-language and raw-script direction of
+[PR #269, “Sapio w/ Arbitrary Scripts”](https://github.com/sapio-lang/sapio/pull/269).
+The current interface retains native policy compilation, contextual metadata,
+checked artifacts and funding/binding validation. It is a Rust extension point;
+it does not sandbox arbitrary backend code.
+
+## Translating a policy
+
+The interchange types are available from `sapio::policy` or
+`sapio_base::policy`:
+
+```rust
+pub trait PolicyCompiler {
+    fn compile_policy(&self) -> Result<ScriptPolicy, PolicyError>;
+}
+
+pub enum ScriptPolicy {
+    Miniscript(Clause),
+    Script(ScriptFragment),
+    And(Vec<ScriptPolicy>),
+    Or(Vec<ScriptPolicy>),
+}
+```
+
+`Clause`, `ScriptPolicy` and `ScriptFragment` implement `PolicyCompiler`.
+`Clause` translates to native source without compiling early, so a timelock can
+still be combined with its authorization before Miniscript checks the result.
+`Result<P, E>` also implements the trait when `P: PolicyCompiler` and
+`E: Display`; an error becomes `PolicyError::Backend(error.to_string())`.
+
+Here is a small custom backend. Its arithmetic preserves the signature
+condition: `CHECKSIG` must produce one for the final comparison to succeed.
+The resulting script lies outside the native Miniscript grammar.
+
+```rust
+use bitcoin::blockdata::{opcodes::all, script::Builder};
+use bitcoin::XOnlyPublicKey;
+use sapio::policy::{PolicyCompiler, PolicyError, ScriptFragment, ScriptPolicy};
+
+pub struct ArithmeticSigner(pub XOnlyPublicKey);
+
+impl PolicyCompiler for ArithmeticSigner {
+    fn compile_policy(&self) -> Result<ScriptPolicy, PolicyError> {
+        ScriptFragment::new(
+            Builder::new()
+                .push_slice(&self.0.serialize())
+                .push_opcode(all::OP_CHECKSIG)
+                .push_opcode(all::OP_1ADD)
+                .push_int(2)
+                .push_opcode(all::OP_NUMEQUAL)
+                .into_script(),
+        )
+        .map(Into::into)
+    }
+}
+
+struct Owned {
+    owner: XOnlyPublicKey,
+}
+
+impl Owned {
+    #[sapio::guard(policy, cached)]
+    fn signed(self) -> ArithmeticSigner {
+        ArithmeticSigner(self.owner)
+    }
+}
+
+impl sapio::contract::Contract for Owned {
+    sapio::declare! {finish, Self::signed}
+    sapio::declare! {non updatable}
+}
+```
+
+Custom guards require the explicit `policy` flag and an explicit return type.
+`#[guard(policy)]` receives `(self, Context)`; adding `cached` removes the context
+argument. A helper can return a backend, a `ScriptPolicy`, a `ScriptFragment`,
+or a `Result` wrapping one of these. Translation errors propagate as
+`CompilationError::Policy`; the macro does not unwrap or omit a failed guard.
+Ordinary `#[guard]` and `#[guard(cached)]` continue to return native `Clause`s.
+
+Trait interfaces use the matching declarations:
+
+```rust
+sapio::decl_guard! { policy signed<ArithmeticSigner> }
+sapio::decl_guard! { cached policy signed<ArithmeticSigner> }
+```
+
+These illustrate separate fresh and cached declarations; select one for a
+given method. As with native guard declarations, the factory is absent until
+implemented. A cached guard evaluates its helper and translates its source once
+per compilation of that contract. Its `simps = "Some(Self::metadata)"` callback
+still runs at every attachment's actual context, including finish guards.
+
+For a transaction-specific precondition, use the template builder inside a
+`#[then]` action:
+
+```rust
+let builder = ctx.template().add_policy(&ArithmeticSigner(owner))?;
+```
+
+`add_policy(&impl PolicyCompiler)` translates immediately and returns a fallible
+builder result. `add_guard(impl Into<ScriptPolicy>)` accepts already translated
+source, checked fragments, or native clauses directly. Both add a requirement
+to that template, in addition to its action guards and covenant. Continuation
+templates are suggestions and cannot carry these additional preconditions.
+
+## What a checked fragment guarantees
+
+`ScriptFragment::new(Script)` validates instruction decoding, balanced
+`IF`/`NOTIF`/`ELSE`/`ENDIF` control flow and locally balanced alternative-stack
+use. Every path starts with an empty alternative stack, cannot read below it,
+must merge at equal depth and must finish with it empty. A backend may use
+balanced alternative-stack operations inside the fragment.
+
+Validation rejects `OP_SUCCESS` instructions even in untaken branches, illegal
+instructions and `OP_CODESEPARATOR`. Code separators are excluded because the
+current signing path assumes none. Opcode-like bytes inside pushed data remain
+data. Errors identify the offending byte offset. Deserializing a fragment
+performs the same checks, and its script is immutable through the public API.
+
+These checks establish composition boundaries. The backend remains responsible
+for the meaning of the program and its witness: each fragment must leave its
+truth value on top of the main stack, ready for Sapio to append `OP_VERIFY`
+and another fragment. It must arrange witness consumption across the complete
+branch and satisfy the final clean-stack requirement. Construction does not
+prove authorization, satisfiability, main-stack discipline, consensus validity
+or a maximum witness size. Tests for a backend should execute complete composed
+spends and demonstrate that missing required authorization fails.
+
+## Ordered composition and native runs
+
+`ScriptPolicy::And` requires all children in encounter order.
+`ScriptPolicy::Or` permits any child. Both are n-ary: an empty `And` is true and
+an empty `Or` has no alternatives. A contract whose complete compilation has no
+spending branch is rejected with `CompilationError::EmptyPolicy`.
+
+Nested IR alternatives expand recursively. Conjunction takes their Cartesian
+product while preserving each branch's operand order. For example:
+
+```text
+And([Or([A, B]), Or([C, D])])
+    -> [A VERIFY C, A VERIFY D, B VERIFY C, B VERIFY D]
+```
+
+Adjacent native operands are combined and compiled as one Miniscript run.
+Consecutive runs and raw fragments are joined with `OP_VERIFY`. Raw fragment
+order and multiplicity are preserved, including repeated inscriptions; the
+compiler never moves a native predicate across raw code to make it compile.
+Identical complete leaf scripts may share one leaf in the final tree.
+
+Each native run must independently satisfy Miniscript's compiler checks.
+Adjacent native key and timelock clauses can form a safe run. A raw signature
+predicate followed by a separate native timelock can fail native safety checks:
+the compiler cannot infer that the raw predicate supplies the missing native
+authorization. Keep native authorization adjacent, or have the custom backend
+emit a complete raw predicate for the combined condition.
+
+Use `ScriptPolicy::Miniscript(clause)` when the whole policy belongs to the
+native language. Native `Clause::And` and `Clause::Or` require two operands, and
+native thresholds require a valid threshold. Source validation runs before
+simplification, including for malformed timelocks and inscription fields in
+branches that would otherwise disappear. Repeated keys in separate native
+alternatives remain valid; each eventual native script receives its own checks.
+
+The IR path treats emitted scripts as opaque even if their bytes happen to
+match Miniscript. Wrapping native policies in general IR nodes does not promise
+native witness analysis. Nor does the compiler promote a key found inside raw
+code to an unconditional Taproot key-path spend. Only an existing standalone
+native key alternative is eligible for that optimization.
+
+## Compilation budgets
+
+The following are local work limits enforced during policy lowering:
+
+| Resource | Per policy lowering |
+| --- | ---: |
+| Source depth, root at zero | 128 |
+| Source nodes, including nested native clauses | 65,536 |
+| Expanded alternatives | 1,024 |
+| Operand slots across expanded alternatives | 65,536 |
+| Aggregate source raw-script and inscription payload bytes | 16 MiB |
+| Payload bytes repeated across expanded alternatives | 16 MiB |
+| Cumulative encoded branch-script bytes, including inserted verification | 16 MiB |
+
+Expansion costs are checked before materializing the alternative product.
+Unreachable source is still checked. Native inscription bodies and metadata can
+span multiple 520-byte pushes; 520 bytes is not a total inscription-body limit.
+There is no separate 64 KiB raw-leaf limit.
+
+Each contract compilation additionally admits at most **1,024 branches** and
+**16 MiB of aggregate encoded scripts** across its actions and finish guards.
+These counts precede final leaf deduplication. Each compiled child contract has
+its own budget. Exceeding a bound returns `CompilationError::PolicyLimit` with
+the resource and limit.
+
+These bounds do not cap arbitrary Rust backend execution, all allocations,
+native compiler CPU time or an entire contract graph. They are separate from
+consensus rules, witness-weight estimates and serialized artifact/transport
+limits. In particular, JSON's hex encoding expands script bytes; passing the
+script-byte limit does not guarantee fitting a WASM ABI message. Direct
+`RawTaproot` construction and deserialization enforce tree and leaf-count checks,
+not the compiler's complete source/expansion byte budget.
+
+## Artifacts, binding and witnesses
+
+Pure native output retains its native descriptor representation. Output with
+opaque branches uses `SupportedDescriptors::Taproot(RawTaproot)`. Its serialized
+spending data contains only the internal key and a depth-first list of
+`(depth, script)` leaves; depths start at zero and scripts are hex strings.
+Output keys, Merkle roots and control blocks are derived again on decoding.
+
+`RawTaproot` checks every script, limits explicit leaves to 1,024 and rejects
+incomplete or invalid trees. Its leaves use the current TapScript version.
+The compiler builds a deterministic equal-weight tree of distinct complete
+scripts. An explicitly constructed raw artifact may retain duplicate scripts
+at different tree positions and their control-block proofs. An empty leaf list
+explicitly describes a key-only raw object; it is distinct from compiling a
+contract with no spending branches.
+
+Call `Compiled::validate` before consuming a publicly constructed or decoded
+artifact. Binding also validates the artifact and the supplied funding data.
+In particular, the descriptor or raw tree must commit to the advertised output
+script. Validation does not establish a custom backend's authorization.
+Binding exports the internal key, Merkle root and every leaf/control-block proof
+into the PSBT, preserving existing template and funding checks.
+
+Any opaque branch makes the contract's maximum satisfaction weight unknown.
+If a committed template requests a minimum feerate, compilation fails with
+`UnknownSatisfactionWeight`. There is no guessed weight or backend-declared
+weight accepted as proof. Backends need their own witness construction and fee
+planning when using opaque scripts.
+
+Signers may add partial signatures to these PSBTs. The existing Miniscript
+finalizer can still finalize through a recognized alternative or key path. If
+finalization fails and a TapScript leaf cannot be parsed as Miniscript, the
+`NotFinished` response identifies its input and leaf hash and reports that
+spending that leaf requires an external satisfier. The returned PSBT retains the
+raw spending data and partial signatures for that unfinished input; successful
+native inputs can retain their finalization progress. Structurally invalid PSBTs
+remain errors.
+An external finalizer must construct the custom witness and validate execution;
+the native finalizer does not certify arbitrary script programs.
+
+## Updating artifact consumers
+
+Guard metadata now uses policy records so that native and custom sources have
+the same representation. The old clause-keyed object:
+
+```json
+{"simps_for_guards":{"older(10)":{"-17":[{"label":"mature"}]}}}
+```
+
+becomes:
+
+```json
+{"simps_for_guards":[
+  {"policy":{"Miniscript":"older(10)"},
+   "protocols":{"-17":[{"label":"mature"}]}}
+]}
+```
+
+Records use deterministic policy order. Within each protocol, equal JSON values
+are deduplicated and distinct attachment values retain encounter order. This
+metadata describes the source guard; the committed output determines spending.
+
+Template `additional_preconditions` also stores tagged `ScriptPolicy` values:
+`["older(10)"]` becomes `[{"Miniscript":"older(10)"}]`. Raw source uses
+`{"Script":"hex"}`, and `And`/`Or` contain arrays of child policy values.
+Consumers must also handle the new `Taproot` variant of `known_descriptor`.
+
+Recompile old artifacts and regenerate consumer schemas. There is no legacy
+field alias or read fallback that guesses a custom policy from old data.
+Direct Rust users of `Template::guards` must convert native clauses with
+`.into()`; builder calls to `add_guard(native_clause)` continue to work.
+
+See [contract action semantics](LANGUAGE_SEMANTICS.md), the
+[policy API](../sapio-base/src/policy.rs),
+[backend integration tests](../sapio/tests/custom_policy.rs) and
+[external-finalization tests](../sapio-psbt/tests/custom_finalization.rs) for the
+corresponding implementation and regression cases.
+
+## Node validation
+
+The native backend regression and WASM catalog demonstrate compilation, artifact
+validation and binding. A separate oracle executes complete custom witnesses
+against Bitcoin Core 31.1 on an isolated regtest node:
+
+```sh
+cargo build --locked -p sapio --example custom_policy_vectors
+python3 contrib/check_custom_policy.py \
+  /path/to/bitcoin-31.1/bin/bitcoind \
+  /path/to/bitcoin-31.1/bin/bitcoin-cli \
+  target/debug/examples/custom_policy_vectors
+```
+
+The driver creates temporary node data and a temporary wallet, mines funding,
+and tests spends of actual outputs with `testmempoolaccept`. It does not access
+an existing node or wallet. It requires permission to bind loopback sockets.
+
+Core accepts two valid transactions: a custom arithmetic signature predicate,
+and that predicate composed with a native action signature, a custom template
+signature and an emulator-provided key clause. Ten invalid variants reach script
+verification and fail: missing each required signature, a wrong owner signature,
+and outputs changed after signing. One changed-output case has freshly generated
+owner/action/template signatures but no covenant-signer signature.
+
+The fixture supplies a fixed emulator key and constructs its signatures
+explicitly; it tests preservation of the emulator's authorization clause, not
+an emulator service's transaction approval rule. Stock Core does not enforce
+native CTV. Native CTV compilation and transaction-hash tests remain separate
+from these ordinary Taproot execution checks. The Ubuntu native CI job runs the
+same oracle with a checksum-pinned Core binary.

--- a/plugin-example/Cargo.lock
+++ b/plugin-example/Cargo.lock
@@ -297,6 +297,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sapio-wasm-custom-policy"
+version = "0.1.0"
+dependencies = [
+ "sapio",
+ "sapio-base",
+ "sapio-bitcoin",
+ "sapio-ctv-emulator-trait",
+ "sapio-wasm-plugin",
+ "schemars",
+ "serde",
+]
+
+[[package]]
 name = "sapio-wasm-fedpeg"
 version = "0.1.0"
 dependencies = [

--- a/plugin-example/Cargo.toml
+++ b/plugin-example/Cargo.toml
@@ -19,7 +19,8 @@ members = ["treepay"
           , "clause-module"
           , "clause-module-trampoline"
           , "ordinal-example"
-          , "ordinal-inscription"]
+          , "ordinal-inscription"
+          , "custom-policy"]
 
 [patch.crates-io]
 # CTV finalization and inscription correctness repairs in the owned fork.

--- a/plugin-example/README.md
+++ b/plugin-example/README.md
@@ -1,6 +1,6 @@
 # Sapio WASM examples
 
-This workspace contains **18 executable guests and two interface libraries**.
+This workspace contains **19 executable guests and two interface libraries**.
 The examples are maintained demonstrations of contract construction. They do not
 include a production wallet, a deployed federation, or audited financial protocols.
 
@@ -63,6 +63,7 @@ network policy acceptability.
 | [clause-module-trampoline](clause-module-trampoline/) | **Delegated clause producer.** Calls another clause module through the typed handle. Actual host calls validate advertised schemas. | Catalog calls the actual clause producer. |
 | [ordinal-example](ordinal-example/) | **Ordinal sale.** Preserves the requested sat at the start of a 501-sat buyer output, with direct and planned sale continuations. Ordered input ranges must be complete, non-overlapping and include the target plus padding. | Native target-position, payment, fee, missing-target and planner tests. |
 | [ordinal-inscription](ordinal-inscription/) | **Inscription reveal.** Commits an Ord envelope under the owner signature and reveals to the owner or a selected address. Complete non-overlapping ranges and enough funds for the inscribed sat, padding and fee are required. | Native signed PSBT/artifact round trip, body chunking and invalid-input tests; CLI smoke. |
+| [custom-policy](custom-policy/) | **Custom policy backend.** Implements a checked arithmetic signature predicate composed with a template covenant through `PolicyCompiler`. Witness construction remains the backend's responsibility. | Native checked payment and underfunding rejection; real WASM catalog checks the raw Taproot artifact and payout. |
 
 ## Interface libraries
 

--- a/plugin-example/custom-policy/Cargo.toml
+++ b/plugin-example/custom-policy/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "sapio-wasm-custom-policy"
+version = "0.1.0"
+edition = "2021"
+license = "MPL-2.0"
+description = "A third-party policy compiler composed with native Sapio guards"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+path = "src/plugin.rs"
+
+[dependencies]
+bitcoin = { package = "sapio-bitcoin", version = "0.28.2", features = ["use-serde"] }
+serde = { version = "1.0", features = ["derive"] }
+schemars = "0.8.22"
+sapio = { path = "../../sapio" }
+sapio-base = { path = "../../sapio-base" }
+sapio-ctv-emulator-trait = { path = "../../emulator-trait" }
+sapio-wasm-plugin = { path = "../../plugins", features = ["client"] }
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false

--- a/plugin-example/custom-policy/README.md
+++ b/plugin-example/custom-policy/README.md
@@ -1,0 +1,11 @@
+# Custom policy compiler
+
+`ArithmeticSigner` implements `sapio_base::policy::PolicyCompiler` and emits
+`<owner> CHECKSIG 1ADD 2 NUMEQUAL`, a signature predicate outside Miniscript's
+language. Sapio combines it with a native co-signer and the payment covenant.
+The payment reserves 1,000 satoshis as fees and pays the co-signer the remainder.
+
+The raw backend owns witness construction and signature semantics. Checked
+fragments preserve composition boundaries; they do not imply an automatic
+finalizer or a satisfaction-weight estimate. The native custom-policy vectors
+and Bitcoin Core harness exercise explicit witnesses for this arithmetic form.

--- a/plugin-example/custom-policy/src/plugin.rs
+++ b/plugin-example/custom-policy/src/plugin.rs
@@ -1,0 +1,129 @@
+//! A custom policy language composed with native guards and a Sapio covenant.
+
+use bitcoin::blockdata::{opcodes::all, script::Builder};
+use bitcoin::{Amount, XOnlyPublicKey};
+use sapio::contract::{CompilationError, Context, Contract};
+use sapio::{declare, guard, then};
+use sapio_base::policy::{PolicyCompiler, PolicyError, ScriptFragment, ScriptPolicy};
+use sapio_base::Clause;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+#[cfg(target_arch = "wasm32")]
+use sapio_wasm_plugin::{optional_logo, REGISTER};
+
+/// An external language whose arithmetic preserves a signature's truth value.
+pub struct ArithmeticSigner(XOnlyPublicKey);
+
+impl PolicyCompiler for ArithmeticSigner {
+    fn compile_policy(&self) -> Result<ScriptPolicy, PolicyError> {
+        ScriptFragment::new(
+            Builder::new()
+                .push_slice(&self.0.serialize())
+                .push_opcode(all::OP_CHECKSIG)
+                .push_opcode(all::OP_1ADD)
+                .push_int(2)
+                .push_opcode(all::OP_NUMEQUAL)
+                .into_script(),
+        )
+        .map(Into::into)
+    }
+}
+
+/// Owner and co-signer authorize a fixed payment, reserving 1,000 sats as fees.
+#[derive(Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct CustomPolicyPayment {
+    /// Signer expressed through the custom arithmetic language.
+    #[schemars(with = "String", regex(pattern = "^[0-9a-fA-F]{64}$"))]
+    owner: XOnlyPublicKey,
+    /// Native Miniscript signer, also receiving the payment.
+    #[schemars(with = "String", regex(pattern = "^[0-9a-fA-F]{64}$"))]
+    co_signer: XOnlyPublicKey,
+}
+
+impl CustomPolicyPayment {
+    #[guard(policy)]
+    fn custom_owner(self, _ctx: Context) -> ArithmeticSigner {
+        ArithmeticSigner(self.owner)
+    }
+
+    #[guard]
+    fn native_co_signer(self, _ctx: Context) {
+        Clause::Key(self.co_signer)
+    }
+
+    #[then(guarded_by = "[Self::custom_owner, Self::native_co_signer]")]
+    fn pay(self, ctx: Context) {
+        let fees = Amount::from_sat(1_000);
+        let payment = ctx
+            .funds()
+            .checked_sub(fees)
+            .ok_or(CompilationError::OutOfFunds)?;
+        if payment == Amount::ZERO {
+            return Err(CompilationError::OutOfFunds);
+        }
+        ctx.template()
+            .add_output(payment, &self.co_signer, None)?
+            .add_fees(fees)?
+            .into()
+    }
+}
+
+impl Contract for CustomPolicyPayment {
+    declare! {then, Self::pay}
+    declare! {non updatable}
+}
+
+#[cfg(target_arch = "wasm32")]
+REGISTER![CustomPolicyPayment];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::secp256k1::{Keypair, Secp256k1, SecretKey};
+    use sapio::contract::abi::object::SupportedDescriptors;
+    use sapio::contract::Compilable;
+    use sapio_ctv_emulator_trait::CTVAvailable;
+    use std::sync::Arc;
+
+    #[test]
+    fn custom_and_native_guards_compile_a_checked_payment() {
+        let key = |byte| {
+            Keypair::from_secret_key(
+                &Secp256k1::new(),
+                &SecretKey::from_slice(&[byte; 32]).unwrap(),
+            )
+            .x_only_public_key()
+            .0
+        };
+        let contract = CustomPolicyPayment {
+            owner: key(1),
+            co_signer: key(2),
+        };
+        for amount in [1_000, 10_000] {
+            let result = contract.compile(Context::new(
+                bitcoin::Network::Regtest,
+                Amount::from_sat(amount),
+                Arc::new(CTVAvailable),
+                "custom_policy".try_into().unwrap(),
+                Arc::new(Default::default()),
+                None,
+            ));
+            if amount == 1_000 {
+                assert!(matches!(result, Err(CompilationError::OutOfFunds)));
+            } else {
+                let compiled = result.unwrap();
+                compiled.validate().unwrap();
+                assert!(matches!(
+                    compiled.descriptor,
+                    Some(SupportedDescriptors::Taproot(_))
+                ));
+                assert_eq!(
+                    compiled.ctv_to_tx.values().next().unwrap().tx.output[0].value,
+                    9_000
+                );
+            }
+        }
+    }
+}

--- a/plugins/examples/check_examples.rs
+++ b/plugins/examples/check_examples.rs
@@ -25,6 +25,7 @@ struct Case {
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct Expected {
+    raw_taproot: Option<bool>,
     clause: Option<String>,
     ctv_count: Option<usize>,
     suggested_count: Option<usize>,
@@ -66,6 +67,15 @@ fn check(value: Value, expected: &Expected) -> Result<(), Box<dyn Error>> {
     }
     let compiled: Compiled = serde_json::from_value(value)?;
     compiled.validate()?;
+    if let Some(expected) = expected.raw_taproot {
+        assert_eq!(
+            matches!(
+                compiled.descriptor,
+                Some(sapio::contract::object::SupportedDescriptors::Taproot(_))
+            ),
+            expected
+        );
+    }
     for (actual, expected) in [
         (compiled.ctv_to_tx.len(), expected.ctv_count),
         (compiled.suggested_txs.len(), expected.suggested_count),

--- a/sapio-base/src/lib.rs
+++ b/sapio-base/src/lib.rs
@@ -12,6 +12,7 @@ use bitcoin::XOnlyPublicKey;
 pub use miniscript;
 pub use util::CTVHash;
 pub mod plugin_args;
+pub mod policy;
 pub mod simp;
 
 /// Helpers for making correct time locks

--- a/sapio-base/src/policy.rs
+++ b/sapio-base/src/policy.rs
@@ -1,0 +1,453 @@
+// Copyright Judica, Inc 2026
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Policy interchange between contract authors, custom compilers and Sapio.
+//!
+//! Custom compilers describe spending conditions; Sapio still combines those
+//! conditions with action guards and transaction commitments. Raw fragments
+//! retain their instruction order and multiplicity when combined.
+
+use crate::Clause;
+use bitcoin::blockdata::opcodes::{all, Class, ClassifyContext};
+use bitcoin::blockdata::script::{Error as ScriptError, Instruction};
+use bitcoin::Script;
+use schemars::JsonSchema;
+use serde::{Deserialize, Deserializer, Serialize};
+use std::fmt;
+
+/// Immutable policy source accepted by Sapio's script lowering stage.
+///
+/// Miniscript clauses remain source policies until their enclosing branch is
+/// assembled. A timelock or hashlock need not be independently safe before it
+/// is combined with the branch's authorization and transaction commitment.
+/// Validation and resource limits still apply during lowering, including to
+/// policies produced by a custom [`PolicyCompiler`].
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, JsonSchema,
+)]
+pub enum ScriptPolicy {
+    /// The existing native Miniscript policy language.
+    Miniscript(Clause),
+    /// A checked raw fragment with backend-defined witness requirements.
+    Script(ScriptFragment),
+    /// Require every child, in encounter order. An empty conjunction is true.
+    And(Vec<ScriptPolicy>),
+    /// Permit any child. An empty disjunction has no spending alternative.
+    Or(Vec<ScriptPolicy>),
+}
+
+impl From<Clause> for ScriptPolicy {
+    fn from(policy: Clause) -> Self {
+        Self::Miniscript(policy)
+    }
+}
+
+impl From<ScriptFragment> for ScriptPolicy {
+    fn from(script: ScriptFragment) -> Self {
+        Self::Script(script)
+    }
+}
+
+/// Translate another policy language into Sapio's immutable policy source.
+///
+/// Implementations must preserve the source language's authorization and
+/// produce raw fragments satisfying [`ScriptFragment`]'s witness contract.
+/// Sapio validates fragment boundaries and controls policy expansion; it does
+/// not prove an arbitrary backend's authorization, satisfiability or witness
+/// size. Returning a raw fragment does not provide a satisfaction-weight bound
+/// or an automatic witness finalizer.
+pub trait PolicyCompiler {
+    /// Translate this policy without constructing a contract artifact directly.
+    fn compile_policy(&self) -> Result<ScriptPolicy, PolicyError>;
+}
+
+impl PolicyCompiler for Clause {
+    fn compile_policy(&self) -> Result<ScriptPolicy, PolicyError> {
+        Ok(ScriptPolicy::Miniscript(self.clone()))
+    }
+}
+
+impl PolicyCompiler for ScriptPolicy {
+    fn compile_policy(&self) -> Result<ScriptPolicy, PolicyError> {
+        Ok(self.clone())
+    }
+}
+
+impl PolicyCompiler for ScriptFragment {
+    fn compile_policy(&self) -> Result<ScriptPolicy, PolicyError> {
+        Ok(ScriptPolicy::Script(self.clone()))
+    }
+}
+
+/// Raw tapscript whose control flow and alternative stack are locally scoped.
+///
+/// A backend must arrange its witness so the fragment leaves its truth value
+/// on top of the main stack. Sapio may append `OP_VERIFY` and another fragment.
+/// Main-stack consumption, clean-stack satisfaction and signature requirements
+/// remain the backend's responsibility; this constructor does not infer them.
+///
+/// Validation prevents control flow, early-success opcodes or alternative-stack
+/// effects from escaping into adjacent fragments. Code separators are excluded
+/// because the current signing path assumes none. No witness-size bound is
+/// implied. Deserialization performs the same validation as construction.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, JsonSchema)]
+#[serde(transparent)]
+pub struct ScriptFragment(Script);
+
+impl ScriptFragment {
+    /// Check the fragment's instruction and composition boundaries.
+    pub fn new(script: Script) -> Result<Self, PolicyError> {
+        validate_tapscript(&script)?;
+        Ok(Self(script))
+    }
+
+    /// Borrow the checked script without exposing mutation.
+    pub fn as_script(&self) -> &Script {
+        &self.0
+    }
+
+    /// Consume the fragment and recover its script.
+    pub fn into_script(self) -> Script {
+        self.0
+    }
+}
+
+impl TryFrom<Script> for ScriptFragment {
+    type Error = PolicyError;
+
+    fn try_from(script: Script) -> Result<Self, Self::Error> {
+        Self::new(script)
+    }
+}
+
+impl<'de> Deserialize<'de> for ScriptFragment {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Self::new(Script::deserialize(deserializer)?).map_err(serde::de::Error::custom)
+    }
+}
+
+/// A source-policy or raw-script boundary error.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PolicyError {
+    /// The script contains a truncated or otherwise undecodable instruction.
+    MalformedScript {
+        /// Byte offset of the instruction.
+        offset: usize,
+        /// The underlying instruction-decoding error.
+        error: ScriptError,
+    },
+    /// An instruction can bypass composition, invalidate signing, or is illegal.
+    ForbiddenOpcode {
+        /// Byte offset of the opcode.
+        offset: usize,
+        /// The rejected opcode byte.
+        opcode: u8,
+    },
+    /// An `ELSE` or `ENDIF` has no corresponding conditional.
+    UnexpectedConditional {
+        /// Byte offset of the opcode.
+        offset: usize,
+        /// The unmatched opcode byte.
+        opcode: u8,
+    },
+    /// An `IF` or `NOTIF` remains open at the end of the fragment.
+    UnclosedConditional {
+        /// Byte offset of the opening opcode.
+        offset: usize,
+    },
+    /// A path consumes alternative-stack state belonging to another fragment.
+    AltStackUnderflow {
+        /// Byte offset of the `FROMALTSTACK` instruction.
+        offset: usize,
+    },
+    /// Alternative-stack depths differ at a branch merge or are nonzero at EOF.
+    AltStackImbalance {
+        /// Byte offset of the merge, or the script length for an EOF error.
+        offset: usize,
+    },
+    /// A custom policy compiler could not translate its source language.
+    Backend(String),
+}
+
+impl fmt::Display for PolicyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MalformedScript { offset, error } => {
+                write!(f, "invalid script instruction at byte {offset}: {error}")
+            }
+            Self::ForbiddenOpcode { offset, opcode } => {
+                write!(f, "unsupported opcode 0x{opcode:02x} at byte {offset}")
+            }
+            Self::UnexpectedConditional { offset, opcode } => {
+                write!(
+                    f,
+                    "unmatched conditional opcode 0x{opcode:02x} at byte {offset}"
+                )
+            }
+            Self::UnclosedConditional { offset } => {
+                write!(f, "unclosed conditional starting at byte {offset}")
+            }
+            Self::AltStackUnderflow { offset } => {
+                write!(f, "alternative-stack underflow at byte {offset}")
+            }
+            Self::AltStackImbalance { offset } => {
+                write!(f, "unbalanced alternative stack at byte {offset}")
+            }
+            Self::Backend(message) => write!(f, "policy compiler: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for PolicyError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::MalformedScript { error, .. } => Some(error),
+            _ => None,
+        }
+    }
+}
+
+/// Validate boundaries shared by raw fragments and assembled tapscript leaves.
+///
+/// Checks instruction decoding, forbidden opcodes, balanced conditionals and
+/// locally balanced alternative-stack effects. Both arms of a conditional must
+/// merge at the same alternative-stack depth; without `ELSE`, the untaken arm
+/// retains the entry depth. Pushed bytes are data, including opcode byte values.
+/// This is a composition check, not proof of consensus validity or satisfaction.
+pub fn validate_tapscript(script: &Script) -> Result<(), PolicyError> {
+    struct Conditional {
+        offset: usize,
+        other_alt_depth: usize,
+    }
+
+    let mut conditionals: Vec<Conditional> = vec![];
+    let mut alt_depth = 0usize;
+    let mut offset = 0usize;
+    for instruction in script.instructions() {
+        let instruction =
+            instruction.map_err(|error| PolicyError::MalformedScript { offset, error })?;
+        match instruction {
+            Instruction::PushBytes(data) => {
+                let prefix = match script.as_bytes()[offset] {
+                    0x4c => 2,
+                    0x4d => 3,
+                    0x4e => 5,
+                    _ => 1,
+                };
+                offset += prefix + data.len();
+                continue;
+            }
+            Instruction::Op(opcode) => {
+                if matches!(
+                    opcode.classify(ClassifyContext::TapScript),
+                    Class::SuccessOp | Class::IllegalOp
+                ) || opcode == all::OP_CODESEPARATOR
+                {
+                    return Err(PolicyError::ForbiddenOpcode {
+                        offset,
+                        opcode: opcode.into_u8(),
+                    });
+                }
+                match opcode {
+                    all::OP_IF | all::OP_NOTIF => conditionals.push(Conditional {
+                        offset,
+                        other_alt_depth: alt_depth,
+                    }),
+                    all::OP_ELSE => {
+                        let conditional =
+                            conditionals
+                                .last_mut()
+                                .ok_or(PolicyError::UnexpectedConditional {
+                                    offset,
+                                    opcode: opcode.into_u8(),
+                                })?;
+                        // Repeated ELSE is legal: switch back to the saved depth
+                        // of the other execution path each time.
+                        std::mem::swap(&mut alt_depth, &mut conditional.other_alt_depth);
+                    }
+                    all::OP_ENDIF => {
+                        let conditional =
+                            conditionals
+                                .pop()
+                                .ok_or(PolicyError::UnexpectedConditional {
+                                    offset,
+                                    opcode: opcode.into_u8(),
+                                })?;
+                        if alt_depth != conditional.other_alt_depth {
+                            return Err(PolicyError::AltStackImbalance { offset });
+                        }
+                    }
+                    all::OP_TOALTSTACK => alt_depth += 1,
+                    all::OP_FROMALTSTACK => {
+                        alt_depth = alt_depth
+                            .checked_sub(1)
+                            .ok_or(PolicyError::AltStackUnderflow { offset })?;
+                    }
+                    _ => {}
+                }
+            }
+        }
+        offset += 1;
+    }
+    if let Some(conditional) = conditionals.first() {
+        return Err(PolicyError::UnclosedConditional {
+            offset: conditional.offset,
+        });
+    }
+    if alt_depth != 0 {
+        return Err(PolicyError::AltStackImbalance { offset });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use schemars::schema::{InstanceType, SingleOrVec};
+
+    fn script(bytes: &[u8]) -> Script {
+        Script::from(bytes.to_vec())
+    }
+
+    #[test]
+    fn rejects_every_success_opcode_even_inside_an_untaken_branch() {
+        let success = [80, 98]
+            .into_iter()
+            .chain(126..=129)
+            .chain(131..=134)
+            .chain(137..=138)
+            .chain(141..=142)
+            .chain(149..=153)
+            .chain(187..=254);
+        for opcode in success {
+            assert_eq!(
+                ScriptFragment::new(script(&[0x00, 0x63, opcode, 0x68, 0x51])),
+                Err(PolicyError::ForbiddenOpcode { offset: 2, opcode }),
+            );
+        }
+        assert_eq!(
+            ScriptFragment::new(script(&[0x51, 0xab])),
+            Err(PolicyError::ForbiddenOpcode {
+                offset: 1,
+                opcode: 0xab
+            }),
+        );
+    }
+
+    #[test]
+    fn pushed_opcode_bytes_are_data_and_instruction_offsets_are_exact() {
+        for opcode in [0x50, 0x63, 0x67, 0x68, 0x6c, 0xab, 0xff] {
+            assert!(ScriptFragment::new(script(&[1, opcode, 0x75, 0x51])).is_ok());
+        }
+        // Nonminimal PUSHDATA is decoded without treating its contents as code.
+        assert_eq!(
+            ScriptFragment::new(script(&[0x4c, 1, 0x50, 0x75, 0xab])),
+            Err(PolicyError::ForbiddenOpcode {
+                offset: 4,
+                opcode: 0xab
+            }),
+        );
+        assert_eq!(
+            ScriptFragment::new(script(&[0x51, 0x4d, 1])),
+            Err(PolicyError::MalformedScript {
+                offset: 1,
+                error: ScriptError::EarlyEndOfScript
+            }),
+        );
+    }
+
+    #[test]
+    fn conditionals_cannot_capture_or_escape_adjacent_fragments() {
+        for opcode in [0x67, 0x68] {
+            assert_eq!(
+                ScriptFragment::new(script(&[opcode])),
+                Err(PolicyError::UnexpectedConditional { offset: 0, opcode }),
+            );
+        }
+        for opcode in [0x63, 0x64] {
+            assert_eq!(
+                ScriptFragment::new(script(&[0x51, opcode, 0x51])),
+                Err(PolicyError::UnclosedConditional { offset: 1 }),
+            );
+        }
+        assert!(ScriptFragment::new(script(&[
+            0x63, 0x64, 0x51, 0x67, 0x00, 0x68, 0x67, 0x51, 0x68
+        ]))
+        .is_ok());
+    }
+
+    #[test]
+    fn alternative_stack_effects_must_balance_on_both_execution_paths() {
+        assert_eq!(
+            ScriptFragment::new(script(&[0x6c])),
+            Err(PolicyError::AltStackUnderflow { offset: 0 }),
+        );
+        assert_eq!(
+            ScriptFragment::new(script(&[0x6b])),
+            Err(PolicyError::AltStackImbalance { offset: 1 }),
+        );
+        // The implicit false arm does not push onto the alternative stack.
+        assert_eq!(
+            ScriptFragment::new(script(&[0x63, 0x6b, 0x68, 0x6c])),
+            Err(PolicyError::AltStackImbalance { offset: 2 }),
+        );
+        // Both branches add one item; the common suffix removes that item.
+        assert!(ScriptFragment::new(script(&[0x63, 0x6b, 0x67, 0x6b, 0x68, 0x6c])).is_ok());
+        // Repeated ELSE resumes the accumulated state of the matching arm.
+        assert!(ScriptFragment::new(script(&[0x63, 0x6b, 0x67, 0x67, 0x6c, 0x68, 0x51])).is_ok());
+        // A nested branch cannot consume an item that exists only in its sibling.
+        assert_eq!(
+            ScriptFragment::new(script(&[0x63, 0x6b, 0x67, 0x63, 0x6c, 0x68, 0x68])),
+            Err(PolicyError::AltStackUnderflow { offset: 4 }),
+        );
+    }
+
+    #[test]
+    fn fragment_serialization_and_schema_match_the_checked_script_format() {
+        let fragment = ScriptFragment::new(script(&[0x51])).unwrap();
+        assert_eq!(
+            serde_json::to_value(&fragment).unwrap(),
+            serde_json::json!("51")
+        );
+        assert_eq!(
+            serde_json::from_str::<ScriptFragment>("\"51\"").unwrap(),
+            fragment
+        );
+        for invalid in ["\"50\"", "\"ab\"", "\"63\"", "\"4d01\"", "\"6c\""] {
+            assert!(serde_json::from_str::<ScriptFragment>(invalid).is_err());
+        }
+        let schema = schemars::schema_for!(ScriptFragment);
+        assert_eq!(
+            schema.schema.instance_type,
+            Some(SingleOrVec::Single(Box::new(InstanceType::String)))
+        );
+    }
+
+    #[test]
+    fn policy_interchange_preserves_source_and_validates_nested_fragments() {
+        // Compiling this alone as a safe Miniscript would fail; translation
+        // retains it so the enclosing branch can supply authorization.
+        let clause = Clause::Older(10);
+        assert_eq!(
+            clause.compile_policy().unwrap(),
+            ScriptPolicy::Miniscript(clause.clone())
+        );
+        let policy = ScriptPolicy::And(vec![
+            clause.into(),
+            ScriptFragment::new(script(&[0x51])).unwrap().into(),
+        ]);
+        let encoded = serde_json::to_value(&policy).unwrap();
+        assert_eq!(
+            serde_json::from_value::<ScriptPolicy>(encoded).unwrap(),
+            policy
+        );
+        assert_eq!(policy.compile_policy().unwrap(), policy);
+        assert!(serde_json::from_value::<ScriptPolicy>(serde_json::json!({
+            "And": [{"Miniscript": "older(10)"}, {"Script": "50"}]
+        }))
+        .is_err());
+    }
+}

--- a/sapio-base/src/policy.rs
+++ b/sapio-base/src/policy.rs
@@ -21,8 +21,10 @@ use std::fmt;
 /// Immutable policy source accepted by Sapio's script lowering stage.
 ///
 /// Miniscript clauses remain source policies until their enclosing branch is
-/// assembled. A timelock or hashlock need not be independently safe before it
-/// is combined with the branch's authorization and transaction commitment.
+/// assembled. Adjacent native predicates compile as one run, so a timelock
+/// or hashlock can share its run's authorization or transaction commitment.
+/// Raw fragments separate runs; each native run must independently pass the
+/// Miniscript compiler's safety checks.
 /// Validation and resource limits still apply during lowering, including to
 /// policies produced by a custom [`PolicyCompiler`].
 #[derive(
@@ -79,6 +81,15 @@ impl PolicyCompiler for ScriptPolicy {
 impl PolicyCompiler for ScriptFragment {
     fn compile_policy(&self) -> Result<ScriptPolicy, PolicyError> {
         Ok(ScriptPolicy::Script(self.clone()))
+    }
+}
+
+impl<P: PolicyCompiler, E: fmt::Display> PolicyCompiler for Result<P, E> {
+    fn compile_policy(&self) -> Result<ScriptPolicy, PolicyError> {
+        match self {
+            Ok(policy) => policy.compile_policy(),
+            Err(error) => Err(PolicyError::Backend(error.to_string())),
+        }
     }
 }
 

--- a/sapio-contrib/src/contracts/derivatives/signature_attested.rs
+++ b/sapio-contrib/src/contracts/derivatives/signature_attested.rs
@@ -215,7 +215,8 @@ mod tests {
                 vec![Clause::Threshold(
                     2,
                     vec![Clause::Key(key(10 + point)), Clause::Key(key(20 + point))]
-                )]
+                )
+                .into()]
             );
             distributions.push(
                 template
@@ -273,7 +274,10 @@ mod tests {
         );
         use sapio_base::miniscript::policy::Liftable;
         assert_eq!(template.guards.len(), 1);
-        let actual = template.guards[0].lift().unwrap();
+        let sapio_base::policy::ScriptPolicy::Miniscript(actual) = &template.guards[0] else {
+            panic!()
+        };
+        let actual = actual.lift().unwrap();
         let expected = expected.lift().unwrap();
         assert!(actual.clone().entails(expected.clone()).unwrap());
         assert!(expected.entails(actual).unwrap());

--- a/sapio-psbt/src/external_api.rs
+++ b/sapio-psbt/src/external_api.rs
@@ -64,7 +64,7 @@ pub fn finalize_psbt_format_api(
                     .collect();
                 for leaf in unsupported {
                     errors.push(format!(
-                        "Input {index}: unsupported custom tapscript leaf {leaf}; an external satisfier is required"
+                        "Input {index}: unsupported custom tapscript leaf {leaf}; spending this leaf requires an external satisfier"
                     ));
                 }
             }

--- a/sapio-psbt/src/external_api.rs
+++ b/sapio-psbt/src/external_api.rs
@@ -5,8 +5,11 @@
 //  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 use crate::{validate_psbt, PSBTValidationError};
 use bitcoin::consensus::serialize;
+use bitcoin::util::taproot::{LeafVersion, TapLeafHash};
 use miniscript::psbt::PsbtExt;
+use miniscript::{Miniscript, Tap};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
 
 use bitcoin::secp256k1::Secp256k1;
 
@@ -29,6 +32,9 @@ pub enum PSBTApi {
 
 /// Finalize a structurally valid PSBT, retaining incomplete signing results.
 /// Malformed transaction and metadata fields return a validation error.
+/// A custom tapscript leaf does not prevent using another satisfiable leaf.
+/// If finalization fails, unsupported leaves are identified in the returned
+/// diagnostics and their PSBT data remains available to an external satisfier.
 pub fn finalize_psbt_format_api(
     psbt: PartiallySignedTransaction,
 ) -> Result<PSBTApi, PSBTValidationError> {
@@ -44,7 +50,24 @@ pub fn finalize_psbt_format_api(
             }
         })
         .unwrap_or_else(|(psbt, errors)| {
-            let errors: Vec<_> = errors.iter().map(|e| format!("{:?}", e)).collect();
+            let mut errors: Vec<_> = errors.iter().map(|e| format!("{:?}", e)).collect();
+            for (index, input) in psbt.inputs.iter().enumerate() {
+                let unsupported: BTreeSet<_> = input
+                    .tap_scripts
+                    .values()
+                    .filter(|(script, version)| {
+                        *version == LeafVersion::TapScript
+                            && Miniscript::<bitcoin::XOnlyPublicKey, Tap>::parse_insane(script)
+                                .is_err()
+                    })
+                    .map(|(script, version)| TapLeafHash::from_script(script, *version))
+                    .collect();
+                for leaf in unsupported {
+                    errors.push(format!(
+                        "Input {index}: unsupported custom tapscript leaf {leaf}; an external satisfier is required"
+                    ));
+                }
+            }
             let encoded_psbt = base64::encode(serialize(&psbt));
             PSBTApi::NotFinished {
                 completed: false,

--- a/sapio-psbt/tests/custom_finalization.rs
+++ b/sapio-psbt/tests/custom_finalization.rs
@@ -1,0 +1,161 @@
+use bitcoin::blockdata::opcodes::all::{OP_ADD, OP_CHECKSIG, OP_NUMEQUALVERIFY};
+use bitcoin::blockdata::script::Builder;
+use bitcoin::consensus::deserialize;
+use bitcoin::hashes::hex::FromHex;
+use bitcoin::secp256k1::{Keypair, Message, Secp256k1, SecretKey};
+use bitcoin::util::psbt::PartiallySignedTransaction;
+use bitcoin::util::sighash::{Prevouts, SighashCache};
+use bitcoin::util::taproot::{LeafVersion, TapLeafHash, TaprootBuilder};
+use bitcoin::{OutPoint, SchnorrSig, SchnorrSighashType, Script, Transaction, TxIn, TxOut};
+use miniscript::{Miniscript, Tap};
+use sapio_psbt::external_api::{finalize_psbt_format_api, PSBTApi};
+use sapio_psbt::PSBTValidationError;
+
+fn keypair(byte: u8) -> Keypair {
+    SecretKey::from_slice(&[byte; 32])
+        .unwrap()
+        .keypair(&Secp256k1::new())
+}
+
+fn fixture(include_native_leaf: bool) -> (PartiallySignedTransaction, Script, Script) {
+    let secp = Secp256k1::new();
+    let signer = keypair(1).x_only_public_key().0;
+    // Witness [signature, 2, 3] satisfies this script, but the arithmetic
+    // fragment is outside the native Miniscript satisfier's language.
+    let raw = Builder::new()
+        .push_opcode(OP_ADD)
+        .push_int(5)
+        .push_opcode(OP_NUMEQUALVERIFY)
+        .push_slice(&signer.serialize())
+        .push_opcode(OP_CHECKSIG)
+        .into_script();
+    let native = Builder::new()
+        .push_slice(&signer.serialize())
+        .push_opcode(OP_CHECKSIG)
+        .into_script();
+    assert!(Miniscript::<bitcoin::XOnlyPublicKey, Tap>::parse_insane(&raw).is_err());
+    assert!(Miniscript::<bitcoin::XOnlyPublicKey, Tap>::parse_insane(&native).is_ok());
+    let scripts = if include_native_leaf {
+        vec![raw.clone(), native.clone()]
+    } else {
+        vec![raw.clone()]
+    };
+    let depth = u8::from(include_native_leaf);
+    let mut builder = TaprootBuilder::new();
+    for script in &scripts {
+        builder = builder.add_leaf(depth, script.clone()).unwrap();
+    }
+    // No key-path signature is supplied: the selected script must authorize
+    // finalization, independently of whether the tree has another leaf.
+    let spend = builder
+        .finalize(&secp, keypair(2).x_only_public_key().0)
+        .unwrap();
+    let prevout = TxOut {
+        value: 1_000,
+        script_pubkey: Script::new_v1_p2tr_tweaked(spend.output_key()),
+    };
+    let tx = Transaction {
+        version: 2,
+        lock_time: 0,
+        input: vec![TxIn {
+            previous_output: OutPoint::default(),
+            ..Default::default()
+        }],
+        output: vec![TxOut {
+            value: 900,
+            script_pubkey: native.clone().to_v0_p2wsh(),
+        }],
+    };
+    let mut psbt = PartiallySignedTransaction::from_unsigned_tx(tx).unwrap();
+    let input = &mut psbt.inputs[0];
+    input.witness_utxo = Some(prevout);
+    input.tap_internal_key = Some(spend.internal_key());
+    input.tap_merkle_root = spend.merkle_root();
+    for script in scripts {
+        let leaf = (script, LeafVersion::TapScript);
+        input
+            .tap_scripts
+            .insert(spend.control_block(&leaf).unwrap(), leaf);
+    }
+    (psbt, raw, native)
+}
+
+fn sign_leaf(psbt: &mut PartiallySignedTransaction, script: &Script) -> SchnorrSig {
+    let secp = Secp256k1::new();
+    let key = keypair(1);
+    let leaf = TapLeafHash::from_script(script, LeafVersion::TapScript);
+    let prevouts = [psbt.inputs[0].witness_utxo.clone().unwrap()];
+    let digest = SighashCache::new(&psbt.unsigned_tx)
+        .taproot_script_spend_signature_hash(
+            0,
+            &Prevouts::All(&prevouts),
+            leaf,
+            SchnorrSighashType::Default,
+        )
+        .unwrap();
+    let message = Message::from_digest_slice(&digest[..]).unwrap();
+    let signature = SchnorrSig {
+        sig: secp.sign_schnorr_no_aux_rand(&message, &key),
+        hash_ty: SchnorrSighashType::Default,
+    };
+    secp.verify_schnorr(&signature.sig, &message, &key.x_only_public_key().0)
+        .unwrap();
+    psbt.inputs[0]
+        .tap_script_sigs
+        .insert((key.x_only_public_key().0, leaf), signature);
+    signature
+}
+
+#[test]
+fn unsupported_custom_leaf_keeps_its_script_proof_and_valid_partial_signature() {
+    let (mut original, raw, _) = fixture(false);
+    sign_leaf(&mut original, &raw);
+    let PSBTApi::NotFinished {
+        completed,
+        psbt,
+        errors,
+        ..
+    } = finalize_psbt_format_api(original.clone()).unwrap()
+    else {
+        panic!("custom arithmetic leaf must require an external satisfier");
+    };
+    assert!(!completed);
+    let restored: PartiallySignedTransaction = deserialize(&base64::decode(psbt).unwrap()).unwrap();
+    assert_eq!(restored, original);
+    let leaf = TapLeafHash::from_script(&raw, LeafVersion::TapScript);
+    assert!(errors.contains(&format!(
+        "Input 0: unsupported custom tapscript leaf {leaf}; an external satisfier is required"
+    )));
+}
+
+#[test]
+fn a_signed_native_leaf_finalizes_even_when_a_custom_leaf_is_present() {
+    let (mut psbt, raw, native) = fixture(true);
+    sign_leaf(&mut psbt, &raw);
+    let signature = sign_leaf(&mut psbt, &native);
+    let PSBTApi::Finished { completed, hex } = finalize_psbt_format_api(psbt).unwrap() else {
+        panic!("the recognized signed alternative must remain usable");
+    };
+    assert!(completed);
+    let tx: Transaction = deserialize(&Vec::<u8>::from_hex(&hex).unwrap()).unwrap();
+    let witness = tx.input[0].witness.to_vec();
+    assert_eq!(witness.len(), 3);
+    assert_eq!(witness[0], signature.to_vec());
+    assert_eq!(witness[1], native.as_bytes());
+}
+
+#[test]
+fn custom_leaves_do_not_hide_structurally_malformed_psbt_maps() {
+    let (mut psbt, _, _) = fixture(false);
+    psbt.inputs.clear();
+    match finalize_psbt_format_api(psbt) {
+        Err(error) => assert_eq!(
+            error,
+            PSBTValidationError::InputMapCount {
+                transaction: 1,
+                maps: 0,
+            }
+        ),
+        Ok(_) => panic!("malformed maps must fail structural validation"),
+    }
+}

--- a/sapio-psbt/tests/custom_finalization.rs
+++ b/sapio-psbt/tests/custom_finalization.rs
@@ -124,7 +124,7 @@ fn unsupported_custom_leaf_keeps_its_script_proof_and_valid_partial_signature() 
     assert_eq!(restored, original);
     let leaf = TapLeafHash::from_script(&raw, LeafVersion::TapScript);
     assert!(errors.contains(&format!(
-        "Input 0: unsupported custom tapscript leaf {leaf}; an external satisfier is required"
+        "Input 0: unsupported custom tapscript leaf {leaf}; spending this leaf requires an external satisfier"
     )));
 }
 

--- a/sapio/examples/custom_policy_vectors.rs
+++ b/sapio/examples/custom_policy_vectors.rs
@@ -1,0 +1,73 @@
+//! Export explicitly signed custom-policy spends for a Bitcoin Core oracle.
+//!
+//! Without arguments, print funding addresses and placeholder-outpoint vectors.
+//! With a JSON file mapping group names to funded OutPoints, sign those actual
+//! spends. `contrib/check_custom_policy.py` drives both stages on isolated regtest.
+
+#[path = "../tests/fixtures/custom_policy.rs"]
+mod fixture;
+
+use bitcoin::consensus::encode::serialize_hex;
+use bitcoin::hashes::hex::ToHex;
+use bitcoin::{Address, Network, OutPoint};
+use fixture::*;
+use serde_json::{json, Value};
+use std::collections::BTreeMap;
+
+fn case(name: &str, allowed: bool, transaction: bitcoin::Transaction) -> Value {
+    json!({"name": name, "allowed": allowed, "transaction": serialize_hex(&transaction)})
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let funding: BTreeMap<String, OutPoint> = match std::env::args_os().nth(1) {
+        Some(path) => serde_json::from_slice(&std::fs::read(path)?)?,
+        None => BTreeMap::new(),
+    };
+    let mut groups = vec![];
+    for (name, protected) in [("pure_custom", false), ("composed_emulated", true)] {
+        // These oracle cases use signer emulation: unmodified Bitcoin Core
+        // does not implement native CheckTemplateVerify consensus semantics.
+        let compiled = compiled(protected, true);
+        let raw = tree(&compiled);
+        let outpoint = funding.get(name).copied().unwrap_or_default();
+        let unsigned = unsigned_spend(&compiled, outpoint);
+        let valid = signed_spend(&compiled, unsigned.clone(), None, false);
+        let mut cases = vec![case("valid", true, valid.clone())];
+        for owner in 1..=if protected { 4 } else { 1 } {
+            cases.push(case(
+                &format!("missing_signer_{owner}"),
+                false,
+                signed_spend(&compiled, unsigned.clone(), Some(owner), false),
+            ));
+        }
+        cases.push(case(
+            "wrong_owner_signature",
+            false,
+            signed_spend(&compiled, unsigned.clone(), None, true),
+        ));
+        let mut tampered = valid;
+        tampered.output[0].value -= 1;
+        cases.push(case("output_changed_after_signing", false, tampered));
+        if protected {
+            let mut changed = unsigned;
+            changed.output[0].value -= 1;
+            cases.push(case(
+                "changed_output_without_covenant_signer",
+                false,
+                signed_spend(&compiled, changed, Some(4), false),
+            ));
+        }
+        groups.push(json!({
+            "name": name,
+            "address": Address::p2tr_tweaked(raw.spend_info().output_key(), Network::Regtest).to_string(),
+            "funding_amount_sats": 10_000,
+            "script": raw.leaves()[0].1.as_bytes().to_hex(),
+            "cases": cases,
+        }));
+    }
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&json!({"groups": groups}))?
+    );
+    Ok(())
+}

--- a/sapio/src/contract/abi/object/bind.rs
+++ b/sapio/src/contract/abi/object/bind.rs
@@ -11,6 +11,7 @@ use crate::contract::object::Object;
 use crate::contract::object::ObjectError;
 use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::util::psbt::PartiallySignedTransaction;
+use bitcoin::util::taproot::ControlBlock;
 use bitcoin::util::taproot::TaprootBuilder;
 use bitcoin::util::taproot::TaprootSpendInfo;
 use bitcoin::{OutPoint, Transaction};
@@ -230,6 +231,27 @@ impl Object {
                         for item in info.as_script_map().keys() {
                             let cb = info.control_block(item).expect("Must be present");
                             input.tap_scripts.insert(cb, item.clone());
+                        }
+                        input.tap_merkle_root = info.merkle_root();
+                        input.tap_internal_key = Some(info.internal_key());
+                    }
+                    Some(SupportedDescriptors::Taproot(tree)) => {
+                        let info = tree.spend_info();
+                        let input = &mut psbt.inputs[0];
+                        for ((script, version), branches) in info.as_script_map() {
+                            // Preserve every proof when the same script occurs
+                            // at different positions in the explicit tree.
+                            for branch in branches {
+                                let control = ControlBlock {
+                                    leaf_version: *version,
+                                    output_key_parity: info.output_key_parity(),
+                                    internal_key: info.internal_key(),
+                                    merkle_branch: branch.clone(),
+                                };
+                                input
+                                    .tap_scripts
+                                    .insert(control, (script.clone(), *version));
+                            }
                         }
                         input.tap_merkle_root = info.merkle_root();
                         input.tap_internal_key = Some(info.internal_key());

--- a/sapio/src/contract/abi/object/descriptors.rs
+++ b/sapio/src/contract/abi/object/descriptors.rs
@@ -6,6 +6,7 @@
 
 //! Wrapper for supported descriptor types
 
+use super::RawTaproot;
 pub use crate::contract::abi::studio::*;
 use bitcoin::PublicKey;
 use bitcoin::Script;
@@ -22,6 +23,10 @@ pub enum SupportedDescriptors {
     Pk(Descriptor<PublicKey>),
     /// # Taproot Descriptors
     XOnly(Descriptor<XOnlyPublicKey>),
+    /// # Checked raw Taproot scripts
+    /// Spending data for scripts whose witness requirements are not described
+    /// by Miniscript. This representation carries no satisfaction-weight bound.
+    Taproot(RawTaproot),
 }
 
 impl From<Descriptor<PublicKey>> for SupportedDescriptors {
@@ -34,12 +39,18 @@ impl From<Descriptor<XOnlyPublicKey>> for SupportedDescriptors {
         SupportedDescriptors::XOnly(x)
     }
 }
+impl From<RawTaproot> for SupportedDescriptors {
+    fn from(tree: RawTaproot) -> Self {
+        SupportedDescriptors::Taproot(tree)
+    }
+}
 impl SupportedDescriptors {
     /// Regardless of descriptor type, get the output script
     pub fn script_pubkey(&self) -> Script {
         match self {
             SupportedDescriptors::Pk(p) => p.script_pubkey(),
             SupportedDescriptors::XOnly(x) => x.script_pubkey(),
+            SupportedDescriptors::Taproot(tree) => tree.script_pubkey(),
         }
     }
 }

--- a/sapio/src/contract/abi/object/mod.rs
+++ b/sapio/src/contract/abi/object/mod.rs
@@ -10,6 +10,7 @@ pub mod error;
 pub use error::*;
 pub mod bind;
 pub mod descriptors;
+pub mod taproot;
 mod validation;
 use crate::contract::abi::continuation::ContinuationPoint;
 use crate::contract::CompilationError;
@@ -22,16 +23,26 @@ pub use descriptors::*;
 use sapio_base::effects::EffectPath;
 use sapio_base::effects::PathFragment;
 use sapio_base::miniscript::*;
+use sapio_base::policy::ScriptPolicy;
 use sapio_base::serialization_helpers::SArc;
 use sapio_base::simp::CompiledObjectLT;
 use sapio_base::simp::SIMPAttachableAt;
 use sapio_base::simp::SIMPError;
-use sapio_base::Clause;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::sync::Arc;
+pub use taproot::{RawTaproot, RawTaprootError};
 pub use validation::{ArtifactError, ArtifactErrorKind};
+
+/// Metadata attached to a particular guard policy.
+#[derive(Serialize, Deserialize, Clone, JsonSchema, Debug, PartialEq, Eq)]
+pub struct GuardMetadata {
+    /// The complete policy source which produced the metadata.
+    pub policy: ScriptPolicy,
+    /// Distinct values per protocol, in attachment order.
+    pub protocols: BTreeMap<i64, Vec<serde_json::Value>>,
+}
 
 /// Metadata for Object, arbitrary KV set.
 #[derive(Serialize, Deserialize, Clone, JsonSchema, Debug, PartialEq, Eq, Default)]
@@ -41,8 +52,9 @@ pub struct ObjectMetadata {
     pub extra: BTreeMap<String, serde_json::Value>,
     /// SIMP: Sapio Interactive Metadata Protocol
     pub simp: BTreeMap<i64, serde_json::Value>,
-    /// Distinct SIMP values per guard and protocol, in attachment order.
-    pub simps_for_guards: BTreeMap<Clause, BTreeMap<i64, Vec<serde_json::Value>>>,
+    /// Guard records in deterministic policy order. Each protocol retains its
+    /// distinct values in attachment order.
+    pub simps_for_guards: Vec<GuardMetadata>,
 }
 impl ObjectMetadata {
     /// Is there any metadata in this field?
@@ -68,7 +80,7 @@ impl ObjectMetadata {
     pub(crate) fn add_guard_simps(
         mut self,
         all_guard_simps: BTreeMap<
-            policy::Concrete<bitcoin::XOnlyPublicKey>,
+            ScriptPolicy,
             Vec<Arc<dyn SIMPAttachableAt<sapio_base::simp::GuardLT>>>,
         >,
     ) -> Result<ObjectMetadata, CompilationError> {
@@ -77,8 +89,8 @@ impl ObjectMetadata {
                 "Contract metadata cannot prepopulate guard SIMPs".into(),
             ));
         }
-        for (clause, metadata) in all_guard_simps {
-            let protocols = self.simps_for_guards.entry(clause).or_default();
+        for (policy, metadata) in all_guard_simps {
+            let mut protocols: BTreeMap<i64, Vec<serde_json::Value>> = BTreeMap::new();
             for simp in metadata {
                 let value = simp
                     .to_json()
@@ -87,6 +99,10 @@ impl ObjectMetadata {
                 if !values.contains(&value) {
                     values.push(value);
                 }
+            }
+            if !protocols.is_empty() {
+                self.simps_for_guards
+                    .push(GuardMetadata { policy, protocols });
             }
         }
         Ok(self)

--- a/sapio/src/contract/abi/object/taproot.rs
+++ b/sapio/src/contract/abi/object/taproot.rs
@@ -1,0 +1,337 @@
+// Copyright Judica, Inc 2022
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Checked Taproot spending data for leaves outside the Miniscript language.
+
+use bitcoin::secp256k1::Secp256k1;
+use bitcoin::util::taproot::{TaprootBuilder, TaprootBuilderError, TaprootSpendInfo};
+use bitcoin::{Script, XOnlyPublicKey};
+use sapio_base::policy::{validate_tapscript, PolicyError};
+use schemars::JsonSchema;
+use serde::{Deserialize, Deserializer, Serialize};
+use std::cmp::Reverse;
+use std::collections::{BTreeSet, BinaryHeap};
+use std::fmt;
+
+/// Maximum number of explicit script leaves in a raw Taproot artifact.
+pub const MAX_TAPROOT_LEAVES: usize = 1024;
+
+/// A checked tree of TapScript leaves in depth-first order.
+///
+/// Serialized data contains only the internal key and ordered `(depth, script)`
+/// leaves. The output key and control blocks are reconstructed on decoding.
+/// Script checks establish structural validity, not satisfiability or a witness
+/// weight bound. An empty leaf list explicitly represents a key-only output.
+#[derive(Serialize, JsonSchema, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RawTaproot {
+    #[schemars(with = "String", regex(pattern = "^[0-9a-fA-F]{64}$"))]
+    internal_key: XOnlyPublicKey,
+    #[schemars(length(max = "MAX_TAPROOT_LEAVES"))]
+    leaves: Vec<(u8, Script)>,
+    #[serde(skip)]
+    #[schemars(skip)]
+    spend_info: TaprootSpendInfo,
+}
+
+/// Why raw Taproot spending data cannot be accepted.
+#[derive(Debug)]
+pub enum RawTaprootError {
+    /// The artifact exceeds the leaf-count bound.
+    TooManyLeaves(usize),
+    /// An individual leaf violates the shared TapScript structure rules.
+    InvalidLeaf {
+        /// Index in the serialized depth-first leaf list.
+        index: usize,
+        /// The failed script invariant.
+        error: PolicyError,
+    },
+    /// The leaf depths do not describe a complete, valid Taproot tree.
+    InvalidTree(TaprootBuilderError),
+}
+
+impl fmt::Display for RawTaprootError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TooManyLeaves(count) => write!(
+                f,
+                "raw Taproot tree has {count} leaves; maximum is {MAX_TAPROOT_LEAVES}"
+            ),
+            Self::InvalidLeaf { index, error } => {
+                write!(f, "invalid raw Taproot leaf {index}: {error}")
+            }
+            Self::InvalidTree(error) => write!(f, "invalid raw Taproot tree: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for RawTaprootError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::TooManyLeaves(_) => None,
+            Self::InvalidLeaf { error, .. } => Some(error),
+            Self::InvalidTree(error) => Some(error),
+        }
+    }
+}
+
+impl RawTaproot {
+    /// Build a deterministic Huffman tree with equal weight for each distinct
+    /// script. Only identical complete leaves are deduplicated; script bytes
+    /// retain their exact instruction order and multiplicity.
+    pub fn from_scripts(
+        internal_key: XOnlyPublicKey,
+        scripts: Vec<Script>,
+    ) -> Result<Self, RawTaprootError> {
+        #[derive(PartialEq, Eq, PartialOrd, Ord)]
+        enum Tree {
+            Leaf(Script),
+            Branch(Box<Tree>, Box<Tree>),
+        }
+
+        let scripts: BTreeSet<_> = scripts.into_iter().collect();
+        if scripts.len() > MAX_TAPROOT_LEAVES {
+            return Err(RawTaprootError::TooManyLeaves(scripts.len()));
+        }
+        // Weight and lexicographic tree order make ties independent of caller
+        // order. Equal leaf weights keep the maximum depth at ten for 1024
+        // leaves, well below Taproot's limit of 128.
+        let mut heap: BinaryHeap<_> = scripts
+            .into_iter()
+            .map(|script| Reverse((1usize, Tree::Leaf(script))))
+            .collect();
+        while heap.len() > 1 {
+            let Reverse((left_weight, left)) = heap.pop().expect("at least two trees");
+            let Reverse((right_weight, right)) = heap.pop().expect("at least two trees");
+            heap.push(Reverse((
+                left_weight + right_weight,
+                Tree::Branch(Box::new(left), Box::new(right)),
+            )));
+        }
+        let mut leaves = vec![];
+        if let Some(Reverse((_, tree))) = heap.pop() {
+            let mut pending = vec![(0, tree)];
+            while let Some((depth, tree)) = pending.pop() {
+                match tree {
+                    Tree::Leaf(script) => leaves.push((depth, script)),
+                    Tree::Branch(left, right) => {
+                        pending.push((depth + 1, *right));
+                        pending.push((depth + 1, *left));
+                    }
+                }
+            }
+        }
+        Self::new(internal_key, leaves)
+    }
+
+    /// Validate scripts and tree shape, and derive the output and spending data.
+    /// Every leaf uses the current TapScript leaf version; hidden subtrees and
+    /// future leaf versions cannot be introduced through this representation.
+    pub fn new(
+        internal_key: XOnlyPublicKey,
+        leaves: Vec<(u8, Script)>,
+    ) -> Result<Self, RawTaprootError> {
+        if leaves.len() > MAX_TAPROOT_LEAVES {
+            return Err(RawTaprootError::TooManyLeaves(leaves.len()));
+        }
+        let mut builder = TaprootBuilder::new();
+        for (index, (depth, script)) in leaves.iter().enumerate() {
+            validate_tapscript(script)
+                .map_err(|error| RawTaprootError::InvalidLeaf { index, error })?;
+            builder = builder
+                .add_leaf(*depth, script.clone())
+                .map_err(RawTaprootError::InvalidTree)?;
+        }
+        // This bitcoin fork's finalize() does not itself require all pending
+        // branches to have been combined. Check completion before calling it.
+        if !leaves.is_empty() && !builder.is_finalized() {
+            return Err(RawTaprootError::InvalidTree(
+                TaprootBuilderError::IncompleteTree,
+            ));
+        }
+        let spend_info = builder
+            .finalize(&Secp256k1::verification_only(), internal_key)
+            .map_err(RawTaprootError::InvalidTree)?;
+        Ok(Self {
+            internal_key,
+            leaves,
+            spend_info,
+        })
+    }
+
+    /// The untweaked internal key committed to by this output.
+    pub fn internal_key(&self) -> XOnlyPublicKey {
+        self.internal_key
+    }
+
+    /// The exact depth-first leaf list, with depths measured from root zero.
+    pub fn leaves(&self) -> &[(u8, Script)] {
+        &self.leaves
+    }
+
+    /// Derived output key, Merkle root and script-path control blocks.
+    pub fn spend_info(&self) -> &TaprootSpendInfo {
+        &self.spend_info
+    }
+
+    /// The scriptPubKey committing to the checked internal key and script tree.
+    pub fn script_pubkey(&self) -> Script {
+        Script::new_v1_p2tr_tweaked(self.spend_info.output_key())
+    }
+}
+
+impl<'de> Deserialize<'de> for RawTaproot {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct Data {
+            internal_key: XOnlyPublicKey,
+            leaves: Vec<(u8, Script)>,
+        }
+
+        let data = Data::deserialize(deserializer)?;
+        Self::new(data.internal_key, data.leaves).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::secp256k1::{Keypair, SecretKey};
+    use bitcoin::util::taproot::LeafVersion;
+    use serde_json::json;
+
+    fn key() -> XOnlyPublicKey {
+        Keypair::from_secret_key(&Secp256k1::new(), &SecretKey::from_slice(&[1; 32]).unwrap())
+            .x_only_public_key()
+            .0
+    }
+
+    fn script(bytes: &[u8]) -> Script {
+        Script::from(bytes.to_vec())
+    }
+
+    #[test]
+    fn round_trip_reconstructs_the_same_output_and_control_blocks() {
+        // The second leaf uses a balanced altstack, as Miniscript can do.
+        let leaves = vec![(1, script(&[0x51])), (1, script(&[0x51, 0x6b, 0x6c]))];
+        let raw = RawTaproot::new(key(), leaves.clone()).unwrap();
+        let serialized = serde_json::to_value(&raw).unwrap();
+        assert_eq!(serialized.as_object().unwrap().len(), 2);
+        let decoded: RawTaproot = serde_json::from_value(serialized).unwrap();
+        assert_eq!(decoded, raw);
+        assert_eq!(decoded.internal_key(), key());
+        assert_eq!(decoded.leaves(), leaves);
+        assert_eq!(decoded.script_pubkey(), raw.script_pubkey());
+        for (_, script) in leaves {
+            let control = decoded
+                .spend_info()
+                .control_block(&(script.clone(), LeafVersion::TapScript))
+                .unwrap();
+            assert!(control.verify_taproot_commitment(
+                &Secp256k1::verification_only(),
+                decoded.spend_info().output_key().to_inner(),
+                &script,
+            ));
+        }
+        assert_eq!(raw.spend_info().as_script_map().len(), 2);
+    }
+
+    #[test]
+    fn an_explicit_key_only_tree_has_no_script_path() {
+        let raw = RawTaproot::new(key(), vec![]).unwrap();
+        assert_eq!(raw.spend_info().merkle_root(), None);
+        assert!(raw.spend_info().as_script_map().is_empty());
+        assert_eq!(
+            raw.script_pubkey(),
+            Script::new_v1_p2tr(&Secp256k1::verification_only(), key(), None)
+        );
+        let decoded: RawTaproot =
+            serde_json::from_str(&serde_json::to_string(&raw).unwrap()).unwrap();
+        assert_eq!(decoded, raw);
+    }
+
+    #[test]
+    fn script_factory_is_canonical_and_preserves_distinct_script_bytes() {
+        let first = script(&[0x51]);
+        let second = script(&[0x52]);
+        let third = script(&[0x51, 0x75, 0x51]);
+        let raw = RawTaproot::from_scripts(
+            key(),
+            vec![first.clone(), second.clone(), first.clone(), third.clone()],
+        )
+        .unwrap();
+        let permuted =
+            RawTaproot::from_scripts(key(), vec![third.clone(), second.clone(), first.clone()])
+                .unwrap();
+        assert_eq!(raw, permuted);
+        assert_eq!(raw.leaves().len(), 3);
+        assert_eq!(
+            raw.leaves()
+                .iter()
+                .map(|(_, script)| script.clone())
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from([first, second, third])
+        );
+        let round_trip: RawTaproot =
+            serde_json::from_slice(&serde_json::to_vec(&raw).unwrap()).unwrap();
+        assert_eq!(round_trip.spend_info(), raw.spend_info());
+        assert_eq!(
+            RawTaproot::from_scripts(key(), vec![]).unwrap(),
+            RawTaproot::new(key(), vec![]).unwrap()
+        );
+    }
+
+    #[test]
+    fn incomplete_out_of_order_and_overcomplete_trees_are_rejected() {
+        for depths in [vec![1], vec![1, 2], vec![2, 1, 2], vec![0, 0]] {
+            let leaves = depths.into_iter().map(|depth| (depth, script(&[0x51])));
+            assert!(matches!(
+                RawTaproot::new(key(), leaves.collect()),
+                Err(RawTaprootError::InvalidTree(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn tree_depth_and_leaf_count_boundaries_are_checked() {
+        let mut deepest: Vec<_> = (1..=128).map(|depth| (depth, script(&[0x51]))).collect();
+        deepest.push((128, script(&[0x51])));
+        assert!(RawTaproot::new(key(), deepest).is_ok());
+        assert!(matches!(
+            RawTaproot::new(key(), vec![(129, script(&[0x51]))]),
+            Err(RawTaprootError::InvalidTree(
+                TaprootBuilderError::InvalidMerkleTreeDepth(129)
+            ))
+        ));
+        let leaves = vec![(10, script(&[0x51])); MAX_TAPROOT_LEAVES];
+        assert!(RawTaproot::new(key(), leaves.clone()).is_ok());
+        let mut too_many = leaves;
+        too_many.push((10, script(&[0x51])));
+        assert!(matches!(
+            RawTaproot::new(key(), too_many),
+            Err(RawTaprootError::TooManyLeaves(1025))
+        ));
+    }
+
+    #[test]
+    fn decoding_rechecks_tree_shape_scripts_and_derived_fields() {
+        let raw = RawTaproot::new(key(), vec![(0, script(&[0x51]))]).unwrap();
+        let serialized = serde_json::to_value(&raw).unwrap();
+        let mut incomplete = serialized.clone();
+        incomplete["leaves"] = json!([(1, script(&[0x51]))]);
+        assert!(serde_json::from_value::<RawTaproot>(incomplete).is_err());
+
+        for bytes in [vec![0x4c], vec![0x50], vec![0xab], vec![0x63, 0x51]] {
+            let mut invalid_script = serialized.clone();
+            invalid_script["leaves"] = json!([(0, script(&bytes))]);
+            assert!(serde_json::from_value::<RawTaproot>(invalid_script).is_err());
+        }
+        let mut injected_cache = serialized;
+        injected_cache["spend_info"] = json!({});
+        assert!(serde_json::from_value::<RawTaproot>(injected_cache).is_err());
+    }
+}

--- a/sapio/src/contract/actions/finish.rs
+++ b/sapio/src/contract/actions/finish.rs
@@ -12,9 +12,9 @@ use crate::contract::actions::ConditionallyCompileIfList;
 use crate::contract::actions::GuardList;
 use crate::template::Template;
 use sapio_base::effects::EffectDBError;
+use sapio_base::policy::ScriptPolicy;
 use sapio_base::simp::ContinuationPointLT;
 use sapio_base::simp::SIMPAttachableAt;
-use sapio_base::Clause;
 use serde_json::Value;
 
 use core::marker::PhantomData;
@@ -62,7 +62,7 @@ pub struct FinishOrFunc<'a, ContractSelf, StatefulArguments, SpecificArgs, WebAP
     pub returned_txtmpls_modify_guards: bool,
     /// extract a clause from the txtmpl
     pub extract_clause_from_txtmpl:
-        fn(&Template, &Context) -> Result<Option<Clause>, CompilationError>,
+        fn(&Template, &Context) -> Result<Option<ScriptPolicy>, CompilationError>,
 }
 
 /// This trait hides the generic parameter `SpecificArgs` in FinishOrFunc
@@ -101,7 +101,7 @@ pub trait CallableAsFoF<ContractSelf, StatefulArguments> {
     /// extract a clause from the txtmpl
     fn get_extract_clause_from_txtmpl(
         &self,
-    ) -> fn(&Template, &Context) -> Result<Option<Clause>, CompilationError>;
+    ) -> fn(&Template, &Context) -> Result<Option<ScriptPolicy>, CompilationError>;
     /// rename this object
     fn rename(&mut self, a: Arc<String>);
 }
@@ -135,7 +135,7 @@ impl<ContractSelf, StatefulArguments, SpecificArgs> CallableAsFoF<ContractSelf, 
     }
     fn get_extract_clause_from_txtmpl(
         &self,
-    ) -> fn(&Template, &Context) -> Result<Option<Clause>, CompilationError> {
+    ) -> fn(&Template, &Context) -> Result<Option<ScriptPolicy>, CompilationError> {
         self.extract_clause_from_txtmpl
     }
 
@@ -188,7 +188,7 @@ where
 
     fn get_extract_clause_from_txtmpl(
         &self,
-    ) -> fn(&Template, &Context) -> Result<Option<Clause>, CompilationError> {
+    ) -> fn(&Template, &Context) -> Result<Option<ScriptPolicy>, CompilationError> {
         self.extract_clause_from_txtmpl
     }
 
@@ -209,7 +209,7 @@ where
 pub fn default_extract_clause_from_txtmpl(
     t: &Template,
     _ctx: &Context,
-) -> Result<Option<Clause>, CompilationError> {
+) -> Result<Option<ScriptPolicy>, CompilationError> {
     // Don't return or use the extra guards here
     // because we're within a non-CTV context... if
     // we did, then it would destabilize compilation

--- a/sapio/src/contract/actions/guard.rs
+++ b/sapio/src/contract/actions/guard.rs
@@ -12,6 +12,7 @@ use crate::contract::CompilationError;
 use super::Context;
 
 use sapio_base::{
+    policy::ScriptPolicy,
     simp::{GuardLT, SIMPAttachableAt},
     Clause,
 };
@@ -26,6 +27,16 @@ pub enum Guard<ContractSelf> {
     /// Evaluate the policy with the context of each attachment.
     Fresh(
         fn(&ContractSelf, Context) -> Clause,
+        Option<SimpGen<ContractSelf>>,
+    ),
+    /// Compile another policy language at this attachment's context.
+    FreshPolicy(
+        fn(&ContractSelf, Context) -> Result<ScriptPolicy, CompilationError>,
+        Option<SimpGen<ContractSelf>>,
+    ),
+    /// Compile another policy language once, independently of attachment context.
+    CachedPolicy(
+        fn(&ContractSelf) -> Result<ScriptPolicy, CompilationError>,
         Option<SimpGen<ContractSelf>>,
     ),
 }

--- a/sapio/src/contract/actions/then.rs
+++ b/sapio/src/contract/actions/then.rs
@@ -12,7 +12,7 @@ use crate::contract::actions::ConditionallyCompileIfList;
 use crate::contract::actions::GuardList;
 use crate::contract::actions::{FinishOrFunc, WebAPIDisabled};
 use crate::template::Template;
-use sapio_base::Clause;
+use sapio_base::policy::ScriptPolicy;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
@@ -67,9 +67,12 @@ impl<'a, ContractSelf, StatefulArgs> From<ThenFunc<'a, ContractSelf>>
     }
 }
 
-fn ctv_clause_extractor(t: &Template, ctx: &Context) -> Result<Option<Clause>, CompilationError> {
-    let covenant = ctx.ctv_emulator(t.hash())?;
-    Ok(Some(crate::contract::compiler::conjoin_guards(
+fn ctv_clause_extractor(
+    t: &Template,
+    ctx: &Context,
+) -> Result<Option<ScriptPolicy>, CompilationError> {
+    let covenant = ScriptPolicy::from(ctx.ctv_emulator(t.hash())?);
+    Ok(Some(crate::contract::compiler::conjoin_source(
         t.guards.iter().chain(std::iter::once(&covenant)),
     )))
 }

--- a/sapio/src/contract/compiler/cache.rs
+++ b/sapio/src/contract/compiler/cache.rs
@@ -10,6 +10,7 @@ use crate::contract::actions::Guard;
 use crate::contract::actions::SimpGen;
 use crate::contract::CompilationError;
 use sapio_base::effects::PathFragment;
+use sapio_base::policy::ScriptPolicy;
 use sapio_base::simp::GuardLT;
 use sapio_base::simp::SIMPAttachableAt;
 use sapio_base::Clause;
@@ -18,8 +19,12 @@ use std::sync::Arc;
 
 pub type GuardSimps = Vec<Arc<dyn SIMPAttachableAt<GuardLT>>>;
 pub(crate) enum CacheEntry<T> {
-    Cached(Clause, Option<SimpGen<T>>),
+    Cached(ScriptPolicy, Option<SimpGen<T>>),
     Fresh(fn(&T, Context) -> Clause, Option<SimpGen<T>>),
+    Policy(
+        fn(&T, Context) -> Result<ScriptPolicy, CompilationError>,
+        Option<SimpGen<T>>,
+    ),
 }
 
 /// GuardCache assists with caching the computation of guard functions
@@ -39,17 +44,36 @@ impl<T> GuardCache<T> {
         f: fn() -> Option<Guard<T>>,
         ctx: Context,
         simp_ctx: Context,
-    ) -> Result<Option<(Clause, GuardSimps)>, CompilationError> {
-        let entry = self.cache.entry(f as usize).or_insert_with(|| match f()? {
-            Guard::Cache(policy, simps) => Some(CacheEntry::Cached(policy(t), simps)),
-            Guard::Fresh(policy, simps) => Some(CacheEntry::Fresh(policy, simps)),
-        });
+    ) -> Result<Option<(ScriptPolicy, GuardSimps)>, CompilationError> {
+        let entry = match self.cache.entry(f as usize) {
+            std::collections::btree_map::Entry::Occupied(entry) => entry.into_mut(),
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                let value = match f() {
+                    None => None,
+                    Some(Guard::Cache(policy, simps)) => {
+                        Some(CacheEntry::Cached(policy(t).into(), simps))
+                    }
+                    Some(Guard::Fresh(policy, simps)) => Some(CacheEntry::Fresh(policy, simps)),
+                    Some(Guard::FreshPolicy(policy, simps)) => {
+                        Some(CacheEntry::Policy(policy, simps))
+                    }
+                    Some(Guard::CachedPolicy(policy, simps)) => {
+                        Some(CacheEntry::Cached(policy(t)?, simps))
+                    }
+                };
+                if let Some(CacheEntry::Cached(policy, _)) = &value {
+                    super::script::validate_source(policy)?;
+                }
+                entry.insert(value)
+            }
+        };
         let Some(entry) = entry else { return Ok(None) };
         let (clause, simps) = match entry {
             CacheEntry::Cached(clause, simps) => (clause.clone(), simps),
-            CacheEntry::Fresh(policy, simps) => (policy(t, ctx), simps),
+            CacheEntry::Fresh(policy, simps) => (policy(t, ctx).into(), simps),
+            CacheEntry::Policy(policy, simps) => (policy(t, ctx)?, simps),
         };
-        super::validation::validate_policy(&clause)?;
+        super::script::validate_source(&clause)?;
         let metadata = match simps {
             Some(generate) => generate(t, simp_ctx)?,
             None => vec![],
@@ -63,7 +87,7 @@ pub(crate) fn create_guards<T>(
     mut ctx: Context,
     guards: &[fn() -> Option<Guard<T>>],
     gc: &mut GuardCache<T>,
-) -> Result<(Clause, Vec<(Clause, GuardSimps)>), CompilationError> {
+) -> Result<(ScriptPolicy, Vec<(ScriptPolicy, GuardSimps)>), CompilationError> {
     let v = guards
         .iter()
         .enumerate()
@@ -74,5 +98,5 @@ pub(crate) fn create_guards<T>(
         })
         .filter_map(Result::transpose)
         .collect::<Result<Vec<_>, _>>()?;
-    Ok((super::conjoin_guards(v.iter().map(|x| &x.0)), v))
+    Ok((super::conjoin_source(v.iter().map(|x| &x.0)), v))
 }

--- a/sapio/src/contract/compiler/cache.rs
+++ b/sapio/src/contract/compiler/cache.rs
@@ -49,6 +49,7 @@ impl<T> GuardCache<T> {
             CacheEntry::Cached(clause, simps) => (clause.clone(), simps),
             CacheEntry::Fresh(policy, simps) => (policy(t, ctx), simps),
         };
+        super::validation::validate_policy(&clause)?;
         let metadata = match simps {
             Some(generate) => generate(t, simp_ctx)?,
             None => vec![],

--- a/sapio/src/contract/compiler/feasibility.rs
+++ b/sapio/src/contract/compiler/feasibility.rs
@@ -1,0 +1,273 @@
+// Copyright Judica, Inc 2021
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+//  License, v. 2.0. If a copy of the MPL was not distributed with this
+//  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Necessary transaction-field checks for the Miniscript policy backend.
+
+use bitcoin::hashes::sha256;
+use bitcoin::Transaction;
+use sapio_base::{CTVHash, Clause};
+
+const LOCK_TIME_THRESHOLD: u32 = 500_000_000;
+const SEQUENCE_DISABLE_FLAG: u32 = 1 << 31;
+const SEQUENCE_TYPE_FLAG: u32 = 1 << 22;
+const SEQUENCE_LOCK_MASK: u32 = SEQUENCE_TYPE_FLAG | 0xffff;
+
+/// Whether a Miniscript policy has an authorization compatible with the fixed
+/// transaction fields at the spending input. Keys and preimages are assumed
+/// available; this does not establish chain maturity, funding, or spendability.
+/// The CTV commitment is recomputed rather than taken from template metadata.
+pub(crate) fn miniscript_policy_possible(
+    policy: &Clause,
+    tx: &Transaction,
+    input_index: u32,
+) -> bool {
+    let Some(input) = tx.input.get(input_index as usize) else {
+        return false;
+    };
+    policy_possible(policy, tx, input.sequence, tx.get_ctv_hash(input_index))
+}
+
+fn policy_possible(policy: &Clause, tx: &Transaction, sequence: u32, ctv: sha256::Hash) -> bool {
+    let possible = |policy| policy_possible(policy, tx, sequence, ctv);
+    match policy {
+        Clause::Unsatisfiable => false,
+        Clause::Trivial
+        | Clause::Key(_)
+        | Clause::Sha256(_)
+        | Clause::Hash256(_)
+        | Clause::Ripemd160(_)
+        | Clause::Hash160(_) => true,
+        Clause::After(required) => {
+            sequence != u32::MAX
+                && (tx.lock_time < LOCK_TIME_THRESHOLD) == (*required < LOCK_TIME_THRESHOLD)
+                && *required <= tx.lock_time
+        }
+        Clause::Older(required) => {
+            // BIP 112 treats an operand with its disable bit set as a NOP,
+            // before inspecting transaction version or input sequence.
+            required & SEQUENCE_DISABLE_FLAG != 0
+                || (tx.version >= 2
+                    && sequence & SEQUENCE_DISABLE_FLAG == 0
+                    && (required & SEQUENCE_TYPE_FLAG) == (sequence & SEQUENCE_TYPE_FLAG)
+                    && (required & SEQUENCE_LOCK_MASK) <= (sequence & SEQUENCE_LOCK_MASK))
+        }
+        Clause::TxTemplate(required) => *required == ctv,
+        Clause::And(children) => children.iter().all(possible),
+        Clause::Or(children) => children.iter().any(|(_, child)| possible(child)),
+        Clause::Threshold(required, children) => {
+            children.iter().filter(|child| possible(child)).count() >= *required
+        }
+        Clause::Inscribe(_, child) => possible(child),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::hashes::{hash160, ripemd160, sha256d, Hash};
+    use bitcoin::secp256k1::{Keypair, Secp256k1, SecretKey};
+    use bitcoin::{TxIn, TxOut, Witness};
+    use sapio_base::miniscript::ord::Inscription;
+
+    fn transaction(version: i32, lock_time: u32, sequence: u32) -> Transaction {
+        Transaction {
+            version,
+            lock_time,
+            input: vec![TxIn {
+                previous_output: Default::default(),
+                script_sig: Default::default(),
+                sequence,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: 1_000,
+                script_pubkey: Default::default(),
+            }],
+        }
+    }
+
+    fn key_policy() -> Clause {
+        let key =
+            Keypair::from_secret_key(&Secp256k1::new(), &SecretKey::from_slice(&[1; 32]).unwrap())
+                .x_only_public_key()
+                .0;
+        Clause::Key(key)
+    }
+
+    #[test]
+    fn credentials_are_potentially_available() {
+        let tx = transaction(2, 0, 0);
+        for policy in [
+            Clause::Trivial,
+            key_policy(),
+            Clause::Sha256(sha256::Hash::hash(b"unknown preimage")),
+            Clause::Hash256(sha256d::Hash::hash(b"unknown preimage")),
+            Clause::Ripemd160(ripemd160::Hash::hash(b"unknown preimage")),
+            Clause::Hash160(hash160::Hash::hash(b"unknown preimage")),
+        ] {
+            assert!(miniscript_policy_possible(&policy, &tx, 0));
+        }
+        assert!(!miniscript_policy_possible(&Clause::Unsatisfiable, &tx, 0));
+    }
+
+    #[test]
+    fn absolute_locktime_requires_same_domain_and_nonfinal_input() {
+        for (required, lock_time, sequence, expected) in [
+            (100, 99, 0, false),
+            (100, 100, 0, true),
+            (100, 101, 0, true),
+            (100, 100, u32::MAX, false),
+            (100, 100, u32::MAX - 1, true),
+            (LOCK_TIME_THRESHOLD - 1, LOCK_TIME_THRESHOLD - 1, 0, true),
+            (LOCK_TIME_THRESHOLD - 1, LOCK_TIME_THRESHOLD, 0, false),
+            (LOCK_TIME_THRESHOLD, LOCK_TIME_THRESHOLD - 1, 0, false),
+            (LOCK_TIME_THRESHOLD, LOCK_TIME_THRESHOLD, 0, true),
+            (LOCK_TIME_THRESHOLD + 1, LOCK_TIME_THRESHOLD, 0, false),
+            (u32::MAX, u32::MAX, 0, true),
+        ] {
+            assert_eq!(
+                miniscript_policy_possible(
+                    &Clause::After(required),
+                    &transaction(1, lock_time, sequence),
+                    0,
+                ),
+                expected,
+                "after({required}), lock_time={lock_time}, sequence={sequence}"
+            );
+        }
+    }
+
+    #[test]
+    fn relative_locktime_requires_enabled_version_and_sequence() {
+        for version in [i32::MIN, -1, 0, 1, 2, 3, i32::MAX] {
+            assert_eq!(
+                miniscript_policy_possible(&Clause::Older(1), &transaction(version, 0, 1), 0),
+                version >= 2,
+                "version={version}"
+            );
+            for sequence in [SEQUENCE_DISABLE_FLAG | 1, u32::MAX] {
+                assert!(!miniscript_policy_possible(
+                    &Clause::Older(1),
+                    &transaction(version, 0, sequence),
+                    0,
+                ));
+            }
+        }
+    }
+
+    #[test]
+    fn disabled_csv_operand_is_a_nop() {
+        for required in [SEQUENCE_DISABLE_FLAG, u32::MAX] {
+            for version in [-1, 1, 2] {
+                for sequence in [0, SEQUENCE_TYPE_FLAG, SEQUENCE_DISABLE_FLAG, u32::MAX] {
+                    assert!(miniscript_policy_possible(
+                        &Clause::Older(required),
+                        &transaction(version, 0, sequence),
+                        0,
+                    ));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn relative_locktime_compares_only_consensus_bits_in_the_same_domain() {
+        const RESERVED: u32 = 0x7fff_ffff & !SEQUENCE_LOCK_MASK;
+        for (required, sequence, expected) in [
+            (10, 9, false),
+            (10, 10, true),
+            (10, 11, true),
+            (0xffff, 0xffff, true),
+            (10, SEQUENCE_TYPE_FLAG | 10, false),
+            (SEQUENCE_TYPE_FLAG | 10, 10, false),
+            (SEQUENCE_TYPE_FLAG | 10, SEQUENCE_TYPE_FLAG | 9, false),
+            (SEQUENCE_TYPE_FLAG | 10, SEQUENCE_TYPE_FLAG | 10, true),
+            (SEQUENCE_TYPE_FLAG | 10, SEQUENCE_TYPE_FLAG | 11, true),
+            (RESERVED | 10, 10, true),
+            (10, RESERVED | 10, true),
+            (RESERVED | 10, RESERVED | 9, false),
+            (
+                RESERVED | SEQUENCE_TYPE_FLAG | 10,
+                SEQUENCE_TYPE_FLAG | 10,
+                true,
+            ),
+        ] {
+            assert_eq!(
+                miniscript_policy_possible(
+                    &Clause::Older(required),
+                    &transaction(2, 0, sequence),
+                    0,
+                ),
+                expected,
+                "older({required}), sequence={sequence}"
+            );
+        }
+    }
+
+    #[test]
+    fn template_commitment_and_timelocks_use_the_selected_input() {
+        let mut tx = transaction(2, 100, u32::MAX);
+        let mut second_input = tx.input[0].clone();
+        second_input.sequence = 10;
+        tx.input.push(second_input);
+        let committed_to_zero = Clause::TxTemplate(tx.get_ctv_hash(0));
+        let committed_to_one = Clause::TxTemplate(tx.get_ctv_hash(1));
+        assert!(miniscript_policy_possible(&committed_to_zero, &tx, 0));
+        assert!(!miniscript_policy_possible(&committed_to_zero, &tx, 1));
+        assert!(miniscript_policy_possible(&committed_to_one, &tx, 1));
+        for policy in [Clause::After(100), Clause::Older(10)] {
+            assert!(!miniscript_policy_possible(&policy, &tx, 0));
+            assert!(miniscript_policy_possible(&policy, &tx, 1));
+        }
+        tx.output[0].value += 1;
+        assert!(!miniscript_policy_possible(&committed_to_zero, &tx, 0));
+        assert!(!miniscript_policy_possible(&committed_to_one, &tx, 1));
+    }
+
+    #[test]
+    fn a_spending_input_must_exist() {
+        let mut tx = transaction(2, 100, 10);
+        assert!(!miniscript_policy_possible(&Clause::Trivial, &tx, 1));
+        assert!(!miniscript_policy_possible(&Clause::Trivial, &tx, u32::MAX));
+        tx.input.clear();
+        assert!(!miniscript_policy_possible(&Clause::Trivial, &tx, 0));
+    }
+
+    #[test]
+    fn alternatives_thresholds_and_inscriptions_preserve_possible_authorizations() {
+        let tx = transaction(2, 100, 10);
+        let impossible = Clause::Older(11);
+        let possible = key_policy();
+        let alternatives = Clause::Or(vec![(1, impossible.clone()), (0, possible.clone())]);
+        assert!(miniscript_policy_possible(&alternatives, &tx, 0));
+        assert!(!miniscript_policy_possible(
+            &Clause::And(vec![impossible.clone(), possible.clone()]),
+            &tx,
+            0,
+        ));
+        let children = vec![impossible.clone(), possible, Clause::After(100)];
+        assert!(miniscript_policy_possible(
+            &Clause::Threshold(2, children.clone()),
+            &tx,
+            0,
+        ));
+        assert!(!miniscript_policy_possible(
+            &Clause::Threshold(3, children),
+            &tx,
+            0,
+        ));
+        for (inner, expected) in [(alternatives, true), (impossible, false)] {
+            let inscription = Clause::Inscribe(
+                Box::new(Inscription::new(
+                    Some(b"application/octet-stream".to_vec()),
+                    Some(vec![0, 1, 255]),
+                )),
+                Box::new(inner),
+            );
+            assert_eq!(miniscript_policy_possible(&inscription, &tx, 0), expected);
+        }
+    }
+}

--- a/sapio/src/contract/compiler/mod.rs
+++ b/sapio/src/contract/compiler/mod.rs
@@ -27,7 +27,9 @@ use sapio_base::Clause;
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 mod cache;
+mod feasibility;
 mod util;
+mod validation;
 use cache::*;
 use util::*;
 /// Grants the compiler access to effects at the current compilation path.
@@ -222,9 +224,24 @@ where
             let mut template_clauses = vec![];
             for template in compute_all_effects(effect_context, self_ref, action.as_ref())? {
                 let mut template = template?;
+                for guard in &template.guards {
+                    validation::validate_policy(guard)?;
+                }
                 // This also rejects forbidden guards on every suggested
                 // template, including duplicates of an earlier valid template.
                 let clause = (action.get_extract_clause_from_txtmpl())(&template, &ctx)?;
+                if let Some(clause) = &clause {
+                    validation::validate_policy(clause)?;
+                    if committed
+                        && (!feasibility::miniscript_policy_possible(&guards, &template.tx, 0)
+                            || !feasibility::miniscript_policy_possible(clause, &template.tx, 0))
+                    {
+                        return Err(CompilationError::ImpossibleTemplate {
+                            hash: template.hash(),
+                            at: effect_path.as_ref().clone(),
+                        });
+                    }
+                }
                 amount_range.update_range(template.required_input_amount);
                 if committed {
                     template.guards = policy_as_guards(conjoin_guards(

--- a/sapio/src/contract/compiler/mod.rs
+++ b/sapio/src/contract/compiler/mod.rs
@@ -22,12 +22,14 @@ use sapio_base::effects::EffectDB;
 use sapio_base::effects::EffectPath;
 use sapio_base::effects::PathFragment;
 use sapio_base::miniscript;
+use sapio_base::policy::ScriptPolicy;
 use sapio_base::serialization_helpers::SArc;
 use sapio_base::Clause;
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 mod cache;
 mod feasibility;
+mod script;
 mod util;
 mod validation;
 use cache::*;
@@ -174,8 +176,9 @@ where
         let mut action_ctx = ctx.derive(PathFragment::Action)?;
         let mut renamer = Renamer::new();
         let mut continue_apis = BTreeMap::new();
-        let mut action_branches = vec![];
-        let mut all_guard_simps: BTreeMap<Clause, GuardSimps> = BTreeMap::new();
+        let mut branches = vec![];
+        let mut branch_bytes = 0usize;
+        let mut all_guard_simps: BTreeMap<ScriptPolicy, GuardSimps> = BTreeMap::new();
         let then_fns = self.then_fns();
         let finish_or_fns = self.finish_or_fns();
         let actions = then_fns
@@ -221,20 +224,20 @@ where
                 PathFragment::Suggested
             })?;
             let effect_path = effect_context.path().clone();
-            let mut template_clauses = vec![];
+            let mut produced_clause = false;
             for template in compute_all_effects(effect_context, self_ref, action.as_ref())? {
                 let mut template = template?;
                 for guard in &template.guards {
-                    validation::validate_policy(guard)?;
+                    script::validate_source(guard)?;
                 }
                 // This also rejects forbidden guards on every suggested
                 // template, including duplicates of an earlier valid template.
                 let clause = (action.get_extract_clause_from_txtmpl())(&template, &ctx)?;
                 if let Some(clause) = &clause {
-                    validation::validate_policy(clause)?;
+                    script::validate_source(clause)?;
                     if committed
-                        && (!feasibility::miniscript_policy_possible(&guards, &template.tx, 0)
-                            || !feasibility::miniscript_policy_possible(clause, &template.tx, 0))
+                        && (!source_policy_possible(&guards, &template.tx)
+                            || !source_policy_possible(clause, &template.tx))
                     {
                         return Err(CompilationError::ImpossibleTemplate {
                             hash: template.hash(),
@@ -244,7 +247,7 @@ where
                 }
                 amount_range.update_range(template.required_input_amount);
                 if committed {
-                    template.guards = policy_as_guards(conjoin_guards(
+                    template.guards = policy_as_guards(conjoin_source(
                         std::iter::once(&guards).chain(template.guards.iter()),
                     ));
                 }
@@ -258,11 +261,20 @@ where
                     &effect_path,
                 )?;
                 if let Some(clause) = clause {
-                    template_clauses.push(clause);
+                    produced_clause = true;
+                    if committed {
+                        append_branches(
+                            &mut branches,
+                            &mut branch_bytes,
+                            compile_branches(conjoin_source([&guards, &clause].into_iter()))?,
+                        )?;
+                    }
                 }
             }
-            action_branches.extend(if committed {
-                combine_txtmpls(nullability, template_clauses, guards)?
+            if committed {
+                if !produced_clause && nullability == Nullable::No {
+                    return Err(CompilationError::MissingTemplates);
+                }
             } else {
                 let mut continuation =
                     ContinuationPoint::at(action.get_schema().clone(), effect_path.clone());
@@ -270,8 +282,8 @@ where
                     continuation = continuation.add_simp(simp.as_ref())?;
                 }
                 continue_apis.insert(SArc(effect_path), continuation);
-                optimizer_flatten_and_compile(guards)?
-            });
+                append_branches(&mut branches, &mut branch_bytes, compile_branches(guards)?)?;
+            }
             for (policy, mut simps) in guard_metadata {
                 all_guard_simps
                     .entry(policy)
@@ -281,7 +293,6 @@ where
         }
 
         let mut finish_context = ctx.derive(PathFragment::FinishFn)?;
-        let mut branches = vec![];
         for (index, factory) in self.finish_fns().iter().enumerate() {
             let mut guard_context = finish_context.derive_num(index as u64)?;
             let metadata_context = guard_context.derive(PathFragment::Metadata)?;
@@ -292,21 +303,60 @@ where
                     .entry(policy.clone())
                     .or_default()
                     .append(&mut simps);
-                branches.extend(optimizer_flatten_and_compile(policy)?);
+                append_branches(&mut branches, &mut branch_bytes, compile_branches(policy)?)?;
             }
         }
-        branches.extend(action_branches);
-        // TODO: Pick a better branch that is guaranteed to work!
-        let some_key = pick_key_from_miniscripts(branches.iter());
-        // Don't remove the key from the scripts in case it was bogus
-        let tree = branches_to_tree(branches);
-        let descriptor = Descriptor::Tr(descriptor::Tr::new(some_key, tree)?);
-        let estimated_max_size = descriptor.max_satisfaction_weight()?;
-        // TODO: Convert into an address instead of keeping descriptor,
-        // hot-fix workaround
-        let address = descriptor.clone().into();
-        let descriptor = Some(descriptor.into());
+        if branches.is_empty() {
+            return Err(CompilationError::EmptyPolicy);
+        }
+        // Only a proven standalone Miniscript key may become a key-path spend.
+        let some_key =
+            pick_key_from_miniscripts(branches.iter().filter_map(|branch| match branch {
+                CompiledBranch::Miniscript(script) => Some(script),
+                CompiledBranch::Script(_) => None,
+            }));
+        let opaque = branches
+            .iter()
+            .any(|branch| matches!(branch, CompiledBranch::Script(_)));
+        let (address, descriptor, estimated_max_size) = if opaque {
+            let scripts = branches
+                .into_iter()
+                .map(|branch| match branch {
+                    CompiledBranch::Miniscript(script) => script.encode(),
+                    CompiledBranch::Script(script) => script,
+                })
+                .collect();
+            let raw = crate::contract::object::RawTaproot::from_scripts(some_key, scripts)?;
+            let address =
+                bitcoin::Address::p2tr_tweaked(raw.spend_info().output_key(), ctx.network).into();
+            (
+                address,
+                crate::contract::object::SupportedDescriptors::Taproot(raw),
+                None,
+            )
+        } else {
+            let native = branches
+                .into_iter()
+                .filter_map(|branch| match branch {
+                    CompiledBranch::Miniscript(script) => Some(script),
+                    CompiledBranch::Script(_) => None,
+                })
+                .collect();
+            let tree = branches_to_tree(native);
+            let descriptor = Descriptor::Tr(descriptor::Tr::new(some_key, tree)?);
+            let weight = descriptor.max_satisfaction_weight()?;
+            (descriptor.clone().into(), descriptor.into(), Some(weight))
+        };
+        let descriptor = Some(descriptor);
         let root_path = SArc(ctx.path().clone());
+
+        if estimated_max_size.is_none()
+            && comitted_txns
+                .values()
+                .any(|t| t.min_feerate_sats_vbyte.is_some())
+        {
+            return Err(CompilationError::UnknownSatisfactionWeight);
+        }
 
         let failed_estimate = comitted_txns.values().any(|a| {
             let Some(rate) = a.min_feerate_sats_vbyte else {
@@ -317,6 +367,9 @@ where
             if a.tx.input.len() != 1 {
                 return true;
             }
+            let Some(estimated_max_size) = estimated_max_size else {
+                return true;
+            };
             let vsize = (a.tx.weight() + estimated_max_size + 2).div_ceil(4) as u64;
             // Only this template's reserved fees count. A larger funding
             // requirement in another branch cannot subsidize this spend.
@@ -379,11 +432,84 @@ pub(crate) fn conjoin_guards<'a>(guards: impl Iterator<Item = &'a Clause>) -> Cl
     }
 }
 
-fn policy_as_guards(policy: Clause) -> Vec<Clause> {
-    if policy == Clause::Trivial {
+/// Compose policy sources without lowering a raw fragment prematurely.
+pub(crate) fn conjoin_source<'a>(policies: impl Iterator<Item = &'a ScriptPolicy>) -> ScriptPolicy {
+    let policies: Vec<_> = policies.collect();
+    if policies
+        .iter()
+        .all(|p| matches!(p, ScriptPolicy::Miniscript(_)))
+    {
+        return conjoin_guards(policies.into_iter().filter_map(|p| match p {
+            ScriptPolicy::Miniscript(clause) => Some(clause),
+            _ => None,
+        }))
+        .into();
+    }
+    let mut policies: Vec<_> = policies
+        .into_iter()
+        .filter(|p| !is_trivial(p))
+        .cloned()
+        .collect();
+    if policies.len() == 1 {
+        policies.pop().unwrap()
+    } else {
+        ScriptPolicy::And(policies)
+    }
+}
+
+fn is_trivial(policy: &ScriptPolicy) -> bool {
+    matches!(policy, ScriptPolicy::Miniscript(Clause::Trivial))
+        || matches!(policy, ScriptPolicy::And(children) if children.is_empty())
+}
+
+fn policy_as_guards(policy: ScriptPolicy) -> Vec<ScriptPolicy> {
+    if is_trivial(&policy) {
         vec![]
     } else {
         vec![policy]
+    }
+}
+
+fn source_policy_possible(policy: &ScriptPolicy, tx: &bitcoin::Transaction) -> bool {
+    match policy {
+        ScriptPolicy::Miniscript(clause) => feasibility::miniscript_policy_possible(clause, tx, 0),
+        ScriptPolicy::Script(_) => true,
+        ScriptPolicy::And(children) => children.iter().all(|p| source_policy_possible(p, tx)),
+        ScriptPolicy::Or(children) => children.iter().any(|p| source_policy_possible(p, tx)),
+    }
+}
+
+fn source_alternatives(policy: ScriptPolicy) -> Vec<ScriptPolicy> {
+    match policy {
+        ScriptPolicy::Miniscript(clause) => optimizer_flatten_policy(clause)
+            .into_iter()
+            .map(Into::into)
+            .collect(),
+        ScriptPolicy::Or(children) => children.into_iter().flat_map(source_alternatives).collect(),
+        policy => vec![policy],
+    }
+}
+
+fn disjoin_source(policies: BTreeSet<ScriptPolicy>) -> ScriptPolicy {
+    if policies.len() == 1 {
+        policies.into_iter().next().unwrap()
+    } else if policies
+        .iter()
+        .all(|p| matches!(p, ScriptPolicy::Miniscript(_)))
+    {
+        Clause::Threshold(
+            1,
+            policies
+                .into_iter()
+                .filter_map(|p| match p {
+                    ScriptPolicy::Miniscript(clause) => Some(clause),
+                    _ => None,
+                })
+                .collect(),
+        )
+        .into()
+    } else {
+        ScriptPolicy::Or(policies.into_iter().collect())
     }
 }
 
@@ -422,19 +548,11 @@ fn insert_template(
                 inputs,
                 outputs
             );
-            let alternatives = optimizer_flatten_policy(conjoin_guards(existing.guards.iter()))
+            let alternatives = source_alternatives(conjoin_source(existing.guards.iter()))
                 .into_iter()
-                .chain(optimizer_flatten_policy(conjoin_guards(
-                    template.guards.iter(),
-                )))
-                .collect::<BTreeSet<_>>();
-            existing.guards = if alternatives.contains(&Clause::Trivial) {
-                vec![]
-            } else if alternatives.len() == 1 {
-                alternatives.into_iter().collect()
-            } else {
-                vec![Clause::Threshold(1, alternatives.into_iter().collect())]
-            };
+                .chain(source_alternatives(conjoin_source(template.guards.iter())))
+                .collect();
+            existing.guards = policy_as_guards(disjoin_source(alternatives));
         }
     }
     Ok(())
@@ -450,48 +568,52 @@ fn optimizer_flatten_and_compile(
     Ok(v)
 }
 
-fn combine_txtmpls(
-    nullability: Nullable,
-    txtmpl_clauses: Vec<Clause>,
-    guards: Clause,
-) -> Result<Vec<Miniscript<XOnlyPublicKey, Tap>>, CompilationError> {
-    match (nullability, txtmpl_clauses.len(), guards) {
-        // This is a nullable branch without any proposed
-        // transactions.
-        // Therefore, mark this branch dead.
-        (Nullable::Yes, 0, _) => Ok(vec![]),
-        // Error if we expect CTV, returned some templates, but our guard
-        // was unsatisfiable, irrespective of nullability. This is because
-        // the behavior should be captured through a compile_if if it is
-        // intended.
-        (_, n, Clause::Unsatisfiable) if n > 0 => {
-            // TODO: Turn into a warning that the intended
-            // behavior should be to compile_if
-            Err(CompilationError::MissingTemplates)
-        }
-        // Error if 0 templates return and we don't want to be nullable
-        (Nullable::No, 0, _) => Err(CompilationError::MissingTemplates),
-        // If the guard is trivial, return the hashes standalone
-        (_, _, Clause::Trivial) => {
-            let r = Ok(txtmpl_clauses
-                .into_iter()
-                .map(|policy| policy.compile().map_err(Into::<CompilationError>::into))
-                .collect::<Result<Vec<_>, _>>()?);
-            r
-        }
-        // If the guard is non-trivial, zip it to each hash
-        // TODO: Arc in miniscript to dedup memory?
-        //       This could be Clause::Shared(x) or something...
-        (_, _, guards) => Ok(txtmpl_clauses
+enum CompiledBranch {
+    Miniscript(Miniscript<XOnlyPublicKey, Tap>),
+    Script(bitcoin::Script),
+}
+
+fn compile_branches(policy: ScriptPolicy) -> Result<Vec<CompiledBranch>, CompilationError> {
+    script::validate_source(&policy)?;
+    match policy {
+        ScriptPolicy::Miniscript(clause) => Ok(optimizer_flatten_and_compile(clause)?
             .into_iter()
-            // extra_guards will contain any CTV
-            .map(|extra_guards| {
-                Clause::And(vec![guards.clone(), extra_guards])
-                    .compile()
-                    .map_err(Into::<CompilationError>::into)
-            })
-            .collect::<Result<Vec<_>, _>>()?),
+            .map(CompiledBranch::Miniscript)
+            .collect()),
+        policy => Ok(script::lower_script_policy(&policy)?
+            .into_iter()
+            .map(CompiledBranch::Script)
+            .collect()),
     }
+}
+
+/// Admit branches incrementally so separate actions share one output budget.
+fn append_branches(
+    branches: &mut Vec<CompiledBranch>,
+    bytes: &mut usize,
+    additions: Vec<CompiledBranch>,
+) -> Result<(), CompilationError> {
+    for branch in additions {
+        if branches.len() == 1_024 {
+            return Err(CompilationError::PolicyLimit {
+                resource: "contract branches",
+                limit: 1_024,
+            });
+        }
+        let size = match &branch {
+            CompiledBranch::Miniscript(script) => script.script_size(),
+            CompiledBranch::Script(script) => script.len(),
+        };
+        *bytes = bytes
+            .checked_add(size)
+            .filter(|total| *total <= script::MAX_SCRIPT_BYTES)
+            .ok_or(CompilationError::PolicyLimit {
+                resource: "contract script bytes",
+                limit: script::MAX_SCRIPT_BYTES,
+            })?;
+        branches.push(branch);
+    }
+    Ok(())
 }
 
 fn optimizer_flatten_policy(p: Clause) -> Vec<Clause> {

--- a/sapio/src/contract/compiler/script.rs
+++ b/sapio/src/contract/compiler/script.rs
@@ -1,0 +1,679 @@
+// Copyright Judica, Inc 2021
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Lower policy alternatives to complete Tapscript predicates.
+
+use crate::contract::CompilationError;
+use bitcoin::blockdata::opcodes;
+use bitcoin::Script;
+use sapio_base::miniscript::ord::Inscription;
+use sapio_base::miniscript::Tap;
+use sapio_base::policy::ScriptPolicy;
+use sapio_base::Clause;
+
+const MAX_DEPTH: usize = 128;
+const MAX_NODES: usize = 65_536;
+const MAX_ALTERNATIVES: usize = 1_024;
+const MAX_EXPANDED_OPERANDS: usize = 65_536;
+/// Maximum source payload, expanded payload and cumulative encoded script
+/// bytes for one lowering operation. This is a work limit, not a consensus
+/// script-size limit or a witness-size estimate.
+pub(super) const MAX_SCRIPT_BYTES: usize = 16 * 1024 * 1024;
+
+fn limit(resource: &'static str, limit: usize) -> CompilationError {
+    CompilationError::PolicyLimit { resource, limit }
+}
+
+#[derive(Clone, Copy)]
+struct Expansion {
+    alternatives: usize,
+    operands: usize,
+    payload_bytes: usize,
+}
+
+impl Expansion {
+    const EMPTY: Self = Self {
+        alternatives: 0,
+        operands: 0,
+        payload_bytes: 0,
+    };
+    const TRUE: Self = Self {
+        alternatives: 1,
+        operands: 0,
+        payload_bytes: 0,
+    };
+    const ONE: Self = Self {
+        alternatives: 1,
+        operands: 1,
+        payload_bytes: 0,
+    };
+
+    fn checked(
+        alternatives: Option<usize>,
+        operands: Option<usize>,
+        payload_bytes: Option<usize>,
+    ) -> Result<Self, CompilationError> {
+        let alternatives = alternatives
+            .filter(|count| *count <= MAX_ALTERNATIVES)
+            .ok_or_else(|| limit("Taproot alternatives", MAX_ALTERNATIVES))?;
+        let operands = operands
+            .filter(|count| *count <= MAX_EXPANDED_OPERANDS)
+            .ok_or_else(|| limit("expanded policy operands", MAX_EXPANDED_OPERANDS))?;
+        let payload_bytes = payload_bytes
+            .filter(|bytes| *bytes <= MAX_SCRIPT_BYTES)
+            .ok_or_else(|| limit("expanded script bytes", MAX_SCRIPT_BYTES))?;
+        Ok(Self {
+            alternatives,
+            operands,
+            payload_bytes,
+        })
+    }
+
+    fn or(self, other: Self) -> Result<Self, CompilationError> {
+        Self::checked(
+            self.alternatives.checked_add(other.alternatives),
+            self.operands.checked_add(other.operands),
+            self.payload_bytes.checked_add(other.payload_bytes),
+        )
+    }
+
+    fn and(self, other: Self) -> Result<Self, CompilationError> {
+        Self::checked(
+            self.alternatives.checked_mul(other.alternatives),
+            self.operands
+                .checked_mul(other.alternatives)
+                .and_then(|left| {
+                    other
+                        .operands
+                        .checked_mul(self.alternatives)
+                        .and_then(|right| left.checked_add(right))
+                }),
+            self.payload_bytes
+                .checked_mul(other.alternatives)
+                .and_then(|left| {
+                    other
+                        .payload_bytes
+                        .checked_mul(self.alternatives)
+                        .and_then(|right| left.checked_add(right))
+                }),
+        )
+    }
+}
+
+#[derive(Default)]
+struct Preflight {
+    nodes: usize,
+    payload_bytes: usize,
+}
+
+impl Preflight {
+    fn payload(&mut self, bytes: usize) -> Result<(), CompilationError> {
+        self.payload_bytes = self
+            .payload_bytes
+            .checked_add(bytes)
+            .filter(|bytes| *bytes <= MAX_SCRIPT_BYTES)
+            .ok_or_else(|| limit("source script bytes", MAX_SCRIPT_BYTES))?;
+        Ok(())
+    }
+
+    fn visit(&mut self, depth: usize) -> Result<(), CompilationError> {
+        if depth > MAX_DEPTH {
+            return Err(limit("policy depth", MAX_DEPTH));
+        }
+        self.nodes += 1;
+        if self.nodes > MAX_NODES {
+            return Err(limit("policy nodes", MAX_NODES));
+        }
+        Ok(())
+    }
+
+    fn policy(
+        &mut self,
+        policy: &ScriptPolicy,
+        depth: usize,
+    ) -> Result<Expansion, CompilationError> {
+        self.visit(depth)?;
+        match policy {
+            ScriptPolicy::Miniscript(clause) => {
+                // Bound recursion before invoking the Miniscript validator.
+                let expansion = self.clause(clause, depth + 1, true)?;
+                super::validation::validate_policy(clause)?;
+                Ok(expansion)
+            }
+            ScriptPolicy::Script(fragment) => {
+                let payload_bytes = fragment.as_script().len();
+                self.payload(payload_bytes)?;
+                Ok(Expansion {
+                    payload_bytes,
+                    ..Expansion::ONE
+                })
+            }
+            ScriptPolicy::And(children) => {
+                let mut expansion = Expansion::TRUE;
+                for child in children {
+                    // Visit even when an earlier child has no alternatives:
+                    // an unreachable malformed declaration is still an error.
+                    expansion = expansion.and(self.policy(child, depth + 1)?)?;
+                }
+                Ok(expansion)
+            }
+            ScriptPolicy::Or(children) => {
+                let mut expansion = Expansion::EMPTY;
+                for child in children {
+                    expansion = expansion.or(self.policy(child, depth + 1)?)?;
+                }
+                Ok(expansion)
+            }
+        }
+    }
+
+    fn clause(
+        &mut self,
+        clause: &Clause,
+        depth: usize,
+        split: bool,
+    ) -> Result<Expansion, CompilationError> {
+        self.visit(depth)?;
+        match clause {
+            Clause::Or(children) => {
+                let mut expansion = Expansion::EMPTY;
+                let mut payload_bytes = 0usize;
+                for (_, child) in children {
+                    let child = self.clause(child, depth + 1, split)?;
+                    if split {
+                        expansion = expansion.or(child)?;
+                    } else {
+                        payload_bytes = payload_bytes
+                            .checked_add(child.payload_bytes)
+                            .ok_or_else(|| limit("expanded script bytes", MAX_SCRIPT_BYTES))?;
+                    }
+                }
+                Ok(if split {
+                    expansion
+                } else {
+                    Expansion {
+                        payload_bytes,
+                        ..Expansion::ONE
+                    }
+                })
+            }
+            Clause::Threshold(1, children) if split => {
+                let mut expansion = Expansion::EMPTY;
+                for child in children {
+                    expansion = expansion.or(self.clause(child, depth + 1, true)?)?;
+                }
+                Ok(expansion)
+            }
+            Clause::And(children) | Clause::Threshold(_, children) => {
+                let mut payload_bytes = 0usize;
+                for child in children {
+                    payload_bytes = payload_bytes
+                        .checked_add(self.clause(child, depth + 1, false)?.payload_bytes)
+                        .ok_or_else(|| limit("expanded script bytes", MAX_SCRIPT_BYTES))?;
+                }
+                Ok(Expansion {
+                    payload_bytes,
+                    ..Expansion::ONE
+                })
+            }
+            Clause::Inscribe(inscription, child) => {
+                let payload_bytes = inscription_payload_bytes(inscription)?;
+                self.payload(payload_bytes)?;
+                let payload_bytes = payload_bytes
+                    .checked_add(self.clause(child, depth + 1, false)?.payload_bytes)
+                    .ok_or_else(|| limit("expanded script bytes", MAX_SCRIPT_BYTES))?;
+                Ok(Expansion {
+                    payload_bytes,
+                    ..Expansion::ONE
+                })
+            }
+            _ => Ok(Expansion::ONE),
+        }
+    }
+}
+
+fn inscription_payload_bytes(inscription: &Inscription) -> Result<usize, CompilationError> {
+    // Inspect the owned payload without calling size_guess(), which encodes an
+    // entire envelope. Body and metadata legitimately span many 520-byte pushes.
+    [
+        &inscription.body,
+        &inscription.content_encoding,
+        &inscription.content_type,
+        &inscription.delegate,
+        &inscription.metadata,
+        &inscription.metaprotocol,
+        &inscription.parent,
+        &inscription.pointer,
+    ]
+    .into_iter()
+    .filter_map(|field| field.as_ref())
+    .try_fold(0usize, |bytes, field| {
+        bytes
+            .checked_add(field.len())
+            .ok_or_else(|| limit("source script bytes", MAX_SCRIPT_BYTES))
+    })
+}
+
+#[derive(Clone, Copy)]
+enum Operand<'a> {
+    Miniscript(&'a Clause),
+    Script(&'a Script),
+}
+
+fn expand_clause(clause: &Clause) -> Vec<Vec<Operand<'_>>> {
+    match clause {
+        Clause::Or(children) => children
+            .iter()
+            .flat_map(|(_, child)| expand_clause(child))
+            .collect(),
+        Clause::Threshold(1, children) => children.iter().flat_map(expand_clause).collect(),
+        clause => vec![vec![Operand::Miniscript(clause)]],
+    }
+}
+
+fn expand(policy: &ScriptPolicy) -> Vec<Vec<Operand<'_>>> {
+    match policy {
+        ScriptPolicy::Miniscript(clause) => expand_clause(clause),
+        ScriptPolicy::Script(fragment) => vec![vec![Operand::Script(fragment.as_script())]],
+        ScriptPolicy::Or(children) => children.iter().flat_map(expand).collect(),
+        ScriptPolicy::And(children) => {
+            let mut alternatives = vec![vec![]];
+            for child in children {
+                if alternatives.is_empty() {
+                    // Preflight already validated every unreachable child.
+                    break;
+                }
+                let next = expand(child);
+                if let [right] = next.as_slice() {
+                    // A long conjunction of single predicates must append in
+                    // place, not repeatedly copy its growing prefix.
+                    for left in &mut alternatives {
+                        left.extend_from_slice(right);
+                    }
+                    continue;
+                }
+                alternatives = alternatives
+                    .into_iter()
+                    .flat_map(|left| {
+                        next.iter().map(move |right| {
+                            let mut operands = Vec::with_capacity(left.len() + right.len());
+                            operands.extend_from_slice(&left);
+                            operands.extend_from_slice(right);
+                            operands
+                        })
+                    })
+                    .collect();
+            }
+            alternatives
+        }
+    }
+}
+
+fn encoded_size(
+    total: usize,
+    script_size: usize,
+    separator: bool,
+) -> Result<usize, CompilationError> {
+    total
+        .checked_add(script_size)
+        .and_then(|bytes| bytes.checked_add(usize::from(separator)))
+        .filter(|bytes| *bytes <= MAX_SCRIPT_BYTES)
+        .ok_or_else(|| limit("encoded script bytes", MAX_SCRIPT_BYTES))
+}
+
+fn compile_run(
+    clauses: &[&Clause],
+    encoded_bytes: usize,
+    separator: bool,
+) -> Result<Script, CompilationError> {
+    // Combining the complete run lets a key/CTV predicate protect an adjacent
+    // timelock or hashlock. Do not reorder predicates across an opaque script.
+    // The current public Miniscript compiler requires a safe run; an opaque
+    // neighbor cannot establish that proof. A custom backend can instead emit
+    // the complete predicate, including its timelock or hashlock, as raw script.
+    let clause = super::conjoin_guards(clauses.iter().copied());
+    let compiled = clause.compile::<Tap>()?;
+    // Check the encoded size before materializing the native script as well.
+    encoded_size(encoded_bytes, compiled.script_size(), separator)?;
+    Ok(compiled.encode())
+}
+
+fn append_script(
+    bytes: &mut Vec<u8>,
+    script: &Script,
+    has_predicate: &mut bool,
+    encoded_bytes: &mut usize,
+) -> Result<(), CompilationError> {
+    let next_size = encoded_size(*encoded_bytes, script.len(), *has_predicate)?;
+    if *has_predicate {
+        bytes.push(opcodes::all::OP_VERIFY.into_u8());
+    }
+    bytes.extend_from_slice(script.as_bytes());
+    *has_predicate = true;
+    *encoded_bytes = next_size;
+    Ok(())
+}
+
+fn compile_alternative(
+    operands: &[Operand<'_>],
+    encoded_bytes: &mut usize,
+) -> Result<Script, CompilationError> {
+    if operands.is_empty() {
+        // The IR's empty conjunction is explicitly true. It has no Miniscript
+        // clause whose standalone signature-safety rules need to be applied.
+        *encoded_bytes = encoded_size(*encoded_bytes, 1, false)?;
+        return Ok(Script::from(vec![opcodes::OP_TRUE.into_u8()]));
+    }
+    let mut bytes = vec![];
+    let mut has_predicate = false;
+    let mut clauses = vec![];
+    for operand in operands {
+        match operand {
+            Operand::Miniscript(clause) => clauses.push(*clause),
+            Operand::Script(script) => {
+                if !clauses.is_empty() {
+                    let script = compile_run(&clauses, *encoded_bytes, has_predicate)?;
+                    append_script(&mut bytes, &script, &mut has_predicate, encoded_bytes)?;
+                    clauses.clear();
+                }
+                // Borrow the source fragment directly. A raw script shared by
+                // many alternatives must not first be cloned into temporary runs.
+                append_script(&mut bytes, script, &mut has_predicate, encoded_bytes)?;
+            }
+        }
+    }
+    if !clauses.is_empty() {
+        let script = compile_run(&clauses, *encoded_bytes, has_predicate)?;
+        append_script(&mut bytes, &script, &mut has_predicate, encoded_bytes)?;
+    }
+    Ok(Script::from(bytes))
+}
+
+/// Compile disjunctive alternatives after validating the complete source and
+/// bounding its expansion. Each raw fragment must supply one complete Boolean
+/// predicate; the caller's backend owns its witness and authorization semantics.
+/// Every adjacent Miniscript run retains Miniscript's compilation checks.
+/// Source raw/inscription payloads, their expanded repetitions and the total
+/// encoded output are each limited to 16 MiB per invocation. This bounds
+/// lowering work; it is not a consensus limit or a witness-size guarantee.
+pub(crate) fn lower_script_policy(policy: &ScriptPolicy) -> Result<Vec<Script>, CompilationError> {
+    validate_source(policy)?;
+    let mut encoded_bytes = 0;
+    expand(policy)
+        .iter()
+        .map(|alternative| compile_alternative(alternative, &mut encoded_bytes))
+        .collect()
+}
+
+/// Validate and bound source policies before cloning, simplification or
+/// enumeration can erase malformed declarations or expand untrusted input.
+pub(crate) fn validate_source(policy: &ScriptPolicy) -> Result<(), CompilationError> {
+    Preflight::default().policy(policy, 0).map(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::blockdata::script::Builder;
+    use bitcoin::secp256k1::{Keypair, Secp256k1, SecretKey};
+    use sapio_base::miniscript::ord::envelope::Envelope;
+    use sapio_base::miniscript::policy::compiler::CompilerError;
+    use sapio_base::policy::ScriptFragment;
+
+    fn raw(value: i64) -> ScriptPolicy {
+        ScriptPolicy::Script(
+            ScriptFragment::new(
+                Builder::new()
+                    .push_int(value)
+                    .push_opcode(opcodes::all::OP_DROP)
+                    .push_int(1)
+                    .into_script(),
+            )
+            .unwrap(),
+        )
+    }
+
+    fn bytes(policy: &ScriptPolicy) -> Vec<u8> {
+        match policy {
+            ScriptPolicy::Script(fragment) => fragment.as_script().as_bytes().to_vec(),
+            _ => unreachable!(),
+        }
+    }
+
+    fn raw_bytes(size: usize) -> ScriptPolicy {
+        let mut bytes = vec![opcodes::all::OP_NOP.into_u8(); size];
+        if let Some(last) = bytes.last_mut() {
+            *last = opcodes::OP_TRUE.into_u8();
+        }
+        ScriptPolicy::Script(ScriptFragment::new(Script::from(bytes)).unwrap())
+    }
+
+    #[test]
+    fn raw_byte_repetition_is_rejected_before_cartesian_materialization() {
+        let fragment = raw_bytes(MAX_SCRIPT_BYTES / MAX_ALTERNATIVES + 1);
+        let choice = ScriptPolicy::Or(vec![ScriptPolicy::And(vec![]); 2]);
+        for raw_first in [false, true] {
+            let mut children = vec![choice.clone(); 10];
+            if raw_first {
+                children.insert(0, fragment.clone());
+            } else {
+                children.push(fragment.clone());
+            }
+            let policy = ScriptPolicy::And(children);
+            // The source owns only about 16 KiB of script data, but expansion
+            // would repeat it in 1,024 alternatives and exceed the byte budget.
+            assert!(matches!(
+                validate_source(&policy),
+                Err(CompilationError::PolicyLimit {
+                    resource: "expanded script bytes",
+                    limit: MAX_SCRIPT_BYTES,
+                })
+            ));
+            assert!(matches!(
+                lower_script_policy(&policy),
+                Err(CompilationError::PolicyLimit {
+                    resource: "expanded script bytes",
+                    limit: MAX_SCRIPT_BYTES,
+                })
+            ));
+        }
+    }
+
+    #[test]
+    fn cumulative_encoding_includes_generated_verification_opcodes() {
+        let policy = ScriptPolicy::And(vec![
+            raw_bytes(MAX_SCRIPT_BYTES / MAX_ALTERNATIVES),
+            ScriptPolicy::Or(vec![ScriptPolicy::And(vec![]); MAX_ALTERNATIVES]),
+            raw_bytes(0),
+        ]);
+        // The repeated raw payload fits exactly. Each branch also inserts a
+        // VERIFY between its two fragments, so the complete output does not.
+        validate_source(&policy).unwrap();
+        assert!(matches!(
+            lower_script_policy(&policy),
+            Err(CompilationError::PolicyLimit {
+                resource: "encoded script bytes",
+                limit: MAX_SCRIPT_BYTES,
+            })
+        ));
+    }
+
+    #[test]
+    fn source_payloads_are_bounded_even_in_unreachable_branches() {
+        let policy = ScriptPolicy::And(vec![
+            ScriptPolicy::Or(vec![]),
+            raw_bytes(MAX_SCRIPT_BYTES + 1),
+        ]);
+        assert!(matches!(
+            validate_source(&policy),
+            Err(CompilationError::PolicyLimit {
+                resource: "source script bytes",
+                limit: MAX_SCRIPT_BYTES,
+            })
+        ));
+    }
+
+    #[test]
+    fn byte_budget_allows_large_raw_leaves_and_chunked_inscription_bodies() {
+        let raw = lower_script_policy(&raw_bytes(65_537)).unwrap();
+        assert_eq!(raw[0].len(), 65_537);
+
+        let key =
+            Keypair::from_secret_key(&Secp256k1::new(), &SecretKey::from_slice(&[3; 32]).unwrap())
+                .x_only_public_key()
+                .0;
+        let inscription = Inscription::new(Some(b"text/plain".to_vec()), Some(vec![42; 1_025]));
+        let policy = ScriptPolicy::Miniscript(Clause::Inscribe(
+            Box::new(inscription.clone()),
+            Box::new(Clause::Key(key)),
+        ));
+        let scripts = lower_script_policy(&policy).unwrap();
+        let envelopes = Envelope::from_tapscript(&scripts[0], 0).unwrap();
+        assert_eq!(envelopes.len(), 1);
+        let parsed: Envelope<Inscription> = envelopes.into_iter().next().unwrap().into();
+        assert_eq!(parsed.payload, inscription);
+    }
+
+    #[test]
+    fn nested_alternatives_expand_in_declared_operand_order() {
+        let left: Vec<_> = (0..5).map(raw).collect();
+        let right: Vec<_> = (10..14).map(raw).collect();
+        let policy = ScriptPolicy::And(vec![
+            ScriptPolicy::Or(left.clone()),
+            ScriptPolicy::Or(vec![
+                ScriptPolicy::Or(right[..2].to_vec()),
+                ScriptPolicy::Or(right[2..].to_vec()),
+            ]),
+        ]);
+        let scripts = lower_script_policy(&policy).unwrap();
+        assert_eq!(scripts.len(), 20);
+        for (index, script) in scripts.iter().enumerate() {
+            let mut expected = bytes(&left[index / 4]);
+            expected.push(opcodes::all::OP_VERIFY.into_u8());
+            expected.extend_from_slice(&bytes(&right[index % 4]));
+            assert_eq!(script.as_bytes(), expected);
+        }
+    }
+
+    #[test]
+    fn empty_connectives_have_boolean_identity_semantics() {
+        assert!(lower_script_policy(&ScriptPolicy::Or(vec![]))
+            .unwrap()
+            .is_empty());
+        assert_eq!(
+            lower_script_policy(&ScriptPolicy::And(vec![])).unwrap(),
+            vec![Builder::new().push_int(1).into_script()]
+        );
+        assert!(
+            lower_script_policy(&ScriptPolicy::And(vec![ScriptPolicy::Or(vec![]), raw(1),]))
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn unreachable_miniscript_still_requires_structural_validation() {
+        let policy = ScriptPolicy::And(vec![
+            ScriptPolicy::Or(vec![]),
+            ScriptPolicy::Miniscript(Clause::Threshold(0, vec![])),
+        ]);
+        assert!(matches!(
+            lower_script_policy(&policy),
+            Err(CompilationError::Miniscript(_))
+        ));
+    }
+
+    #[test]
+    fn pure_miniscript_runs_preserve_combined_safety_and_optimization() {
+        let key =
+            Keypair::from_secret_key(&Secp256k1::new(), &SecretKey::from_slice(&[3; 32]).unwrap())
+                .x_only_public_key()
+                .0;
+        let key = Clause::Key(key);
+        let time = Clause::Older(16);
+        let policy = ScriptPolicy::And(vec![
+            ScriptPolicy::Miniscript(key.clone()),
+            ScriptPolicy::Miniscript(time.clone()),
+        ]);
+        assert_eq!(
+            lower_script_policy(&policy).unwrap(),
+            vec![Clause::And(vec![key, time])
+                .compile::<Tap>()
+                .unwrap()
+                .encode()]
+        );
+    }
+
+    #[test]
+    fn opaque_neighbors_do_not_silently_bypass_miniscript_safety_checks() {
+        let key =
+            Keypair::from_secret_key(&Secp256k1::new(), &SecretKey::from_slice(&[3; 32]).unwrap())
+                .x_only_public_key()
+                .0;
+        let raw_key = ScriptPolicy::Script(
+            ScriptFragment::new(
+                Builder::new()
+                    .push_slice(&key.serialize())
+                    .push_opcode(opcodes::all::OP_CHECKSIG)
+                    .into_script(),
+            )
+            .unwrap(),
+        );
+        let time = ScriptPolicy::Miniscript(Clause::Older(16));
+        for children in [vec![raw_key.clone(), time.clone()], vec![time, raw_key]] {
+            assert!(matches!(
+                lower_script_policy(&ScriptPolicy::And(children)),
+                Err(CompilationError::Miniscript(CompilerError::TopLevelNonSafe))
+            ));
+        }
+    }
+
+    #[test]
+    fn cartesian_expansion_is_bounded_before_materialization() {
+        let choice = ScriptPolicy::Or(vec![raw(1), raw(2)]);
+        let at_limit = ScriptPolicy::And(vec![choice.clone(); 10]);
+        assert_eq!(lower_script_policy(&at_limit).unwrap().len(), 1_024);
+        let too_many = ScriptPolicy::And(vec![choice; 11]);
+        assert!(matches!(
+            lower_script_policy(&too_many),
+            Err(CompilationError::PolicyLimit {
+                resource: "Taproot alternatives",
+                limit: 1_024
+            })
+        ));
+        let mut large_product = vec![ScriptPolicy::Or(vec![raw(1); 1_024])];
+        large_product.extend(vec![raw(2); 64]);
+        assert!(matches!(
+            lower_script_policy(&ScriptPolicy::And(large_product)),
+            Err(CompilationError::PolicyLimit {
+                resource: "expanded policy operands",
+                limit: 65_536
+            })
+        ));
+    }
+
+    #[test]
+    fn source_depth_and_nodes_are_checked_before_recursive_compilation() {
+        let mut deep = raw(1);
+        for _ in 0..=MAX_DEPTH {
+            deep = ScriptPolicy::And(vec![deep]);
+        }
+        assert!(matches!(
+            lower_script_policy(&deep),
+            Err(CompilationError::PolicyLimit {
+                resource: "policy depth",
+                limit: 128
+            })
+        ));
+        assert!(matches!(
+            lower_script_policy(&ScriptPolicy::And(vec![raw(1); MAX_NODES])),
+            Err(CompilationError::PolicyLimit {
+                resource: "policy nodes",
+                limit: 65_536
+            })
+        ));
+    }
+}

--- a/sapio/src/contract/compiler/util.rs
+++ b/sapio/src/contract/compiler/util.rs
@@ -13,9 +13,19 @@ use miniscript::descriptor::TapTree;
 use miniscript::*;
 use sapio_base::miniscript;
 use std::cmp::Reverse;
-use std::collections::BinaryHeap;
+use std::collections::{BTreeMap, BinaryHeap};
 use std::sync::Arc;
-/// picks a key from an iter of miniscripts, or returns a static default key
+
+/// A reproducible internal point with no known discrete logarithm. Retain its
+/// original derivation so script-only outputs do not change unnecessarily.
+fn unspendable_internal_key() -> XOnlyPublicKey {
+    XOnlyPublicKey::from_slice(&Sha256::hash(&[1u8; 32]).into_inner())
+        .expect("fixed hash is a valid x-only point")
+}
+
+/// Promote only an independently sufficient, bare key predicate. Choosing the
+/// smallest eligible key makes the output independent of alternative order.
+/// Constrained keys must remain behind their scripts, including inscriptions.
 pub fn pick_key_from_miniscripts<'a, I: Iterator<Item = &'a Miniscript<XOnlyPublicKey, Tap>>>(
     branches: I,
 ) -> XOnlyPublicKey {
@@ -28,19 +38,34 @@ pub fn pick_key_from_miniscripts<'a, I: Iterator<Item = &'a Miniscript<XOnlyPubl
             }
             None
         })
-        .next()
-        .unwrap_or(
-            XOnlyPublicKey::from_slice(&Sha256::hash(&[1u8; 32]).into_inner()).expect("constant"),
-        )
+        .min()
+        .unwrap_or_else(unspendable_internal_key)
 }
 
-/// Convert the branches into a heap for taproot tree consumption
+/// Build a deterministic tree of distinct script alternatives. Deduplication is
+/// by complete script bytes: repeated envelopes within one script survive, and
+/// different envelope contents or ordering remain different alternatives.
 pub fn branches_to_tree(
     branches: Vec<Miniscript<XOnlyPublicKey, Tap>>,
 ) -> Option<TapTree<XOnlyPublicKey>> {
-    let mut scripts: BinaryHeap<(Reverse<u64>, TapTree<XOnlyPublicKey>)> = branches
+    let mut distinct_scripts = BTreeMap::new();
+    for branch in branches {
+        match distinct_scripts.entry(branch.encode()) {
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                entry.insert(branch);
+            }
+            std::collections::btree_map::Entry::Occupied(mut entry) => {
+                // Different ASTs can encode the same script. Keep a stable
+                // representative because AST ordering also breaks heap ties.
+                if branch < *entry.get() {
+                    entry.insert(branch);
+                }
+            }
+        }
+    }
+    let mut scripts: BinaryHeap<(Reverse<u64>, TapTree<XOnlyPublicKey>)> = distinct_scripts
         .into_iter()
-        .map(|b| (Reverse(1), TapTree::Leaf(Arc::new(b))))
+        .map(|(_, branch)| (Reverse(1), TapTree::Leaf(Arc::new(branch))))
         .collect();
     while scripts.len() > 1 {
         let (w1, v1) = scripts.pop().unwrap();
@@ -51,4 +76,31 @@ pub fn branches_to_tree(
         ));
     }
     scripts.pop().map(|v| v.1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use miniscript::ord::Inscription;
+    use std::str::FromStr;
+
+    #[test]
+    fn byte_identical_inscription_asts_have_one_stable_leaf() {
+        let key = unspendable_internal_key();
+        let envelope = Inscription::new(None, Some(b"same script".to_vec()));
+        let outside = Miniscript::<XOnlyPublicKey, Tap>::from_str(&format!(
+            "inscribe_pre({envelope},pk({key}))"
+        ))
+        .unwrap();
+        let inside = Miniscript::<XOnlyPublicKey, Tap>::from_str(&format!(
+            "c:inscribe_pre({envelope},pk_k({key}))"
+        ))
+        .unwrap();
+        assert_ne!(outside, inside);
+        assert_eq!(outside.encode(), inside.encode());
+        let forward = branches_to_tree(vec![outside.clone(), inside.clone()]).unwrap();
+        let reversed = branches_to_tree(vec![inside, outside]).unwrap();
+        assert_eq!(forward, reversed);
+        assert_eq!(forward.iter().count(), 1);
+    }
 }

--- a/sapio/src/contract/compiler/validation.rs
+++ b/sapio/src/contract/compiler/validation.rs
@@ -1,0 +1,47 @@
+// Copyright Judica, Inc 2021
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Validate source policies before conjunction simplification or leaf splitting.
+
+use crate::contract::CompilationError;
+use sapio_base::miniscript::policy::{compiler::CompilerError, concrete::PolicyError};
+use sapio_base::Clause;
+
+/// Check every source node, including nodes that optimization would discard.
+/// Duplicate-key and combined timelock checks belong to each eventual script:
+/// separate alternatives may legitimately repeat a key.
+pub(crate) fn validate_policy(policy: &Clause) -> Result<(), CompilationError> {
+    fn validate(policy: &Clause) -> Result<(), PolicyError> {
+        match policy {
+            Clause::And(children) => {
+                if children.len() != 2 {
+                    return Err(PolicyError::NonBinaryArgAnd);
+                }
+                children.iter().try_for_each(validate)
+            }
+            Clause::Or(children) => {
+                if children.len() != 2 {
+                    return Err(PolicyError::NonBinaryArgOr);
+                }
+                children.iter().try_for_each(|(_, child)| validate(child))
+            }
+            Clause::Threshold(required, children) => {
+                if *required == 0 || *required > children.len() {
+                    return Err(PolicyError::IncorrectThresh);
+                }
+                children.iter().try_for_each(validate)
+            }
+            Clause::Inscribe(inscription, child) => {
+                inscription
+                    .validate()
+                    .map_err(|_| PolicyError::InvalidInscription)?;
+                validate(child)
+            }
+            leaf => leaf.is_valid(),
+        }
+    }
+    validate(policy).map_err(|error| CompilerError::PolicyError(error).into())
+}

--- a/sapio/src/contract/error.rs
+++ b/sapio/src/contract/error.rs
@@ -53,6 +53,19 @@ pub enum CompilationError {
     },
     /// Error if a Policy is empty
     EmptyPolicy,
+    /// A custom policy compiler or script boundary rejected its input.
+    Policy(sapio_base::policy::PolicyError),
+    /// Policy expansion exceeded a documented compilation limit.
+    PolicyLimit {
+        /// The bounded resource.
+        resource: &'static str,
+        /// Maximum permitted count.
+        limit: usize,
+    },
+    /// A raw policy has no proven satisfaction weight for a fee guarantee.
+    UnknownSatisfactionWeight,
+    /// Invalid raw Taproot spending data.
+    RawTaproot(crate::contract::object::RawTaprootError),
     /// No authorization satisfies this action's fixed transaction fields.
     ImpossibleTemplate {
         /// Commitment of the incompatible transaction.
@@ -134,6 +147,18 @@ pub enum CompilationError {
 impl From<SIMPError> for CompilationError {
     fn from(e: SIMPError) -> CompilationError {
         CompilationError::SIMPError(e)
+    }
+}
+
+impl From<sapio_base::policy::PolicyError> for CompilationError {
+    fn from(error: sapio_base::policy::PolicyError) -> Self {
+        Self::Policy(error)
+    }
+}
+
+impl From<crate::contract::object::RawTaprootError> for CompilationError {
+    fn from(error: crate::contract::object::RawTaprootError) -> Self {
+        Self::RawTaproot(error)
     }
 }
 impl From<ValidFragmentError> for CompilationError {

--- a/sapio/src/contract/error.rs
+++ b/sapio/src/contract/error.rs
@@ -53,6 +53,13 @@ pub enum CompilationError {
     },
     /// Error if a Policy is empty
     EmptyPolicy,
+    /// No authorization satisfies this action's fixed transaction fields.
+    ImpossibleTemplate {
+        /// Commitment of the incompatible transaction.
+        hash: bitcoin::hashes::sha256::Hash,
+        /// Action/effect path that returned the transaction.
+        at: EffectPath,
+    },
     /// Error if a contract does not have sufficient funds available
     OutOfFunds,
     /// Error if a CheckSequenceVerify clause is incompatible with the sequence already set.

--- a/sapio/src/contract/macros.rs
+++ b/sapio/src/contract/macros.rs
@@ -200,8 +200,36 @@ macro_rules! decl_continuation {
 /// Use `decl_guard! { cached name }` for a context-free cached clause.
 /// Implement these with `#[guard] fn name(self, ctx: Context)` and
 /// `#[guard(cached)] fn name(self)` respectively.
+/// Custom backends use `decl_guard! { policy name<Backend> }` or
+/// `decl_guard! { cached policy name<Backend> }` and `#[guard(policy)]`.
 #[macro_export]
 macro_rules! decl_guard {
+    {
+        $(#[$meta:meta])*
+        cached policy $name:ident<$policy:ty>
+    } => {
+        $crate::contract::macros::paste! {
+            $(#[$meta])*
+            fn [<guard_ $name>](&self) -> $policy { unimplemented!(); }
+            $(#[$meta])*
+            fn $name() -> ::std::option::Option<$crate::contract::actions::Guard<Self>> {
+                ::std::option::Option::None
+            }
+        }
+    };
+    {
+        $(#[$meta:meta])*
+        policy $name:ident<$policy:ty>
+    } => {
+        $crate::contract::macros::paste! {
+            $(#[$meta])*
+            fn [<guard_ $name>](&self, _ctx: $crate::contract::Context) -> $policy { unimplemented!(); }
+            $(#[$meta])*
+            fn $name() -> ::std::option::Option<$crate::contract::actions::Guard<Self>> {
+                ::std::option::Option::None
+            }
+        }
+    };
     {
         $(#[$meta:meta])*
         cached $name:ident

--- a/sapio/src/lib.rs
+++ b/sapio/src/lib.rs
@@ -14,6 +14,8 @@ pub mod template;
 pub mod util;
 pub use contract::Context;
 pub use sapio_base;
+/// Policy compiler interfaces and checked script fragments.
+pub use sapio_base::policy;
 pub use sapio_macros;
 pub use sapio_macros::*;
 pub use schemars;

--- a/sapio/src/template/builder.rs
+++ b/sapio/src/template/builder.rs
@@ -14,12 +14,12 @@ use bitcoin::util::amount::Amount;
 use bitcoin::Witness;
 use bitcoin::{Script, VarInt};
 use sapio_base::effects::PathFragment;
+use sapio_base::policy::ScriptPolicy;
 use sapio_base::simp::SIMPAttachableAt;
 use sapio_base::simp::TemplateInputLT;
 use sapio_base::simp::TemplateLT;
 use sapio_base::timelocks::*;
 use sapio_base::CTVHash;
-use sapio_base::Clause;
 use std::convert::TryFrom;
 use std::marker::PhantomData;
 
@@ -30,7 +30,7 @@ pub struct AddingFees;
 /// Builder can be used to interactively put together a transaction template before
 /// finalizing into a Template.
 pub struct BuilderState<State> {
-    guards: Vec<Clause>,
+    guards: Vec<ScriptPolicy>,
     // TODO: Should be Comitted/Uncomitted if not CTV
     sequences: Vec<Option<AnyRelTimeLock>>,
     outputs: Vec<Output>,
@@ -237,9 +237,18 @@ impl BuilderState<NotAddingFees> {
     /// which ends up being computed as:
     /// And(And(Top Guard, And(add_guard(1),..., add_guard(n))), CTV)
     /// n.b. not to be used with a continuation!
-    pub fn add_guard(mut self, guard: Clause) -> Self {
-        self.guards.push(guard);
+    pub fn add_guard(mut self, guard: impl Into<ScriptPolicy>) -> Self {
+        self.guards.push(guard.into());
         self
+    }
+
+    /// Compile another policy language as an additional template precondition.
+    /// Backend errors propagate before the template can be returned.
+    pub fn add_policy(
+        self,
+        policy: &impl sapio_base::policy::PolicyCompiler,
+    ) -> Result<Self, CompilationError> {
+        Ok(self.add_guard(policy.compile_policy()?))
     }
 }
 

--- a/sapio/src/template/mod.rs
+++ b/sapio/src/template/mod.rs
@@ -8,11 +8,11 @@
 use crate::contract::error::CompilationError;
 use bitcoin::hashes::sha256;
 use bitcoin::util::amount::Amount;
+use sapio_base::policy::ScriptPolicy;
 use sapio_base::simp::SIMPAttachableAt;
 use sapio_base::simp::SIMPError;
 use sapio_base::simp::TemplateInputLT;
 use sapio_base::simp::TemplateLT;
-use sapio_base::Clause;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -117,7 +117,7 @@ pub struct Template {
     /// compilation, these include the action guards; duplicate transactions
     /// retain their complete alternative authorizations here.
     #[serde(rename = "additional_preconditions")]
-    pub guards: Vec<Clause>,
+    pub guards: Vec<ScriptPolicy>,
     /// the precomputed template hash for this Template
     #[serde(rename = "precomputed_template_hash")]
     pub ctv: sha256::Hash,

--- a/sapio/tests/contract_policy_limits.rs
+++ b/sapio/tests/contract_policy_limits.rs
@@ -1,0 +1,82 @@
+use bitcoin::blockdata::opcodes::all::OP_DROP;
+use bitcoin::blockdata::script::Builder;
+use bitcoin::{Amount, Network};
+use sapio::contract::actions::Guard;
+use sapio::contract::object::SupportedDescriptors;
+use sapio::contract::{Compilable, CompilationError, Context, Contract};
+use sapio::{declare, guard};
+use sapio_base::policy::{PolicyError, ScriptFragment};
+use sapio_ctv_emulator_trait::CTVAvailable;
+use std::cell::Cell;
+use std::sync::Arc;
+
+struct Alternatives<const COUNT: usize> {
+    calls: Cell<usize>,
+}
+
+impl<const COUNT: usize> Alternatives<COUNT> {
+    fn new() -> Self {
+        Self {
+            calls: Cell::new(0),
+        }
+    }
+
+    #[guard(policy)]
+    fn alternative(self, _ctx: Context) -> Result<ScriptFragment, PolicyError> {
+        let call = self.calls.get() + 1;
+        self.calls.set(call);
+        // Each independent backend invocation produces a distinct complete
+        // script. No signature generation is needed to exercise tree growth.
+        ScriptFragment::new(
+            Builder::new()
+                .push_int(call as i64)
+                .push_opcode(OP_DROP)
+                .push_int(1)
+                .into_script(),
+        )
+    }
+}
+
+impl<const COUNT: usize> Contract for Alternatives<COUNT> {
+    const FINISH_FNS: &'static [fn() -> Option<Guard<Self>>] =
+        &[Self::alternative as fn() -> Option<Guard<Self>>; COUNT];
+    declare! {non updatable}
+}
+
+fn context() -> Context {
+    Context::new(
+        Network::Regtest,
+        Amount::ZERO,
+        Arc::new(CTVAvailable),
+        "limits".try_into().unwrap(),
+        Arc::new(Default::default()),
+        None,
+    )
+}
+
+#[test]
+fn the_contract_accepts_1024_independently_compiled_alternatives() {
+    let contract = Alternatives::<1024>::new();
+    let compiled = contract.compile(context()).unwrap();
+    let Some(SupportedDescriptors::Taproot(raw)) = &compiled.descriptor else {
+        panic!("raw backend branches must retain their spending data");
+    };
+    assert_eq!(raw.leaves().len(), 1024);
+    assert_eq!(contract.calls.get(), 1024);
+    compiled.validate().unwrap();
+}
+
+#[test]
+fn the_contract_stops_evaluating_guards_when_the_branch_budget_is_exhausted() {
+    let contract = Alternatives::<2048>::new();
+    assert!(matches!(
+        contract.compile(context()),
+        Err(CompilationError::PolicyLimit {
+            resource: "contract branches",
+            limit: 1024,
+        })
+    ));
+    // Reject the first excess emission instead of compiling every remaining
+    // declared guard and checking the aggregate only at the end.
+    assert_eq!(contract.calls.get(), 1025);
+}

--- a/sapio/tests/custom_policy.rs
+++ b/sapio/tests/custom_policy.rs
@@ -1,0 +1,264 @@
+#[path = "fixtures/custom_policy.rs"]
+mod fixture;
+
+use bitcoin::consensus::deserialize;
+use bitcoin::psbt::PartiallySignedTransaction as Psbt;
+use bitcoin::{Amount, OutPoint};
+use fixture::*;
+use sapio::contract::abi::studio::SapioStudioFormat;
+use sapio::contract::{Compilable, CompilationError, Compiled, Context, Contract};
+use sapio::{declare, guard};
+use sapio_base::miniscript::{Miniscript, Tap};
+use sapio_base::policy::{PolicyCompiler, PolicyError, ScriptPolicy};
+use sapio_base::simp::{GuardLT, SIMPAttachableAt};
+use sapio_base::txindex::{TxIndex, TxIndexLogger};
+use sapio_base::util::CTVHash;
+use sapio_base::Clause;
+use sapio_ctv_emulator_trait::CTVAvailable;
+use std::cell::{Cell, RefCell};
+use std::collections::{BTreeMap, BTreeSet};
+use std::rc::Rc;
+use std::sync::Arc;
+
+#[test]
+fn an_external_backend_compiles_beyond_miniscript_and_round_trips() {
+    let compiled = compiled(false, false);
+    let raw = tree(&compiled);
+    assert_eq!(raw.leaves().len(), 1);
+    let script = &raw.leaves()[0].1;
+    assert!(Miniscript::<bitcoin::XOnlyPublicKey, Tap>::parse(script).is_err());
+    assert_eq!(script_signers(script), vec![key(1)]);
+    let decoded: Compiled =
+        serde_json::from_slice(&serde_json::to_vec(&compiled).unwrap()).unwrap();
+    decoded.validate().unwrap();
+    assert_eq!(decoded, compiled);
+    assert_ne!(raw.internal_key(), key(1));
+    let spend = signed_spend(
+        &compiled,
+        unsigned_spend(&compiled, OutPoint::default()),
+        None,
+        false,
+    );
+    assert_eq!(spend.input[0].witness.len(), 3);
+    let control = raw
+        .spend_info()
+        .control_block(&(
+            script.clone(),
+            bitcoin::util::taproot::LeafVersion::TapScript,
+        ))
+        .unwrap();
+    assert!(control.verify_taproot_commitment(
+        &bitcoin::secp256k1::Secp256k1::new(),
+        raw.spend_info().output_key().to_inner(),
+        script
+    ));
+}
+
+#[test]
+fn native_guards_custom_template_guards_and_covenants_survive_composition() {
+    for emulated in [false, true] {
+        let compiled = compiled(true, emulated);
+        let raw = tree(&compiled);
+        assert_eq!(raw.leaves().len(), 1);
+        let script = &raw.leaves()[0].1;
+        let expected: BTreeSet<_> = (1..=if emulated { 4 } else { 3 }).map(key).collect();
+        assert_eq!(
+            script_signers(script).into_iter().collect::<BTreeSet<_>>(),
+            expected
+        );
+        for owner in [1, 3] {
+            let ScriptPolicy::Script(fragment) =
+                ArithmeticSigner(key(owner)).compile_policy().unwrap()
+            else {
+                unreachable!()
+            };
+            assert!(script
+                .as_bytes()
+                .windows(fragment.as_script().len())
+                .any(|bytes| bytes == fragment.as_script().as_bytes()));
+        }
+        let template = compiled.ctv_to_tx.values().next().unwrap();
+        assert_eq!(template.tx.output[0].value, 9_000);
+        assert_eq!(template.required_input_amount, Amount::from_sat(10_000));
+        if !emulated {
+            let covenant = Clause::TxTemplate(template.tx.get_ctv_hash(0))
+                .compile::<Tap>()
+                .unwrap()
+                .encode();
+            assert!(script
+                .as_bytes()
+                .windows(covenant.len())
+                .any(|bytes| bytes == covenant.as_bytes()));
+        }
+    }
+}
+
+#[test]
+fn bound_raw_artifacts_provide_complete_psbt_spending_data() {
+    let compiled = compiled(true, false);
+    let tx = Arc::new(funding(&compiled));
+    let index = Rc::new(TxIndexLogger::new());
+    let txid = index.add_tx(tx.clone()).unwrap();
+    let program = compiled
+        .bind_psbt(
+            OutPoint::new(txid, 0),
+            BTreeMap::new(),
+            index,
+            &CTVAvailable,
+        )
+        .unwrap();
+    let root = &program.program[&compiled.root_path];
+    let SapioStudioFormat::LinkedPSBT { psbt, .. } = &root.txs[0];
+    let psbt: Psbt = deserialize(&base64::decode(psbt).unwrap()).unwrap();
+    assert_eq!(
+        psbt.unsigned_tx.input[0].previous_output,
+        OutPoint::new(txid, 0)
+    );
+    assert_eq!(psbt.inputs[0].witness_utxo.as_ref(), Some(&tx.output[0]));
+    assert_eq!(psbt.inputs[0].non_witness_utxo.as_ref(), Some(tx.as_ref()));
+    let raw = tree(&compiled);
+    assert_eq!(psbt.inputs[0].tap_internal_key, Some(raw.internal_key()));
+    assert_eq!(
+        psbt.inputs[0].tap_merkle_root,
+        raw.spend_info().merkle_root()
+    );
+    assert_eq!(psbt.inputs[0].tap_scripts.len(), raw.leaves().len());
+    for (control, (script, _)) in &psbt.inputs[0].tap_scripts {
+        assert!(control.verify_taproot_commitment(
+            &bitcoin::secp256k1::Secp256k1::new(),
+            raw.spend_info().output_key().to_inner(),
+            script
+        ));
+    }
+}
+
+struct Nested;
+
+impl Nested {
+    #[guard(policy)]
+    fn alternatives(self, _ctx: Context) -> ScriptPolicy {
+        let raw = |owner| ArithmeticSigner(key(owner)).compile_policy().unwrap();
+        ScriptPolicy::And(vec![
+            ScriptPolicy::Or(vec![raw(1), ScriptPolicy::Or(vec![raw(2)])]),
+            ScriptPolicy::Or(vec![raw(3), raw(4)]),
+        ])
+    }
+}
+
+impl Contract for Nested {
+    declare! {finish, Self::alternatives}
+    declare! {non updatable}
+}
+
+#[test]
+fn nested_custom_alternatives_keep_each_required_pair() {
+    let compiled = Nested.compile(context(false)).unwrap();
+    let required: BTreeSet<_> = tree(&compiled)
+        .leaves()
+        .iter()
+        .map(|(_, script)| script_signers(script))
+        .collect();
+    assert_eq!(
+        required,
+        BTreeSet::from([
+            vec![key(1), key(3)],
+            vec![key(1), key(4)],
+            vec![key(2), key(3)],
+            vec![key(2), key(4)]
+        ])
+    );
+}
+
+struct FallibleSigner(bool);
+
+impl PolicyCompiler for FallibleSigner {
+    fn compile_policy(&self) -> Result<ScriptPolicy, PolicyError> {
+        if self.0 {
+            Err(PolicyError::Backend("translation rejected".into()))
+        } else {
+            ArithmeticSigner(key(1)).compile_policy()
+        }
+    }
+}
+
+#[derive(Default)]
+struct Cached {
+    calls: Cell<usize>,
+    paths: RefCell<Vec<String>>,
+    backend_error: bool,
+    metadata_error: bool,
+}
+
+impl Cached {
+    #[guard(policy, cached, simps = "Some(Self::metadata)")]
+    fn owner(self) -> FallibleSigner {
+        self.calls.set(self.calls.get() + 1);
+        FallibleSigner(self.backend_error)
+    }
+
+    fn metadata(
+        &self,
+        ctx: Context,
+    ) -> Result<Vec<Arc<dyn SIMPAttachableAt<GuardLT>>>, CompilationError> {
+        let path = String::from(ctx.path().as_ref().clone());
+        self.paths.borrow_mut().push(path.clone());
+        if self.metadata_error && path.contains("/#1/") {
+            Err(CompilationError::TerminateWith(
+                "second metadata failed".into(),
+            ))
+        } else {
+            Ok(vec![])
+        }
+    }
+}
+
+impl Contract for Cached {
+    declare! {finish, Self::owner, Self::owner}
+    declare! {non updatable}
+}
+
+#[test]
+fn custom_backend_caching_keeps_contextual_metadata_and_propagates_errors() {
+    let contract = Cached::default();
+    let first = contract.compile(context(false)).unwrap();
+    assert_eq!(contract.calls.get(), 1);
+    assert_eq!(
+        *contract.paths.borrow(),
+        [
+            "custom/@finish_fn/#0/@metadata",
+            "custom/@finish_fn/#1/@metadata"
+        ]
+    );
+    assert_eq!(tree(&first).leaves().len(), 1);
+    assert_eq!(contract.compile(context(false)).unwrap(), first);
+    assert_eq!(contract.calls.get(), 2);
+    let backend_error = Cached {
+        backend_error: true,
+        ..Default::default()
+    };
+    assert!(
+        matches!(backend_error.compile(context(false)), Err(CompilationError::Policy(PolicyError::Backend(message))) if message == "translation rejected")
+    );
+    assert!(backend_error.paths.borrow().is_empty());
+    let metadata_error = Cached {
+        metadata_error: true,
+        ..Default::default()
+    };
+    assert!(
+        matches!(metadata_error.compile(context(false)), Err(CompilationError::TerminateWith(message)) if message == "second metadata failed")
+    );
+    assert_eq!(metadata_error.calls.get(), 1);
+}
+
+#[test]
+fn raw_policy_fee_claims_require_a_real_satisfaction_weight_bound() {
+    for emulated in [false, true] {
+        assert!(matches!(
+            Protected {
+                require_feerate: true
+            }
+            .compile(context(emulated)),
+            Err(CompilationError::UnknownSatisfactionWeight)
+        ));
+    }
+}

--- a/sapio/tests/fixtures/custom_policy.rs
+++ b/sapio/tests/fixtures/custom_policy.rs
@@ -1,0 +1,245 @@
+#![allow(dead_code)]
+
+use bitcoin::blockdata::opcodes::all;
+use bitcoin::blockdata::script::{Builder, Instruction};
+use bitcoin::hashes::sha256;
+use bitcoin::secp256k1::{Keypair, Message, Secp256k1, SecretKey};
+use bitcoin::util::psbt::PartiallySignedTransaction as Psbt;
+use bitcoin::util::sighash::{Prevouts, SighashCache};
+use bitcoin::util::taproot::{LeafVersion, TapLeafHash};
+use bitcoin::{Amount, Network, OutPoint, SchnorrSighashType, Transaction, TxIn, TxOut, Witness};
+use bitcoin::{Script, XOnlyPublicKey};
+use sapio::contract::abi::object::{RawTaproot, SupportedDescriptors};
+use sapio::contract::{Compilable, Compiled, Context, Contract};
+use sapio::{declare, guard, then};
+use sapio_base::policy::{PolicyCompiler, PolicyError, ScriptFragment, ScriptPolicy};
+use sapio_base::Clause;
+use sapio_ctv_emulator_trait::{CTVAvailable, CTVEmulator, EmulatorError};
+use std::sync::Arc;
+
+pub fn keypair(byte: u8) -> Keypair {
+    Keypair::from_secret_key(
+        &Secp256k1::new(),
+        &SecretKey::from_slice(&[byte; 32]).unwrap(),
+    )
+}
+
+pub fn key(byte: u8) -> XOnlyPublicKey {
+    keypair(byte).x_only_public_key().0
+}
+
+/// A small external policy language: CHECKSIG's Boolean becomes 1 or 2,
+/// and equality with 2 preserves exactly the original signature condition.
+pub struct ArithmeticSigner(pub XOnlyPublicKey);
+
+impl PolicyCompiler for ArithmeticSigner {
+    fn compile_policy(&self) -> Result<ScriptPolicy, PolicyError> {
+        ScriptFragment::new(
+            Builder::new()
+                .push_slice(&self.0.serialize())
+                .push_opcode(all::OP_CHECKSIG)
+                .push_opcode(all::OP_1ADD)
+                .push_int(2)
+                .push_opcode(all::OP_NUMEQUAL)
+                .into_script(),
+        )
+        .map(Into::into)
+    }
+}
+
+pub struct Emulated;
+
+impl CTVEmulator for Emulated {
+    fn get_signer_for(&self, _: sha256::Hash) -> Result<Clause, EmulatorError> {
+        Ok(Clause::Key(key(4)))
+    }
+
+    fn sign(&self, psbt: Psbt) -> Result<Psbt, EmulatorError> {
+        // Fixture signatures are added explicitly after binding. This mock
+        // represents the emulator's clause, not its transaction approval logic.
+        Ok(psbt)
+    }
+}
+
+pub fn context(emulated: bool) -> Context {
+    Context::new(
+        Network::Regtest,
+        Amount::from_sat(10_000),
+        if emulated {
+            Arc::new(Emulated)
+        } else {
+            Arc::new(CTVAvailable)
+        },
+        "custom".try_into().unwrap(),
+        Arc::new(Default::default()),
+        None,
+    )
+}
+
+pub struct Pure;
+
+impl Pure {
+    #[guard(policy)]
+    fn owner(self, _ctx: Context) -> ArithmeticSigner {
+        ArithmeticSigner(key(1))
+    }
+}
+
+impl Contract for Pure {
+    declare! {finish, Self::owner}
+    declare! {non updatable}
+}
+
+pub struct Protected {
+    pub require_feerate: bool,
+}
+
+impl Protected {
+    #[guard(policy)]
+    fn owner(self, _ctx: Context) -> ArithmeticSigner {
+        ArithmeticSigner(key(1))
+    }
+
+    #[guard]
+    fn action_signer(self, _ctx: Context) {
+        Clause::Key(key(2))
+    }
+
+    #[then(guarded_by = "[Self::owner, Self::action_signer]")]
+    fn pay(self, ctx: Context) {
+        let mut builder = ctx
+            .template()
+            .add_guard(ArithmeticSigner(key(3)).compile_policy()?)
+            .add_output(Amount::from_sat(9_000), &key(9), None)?
+            .add_fees(Amount::from_sat(1_000))?;
+        if self.require_feerate {
+            builder = builder.set_min_feerate(Amount::from_sat(1));
+        }
+        builder.into()
+    }
+}
+
+impl Contract for Protected {
+    declare! {then, Self::pay}
+    declare! {non updatable}
+}
+
+pub fn compiled(protected: bool, emulated: bool) -> Compiled {
+    let compiled = if protected {
+        Protected {
+            require_feerate: false,
+        }
+        .compile(context(emulated))
+    } else {
+        Pure.compile(context(emulated))
+    }
+    .unwrap();
+    compiled.validate().unwrap();
+    compiled
+}
+
+pub fn tree(compiled: &Compiled) -> &RawTaproot {
+    match compiled.descriptor.as_ref().unwrap() {
+        SupportedDescriptors::Taproot(tree) => tree,
+        _ => panic!("custom policy must retain raw Taproot spending data"),
+    }
+}
+
+pub fn funding(compiled: &Compiled) -> Transaction {
+    Transaction {
+        version: 2,
+        lock_time: 0,
+        input: vec![TxIn::default()],
+        output: vec![TxOut {
+            value: 10_000,
+            script_pubkey: tree(compiled).script_pubkey(),
+        }],
+    }
+}
+
+pub fn unsigned_spend(compiled: &Compiled, outpoint: OutPoint) -> Transaction {
+    let mut transaction = match compiled.ctv_to_tx.values().next() {
+        Some(template) => template.tx.clone(),
+        None => Transaction {
+            version: 2,
+            lock_time: 0,
+            input: vec![TxIn::default()],
+            output: vec![TxOut {
+                value: 9_000,
+                script_pubkey: Script::new_v1_p2tr(&Secp256k1::new(), key(9), None),
+            }],
+        },
+    };
+    transaction.input[0].previous_output = outpoint;
+    transaction
+}
+
+pub fn script_signers(script: &Script) -> Vec<XOnlyPublicKey> {
+    let instructions: Vec<_> = script.instructions().collect::<Result<_, _>>().unwrap();
+    instructions
+        .windows(2)
+        .filter_map(|pair| match pair {
+            [Instruction::PushBytes(bytes), Instruction::Op(opcode)]
+                if bytes.len() == 32
+                    && [
+                        all::OP_CHECKSIG,
+                        all::OP_CHECKSIGVERIFY,
+                        all::OP_CHECKSIGADD,
+                    ]
+                    .contains(opcode) =>
+            {
+                Some(XOnlyPublicKey::from_slice(bytes).unwrap())
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+/// Construct the backend's witness explicitly; the Miniscript finalizer does
+/// not support this arithmetic fragment. Bitcoin Core is the execution oracle.
+pub fn signed_spend(
+    compiled: &Compiled,
+    mut transaction: Transaction,
+    missing: Option<u8>,
+    wrong_owner: bool,
+) -> Transaction {
+    let tree = tree(compiled);
+    assert_eq!(tree.leaves().len(), 1);
+    let script = &tree.leaves()[0].1;
+    let prevouts = funding(compiled).output;
+    let leaf = TapLeafHash::from_script(script, LeafVersion::TapScript);
+    let hash = SighashCache::new(&transaction)
+        .taproot_script_spend_signature_hash(
+            0,
+            &Prevouts::All(&prevouts),
+            leaf,
+            SchnorrSighashType::Default,
+        )
+        .unwrap();
+    let message = Message::from_digest_slice(&hash[..]).unwrap();
+    let secp = Secp256k1::new();
+    let mut witness: Vec<Vec<u8>> = script_signers(script)
+        .into_iter()
+        .rev()
+        .map(|public_key| {
+            let owner = (1..=4).find(|owner| key(*owner) == public_key).unwrap();
+            if missing == Some(owner) {
+                vec![]
+            } else {
+                let signer = if wrong_owner && owner == 1 { 8 } else { owner };
+                secp.sign_schnorr_no_aux_rand(&message, &keypair(signer))
+                    .as_ref()
+                    .to_vec()
+            }
+        })
+        .collect();
+    witness.push(script.as_bytes().to_vec());
+    witness.push(
+        tree.spend_info()
+            .control_block(&(script.clone(), LeafVersion::TapScript))
+            .unwrap()
+            .serialize(),
+    );
+    transaction.input[0].witness = Witness::from_vec(witness);
+    transaction
+}

--- a/sapio/tests/guard_semantics.rs
+++ b/sapio/tests/guard_semantics.rs
@@ -213,7 +213,13 @@ fn policies_and_metadata_use_their_declared_lifetimes_and_contexts() {
         ];
         assert_eq!(*recorded.borrow(), paths);
         assert_eq!(
-            compiled.metadata.simps_for_guards[&Clause::Key(key)][&PROTOCOL],
+            compiled
+                .metadata
+                .simps_for_guards
+                .iter()
+                .find(|record| record.policy == Clause::Key(key).into())
+                .unwrap()
+                .protocols[&PROTOCOL],
             paths
                 .into_iter()
                 .map(|path| json!({"path": path}))
@@ -236,7 +242,13 @@ fn equal_json_annotations_deduplicate_without_losing_distinct_values() {
     let compiled = contract.compile(context()).unwrap();
     for key in [contract.cached_key, contract.fresh_key] {
         assert_eq!(
-            compiled.metadata.simps_for_guards[&Clause::Key(key)][&PROTOCOL],
+            compiled
+                .metadata
+                .simps_for_guards
+                .iter()
+                .find(|record| record.policy == Clause::Key(key).into())
+                .unwrap()
+                .protocols[&PROTOCOL],
             vec![json!("first"), json!("second")]
         );
     }

--- a/sapio/tests/inscription_guards.rs
+++ b/sapio/tests/inscription_guards.rs
@@ -150,10 +150,7 @@ fn conjunction_keeps_effect_order_and_nonadjacent_duplicates() {
     let template = compiled.ctv_to_tx.values().next().unwrap();
     assert_eq!(
         template.guards,
-        vec![Clause::Threshold(
-            3,
-            vec![effect(b"z"), effect(b"a"), effect(b"z")]
-        )]
+        vec![Clause::Threshold(3, vec![effect(b"z"), effect(b"a"), effect(b"z")]).into()]
     );
     let mut inscriptions = encoded_inscriptions(&compiled);
     // Miniscript chooses the final instruction order while compiling the

--- a/sapio/tests/macro_declarations.rs
+++ b/sapio/tests/macro_declarations.rs
@@ -27,6 +27,61 @@ fn key(byte: u8) -> XOnlyPublicKey {
     .0
 }
 
+trait BackendGuards: Contract {
+    sapio::decl_guard! { policy external<Result<Clause, &'static str>> }
+    sapio::decl_guard! { cached policy cached_external<Clause> }
+}
+
+struct BackendContract(bool);
+impl BackendGuards for BackendContract {
+    #[sapio::guard(policy)]
+    fn external(self, _ctx: Context) -> Result<Clause, &'static str> {
+        if self.0 {
+            Ok(Clause::Key(key(1)))
+        } else {
+            Err("external policy unavailable")
+        }
+    }
+
+    #[sapio::guard(policy, cached)]
+    fn cached_external(self) -> Clause {
+        Clause::Key(key(2))
+    }
+}
+impl Contract for BackendContract {
+    sapio::declare! {finish, Self::external, Self::cached_external}
+    sapio::declare! {non updatable}
+}
+
+#[test]
+fn custom_backend_trait_guards_preserve_fallibility_and_optional_declarations() {
+    assert!(matches!(
+        BackendContract::external(),
+        Some(Guard::FreshPolicy(..))
+    ));
+    assert!(matches!(
+        BackendContract::cached_external(),
+        Some(Guard::CachedPolicy(..))
+    ));
+    BackendContract(true)
+        .compile(context())
+        .unwrap()
+        .validate()
+        .unwrap();
+    let error = BackendContract(false).compile(context()).unwrap_err();
+    assert!(
+        matches!(error, CompilationError::Policy(sapio::policy::PolicyError::Backend(message)) if message == "external policy unavailable")
+    );
+
+    struct Optional;
+    impl BackendGuards for Optional {}
+    impl Contract for Optional {
+        sapio::declare! {non updatable}
+    }
+    assert!(Optional::external().is_none());
+    assert!(Optional::cached_external().is_none());
+}
+
 struct OfflineArgs(u64);
 
 trait Actions: Contract {

--- a/sapio/tests/policy_validation.rs
+++ b/sapio/tests/policy_validation.rs
@@ -1,0 +1,281 @@
+use bitcoin::secp256k1::{Secp256k1, SecretKey};
+use bitcoin::{Amount, Network, XOnlyPublicKey};
+use sapio::contract::actions::{CallableAsFoF, Guard};
+use sapio::contract::object::SupportedDescriptors;
+use sapio::contract::{Compilable, CompilationError, Compiled, Contract};
+use sapio::miniscript::ord::Inscription;
+use sapio::miniscript::policy::{
+    compiler::CompilerError, concrete::PolicyError, semantic::Policy, Liftable,
+};
+use sapio::miniscript::MiniscriptKey;
+use sapio::{continuation, declare, guard, then, Context};
+use sapio_base::Clause;
+use sapio_ctv_emulator_trait::CTVAvailable;
+use std::sync::Arc;
+
+fn key(index: u8) -> XOnlyPublicKey {
+    SecretKey::from_slice(&[index; 32])
+        .unwrap()
+        .keypair(&Secp256k1::new())
+        .x_only_public_key()
+        .0
+}
+
+fn context() -> Context {
+    Context::new(
+        Network::Regtest,
+        Amount::from_sat(1_000),
+        Arc::new(CTVAvailable),
+        "validation".try_into().unwrap(),
+        Arc::new(Default::default()),
+        None,
+    )
+}
+
+struct SinglePolicy<const CONTINUATION: bool>(Clause);
+
+impl<const CONTINUATION: bool> SinglePolicy<CONTINUATION> {
+    #[guard]
+    fn policy(self, _ctx: Context) {
+        self.0.clone()
+    }
+
+    #[continuation(guarded_by = "[Self::policy]", coerce_args = "Ok")]
+    fn update(self, _ctx: Context, _args: ()) {
+        sapio::contract::empty()
+    }
+}
+
+impl<const CONTINUATION: bool> Contract for SinglePolicy<CONTINUATION> {
+    const FINISH_FNS: &'static [fn() -> Option<Guard<Self>>] =
+        if CONTINUATION { &[] } else { &[Self::policy] };
+    const FINISH_OR_FUNCS: &'static [fn() -> Option<Box<dyn CallableAsFoF<Self, ()>>>] =
+        if CONTINUATION { &[Self::update] } else { &[] };
+    declare! {non updatable}
+}
+
+fn assert_policy_error(result: Result<Compiled, CompilationError>, expected: PolicyError) {
+    match result {
+        Err(CompilationError::Miniscript(CompilerError::PolicyError(actual))) => {
+            assert_eq!(actual, expected);
+        }
+        other => panic!("expected policy error {expected:?}, received {other:?}"),
+    }
+}
+
+fn assert_finish_and_continuation_error(policy: Clause, expected: PolicyError) {
+    assert_policy_error(
+        SinglePolicy::<false>(policy.clone()).compile(context()),
+        expected,
+    );
+    assert_policy_error(SinglePolicy::<true>(policy).compile(context()), expected);
+}
+
+#[test]
+fn malformed_policy_roots_fail_before_alternatives_are_flattened() {
+    let cases = [
+        (Clause::And(vec![]), PolicyError::NonBinaryArgAnd),
+        (
+            Clause::And(vec![Clause::Key(key(1))]),
+            PolicyError::NonBinaryArgAnd,
+        ),
+        (
+            Clause::And((1..=3).map(|i| Clause::Key(key(i))).collect()),
+            PolicyError::NonBinaryArgAnd,
+        ),
+        (Clause::Or(vec![]), PolicyError::NonBinaryArgOr),
+        (
+            Clause::Or(vec![(1, Clause::Key(key(1)))]),
+            PolicyError::NonBinaryArgOr,
+        ),
+        (
+            Clause::Or((1..=3).map(|i| (1, Clause::Key(key(i)))).collect()),
+            PolicyError::NonBinaryArgOr,
+        ),
+        (Clause::Threshold(0, vec![]), PolicyError::IncorrectThresh),
+        (Clause::Threshold(1, vec![]), PolicyError::IncorrectThresh),
+        (
+            Clause::Threshold(0, vec![Clause::Key(key(1))]),
+            PolicyError::IncorrectThresh,
+        ),
+        (
+            Clause::Threshold(2, vec![Clause::Key(key(1))]),
+            PolicyError::IncorrectThresh,
+        ),
+    ];
+    for (policy, expected) in cases {
+        assert_finish_and_continuation_error(policy, expected);
+    }
+}
+
+#[test]
+fn malformed_nested_nodes_cannot_disappear_during_simplification() {
+    let malformed = Clause::Or(vec![]);
+    let inscription = Inscription::new(Some(b"text/plain".to_vec()), Some(b"body".to_vec()));
+    for policy in [
+        Clause::And(vec![Clause::Trivial, malformed.clone()]),
+        Clause::And(vec![Clause::Unsatisfiable, malformed.clone()]),
+        Clause::And(vec![malformed.clone(), Clause::Unsatisfiable]),
+        Clause::Or(vec![(1, Clause::Trivial), (1, malformed.clone())]),
+        Clause::Or(vec![(1, Clause::Key(key(1))), (1, malformed.clone())]),
+        Clause::Threshold(1, vec![Clause::Key(key(1)), malformed.clone()]),
+        Clause::Threshold(2, vec![Clause::Unsatisfiable, malformed.clone()]),
+        Clause::Inscribe(Box::new(inscription), Box::new(malformed)),
+    ] {
+        assert_finish_and_continuation_error(policy, PolicyError::NonBinaryArgOr);
+    }
+}
+
+struct ConjoinedPolicies {
+    first: Clause,
+    second: Clause,
+}
+
+impl ConjoinedPolicies {
+    #[guard]
+    fn first(self, _ctx: Context) {
+        self.first.clone()
+    }
+
+    #[guard]
+    fn second(self, _ctx: Context) {
+        self.second.clone()
+    }
+
+    #[continuation(guarded_by = "[Self::first, Self::second]", coerce_args = "Ok")]
+    fn update(self, _ctx: Context, _args: ()) {
+        sapio::contract::empty()
+    }
+}
+
+impl Contract for ConjoinedPolicies {
+    declare! {updatable<()>, Self::update}
+}
+
+#[test]
+fn every_source_guard_is_validated_before_conjunction_shortcuts() {
+    for literal in [Clause::Trivial, Clause::Unsatisfiable] {
+        let malformed = Clause::Threshold(1, vec![]);
+        for (first, second) in [(literal.clone(), malformed.clone()), (malformed, literal)] {
+            assert_policy_error(
+                ConjoinedPolicies { first, second }.compile(context()),
+                PolicyError::IncorrectThresh,
+            );
+        }
+    }
+}
+
+#[test]
+fn invalid_terminals_are_rejected_even_in_dead_conjunctions() {
+    let invalid_inscription = Inscription::new(Some(vec![b'x'; 521]), Some(b"body".to_vec()));
+    let cases = [
+        (Clause::After(0), PolicyError::ZeroTime),
+        (Clause::Older(0), PolicyError::ZeroTime),
+        (Clause::After(u32::MAX), PolicyError::TimeTooFar),
+        (Clause::Older(u32::MAX), PolicyError::TimeTooFar),
+        (
+            Clause::Inscribe(Box::new(invalid_inscription), Box::new(Clause::Trivial)),
+            PolicyError::InvalidInscription,
+        ),
+    ];
+    for (terminal, expected) in cases {
+        assert_finish_and_continuation_error(terminal.clone(), expected);
+        assert_finish_and_continuation_error(
+            Clause::And(vec![Clause::Unsatisfiable, terminal.clone()]),
+            expected,
+        );
+        for (first, second) in [
+            (Clause::Unsatisfiable, terminal.clone()),
+            (terminal, Clause::Unsatisfiable),
+        ] {
+            assert_policy_error(
+                ConjoinedPolicies { first, second }.compile(context()),
+                expected,
+            );
+        }
+    }
+}
+
+struct TemplatePolicies(Vec<Clause>);
+
+impl TemplatePolicies {
+    #[then]
+    fn pay(self, ctx: Context) {
+        let mut builder = ctx.template();
+        for policy in &self.0 {
+            builder = builder.add_guard(policy.clone());
+        }
+        builder
+            .add_output(Amount::from_sat(1_000), &key(3), None)?
+            .into()
+    }
+}
+
+impl Contract for TemplatePolicies {
+    declare! {then, Self::pay}
+    declare! {non updatable}
+}
+
+#[test]
+fn template_guard_simplification_also_rejects_hidden_malformed_nodes() {
+    for literal in [Clause::Trivial, Clause::Unsatisfiable] {
+        let malformed = Clause::And(vec![]);
+        for guards in [
+            vec![literal.clone(), malformed.clone()],
+            vec![malformed, literal],
+        ] {
+            assert_policy_error(
+                TemplatePolicies(guards).compile(context()),
+                PolicyError::NonBinaryArgAnd,
+            );
+        }
+    }
+}
+
+fn accepts(policy: &Policy<XOnlyPublicKey>, signers: u8) -> bool {
+    match policy {
+        Policy::Unsatisfiable => false,
+        Policy::Trivial => true,
+        Policy::KeyHash(hash) => {
+            (1..=3).any(|i| signers & (1 << (i - 1)) != 0 && key(i).to_pubkeyhash() == *hash)
+        }
+        Policy::Threshold(required, children) => {
+            children.iter().filter(|p| accepts(p, signers)).count() >= *required
+        }
+        other => panic!("unexpected policy in signer fixture: {other:?}"),
+    }
+}
+
+fn assert_shared_key_authorization(compiled: Compiled) {
+    compiled.validate().unwrap();
+    let Some(SupportedDescriptors::XOnly(descriptor)) = compiled.descriptor else {
+        panic!("expected a Taproot descriptor");
+    };
+    let policy = descriptor.lift().unwrap();
+    for signers in 0..8 {
+        assert_eq!(
+            accepts(&policy, signers),
+            signers & 1 != 0 && signers & 6 != 0,
+            "signers={signers}"
+        );
+    }
+}
+
+#[test]
+fn separately_spendable_alternatives_can_share_a_signer() {
+    let alternatives = vec![
+        Clause::And(vec![Clause::Key(key(1)), Clause::Key(key(2))]),
+        Clause::And(vec![Clause::Key(key(1)), Clause::Key(key(3))]),
+    ];
+    for policy in [
+        Clause::Or(alternatives.iter().cloned().map(|p| (1, p)).collect()),
+        Clause::Threshold(1, alternatives),
+    ] {
+        assert_shared_key_authorization(
+            SinglePolicy::<false>(policy.clone())
+                .compile(context())
+                .unwrap(),
+        );
+        assert_shared_key_authorization(SinglePolicy::<true>(policy).compile(context()).unwrap());
+    }
+}

--- a/sapio/tests/raw_artifacts.rs
+++ b/sapio/tests/raw_artifacts.rs
@@ -1,0 +1,248 @@
+use bitcoin::blockdata::opcodes::all::{OP_DROP, OP_NOP4};
+use bitcoin::blockdata::script::Builder;
+use bitcoin::hashes::sha256;
+use bitcoin::psbt::PartiallySignedTransaction as Psbt;
+use bitcoin::secp256k1::{Keypair, Secp256k1, SecretKey};
+use bitcoin::util::taproot::LeafVersion;
+use bitcoin::{Address, Amount, Network, OutPoint, Script, Transaction, TxIn, TxOut, Txid};
+use sapio::contract::abi::object::{
+    ArtifactErrorKind, GuardMetadata, ObjectError, RawTaproot, SupportedDescriptors,
+};
+use sapio::contract::abi::studio::SapioStudioFormat;
+use sapio::contract::{Compiled, Context};
+use sapio::template::Template;
+use sapio_base::policy::{ScriptFragment, ScriptPolicy};
+use sapio_base::txindex::{TxIndex, TxIndexError};
+use sapio_base::{CTVHash, Clause};
+use sapio_ctv_emulator_trait::{CTVAvailable, CTVEmulator, EmulatorError};
+use std::cell::{Cell, RefCell};
+use std::collections::BTreeMap;
+use std::rc::Rc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+fn artifact(key_only: bool) -> Compiled {
+    let secp = Secp256k1::new();
+    let key = Keypair::from_secret_key(&secp, &SecretKey::from_slice(&[1; 32]).unwrap())
+        .x_only_public_key()
+        .0;
+    let destination =
+        Compiled::from_address(Address::p2tr(&secp, key, None, Network::Regtest), None);
+    let template: Template = Context::new(
+        Network::Regtest,
+        Amount::from_sat(1_000),
+        Arc::new(CTVAvailable),
+        "raw".try_into().unwrap(),
+        Arc::new(Default::default()),
+        None,
+    )
+    .template()
+    .add_output(Amount::from_sat(1_000), &destination, None)
+    .unwrap()
+    .into();
+    let script = Builder::new()
+        .push_slice(template.hash().as_ref())
+        .push_opcode(OP_NOP4);
+    let ctv = script.clone().into_script();
+    let alternate = script.push_opcode(OP_DROP).push_int(1).into_script();
+    let leaves = if key_only {
+        vec![]
+    } else {
+        // A repeated script at unequal depths must retain both control blocks.
+        vec![(1, ctv.clone()), (2, alternate), (2, ctv)]
+    };
+    let raw = RawTaproot::new(key, leaves).unwrap();
+    let mut object = Compiled::from_address(
+        Address::from_script(&raw.script_pubkey(), Network::Regtest).unwrap(),
+        None,
+    );
+    object.descriptor = Some(raw.into());
+    object.ctv_to_tx.insert(template.hash(), template);
+    object
+}
+
+fn funding(object: &Compiled) -> Transaction {
+    Transaction {
+        version: 2,
+        lock_time: 0,
+        input: vec![TxIn::default()],
+        output: vec![TxOut {
+            value: 1_000,
+            script_pubkey: Script::from(&object.address),
+        }],
+    }
+}
+
+struct Index {
+    transactions: RefCell<BTreeMap<Txid, Arc<Transaction>>>,
+    lookups: Cell<usize>,
+    writes: Cell<usize>,
+}
+
+impl Index {
+    fn with(tx: Transaction) -> Rc<Self> {
+        Rc::new(Self {
+            transactions: RefCell::new(BTreeMap::from([(tx.txid(), Arc::new(tx))])),
+            lookups: Cell::new(0),
+            writes: Cell::new(0),
+        })
+    }
+}
+
+impl TxIndex for Index {
+    fn lookup_tx(&self, txid: &Txid) -> Result<Arc<Transaction>, TxIndexError> {
+        self.lookups.set(self.lookups.get() + 1);
+        self.transactions
+            .borrow()
+            .get(txid)
+            .cloned()
+            .ok_or(TxIndexError::UnknownTxid(*txid))
+    }
+
+    fn add_tx(&self, tx: Arc<Transaction>) -> Result<Txid, TxIndexError> {
+        self.writes.set(self.writes.get() + 1);
+        let txid = tx.txid();
+        self.transactions.borrow_mut().insert(txid, tx);
+        Ok(txid)
+    }
+}
+
+#[derive(Default)]
+struct Signer {
+    calls: AtomicUsize,
+    strip_scripts: bool,
+}
+
+impl CTVEmulator for Signer {
+    fn get_signer_for(&self, _: sha256::Hash) -> Result<Clause, EmulatorError> {
+        unreachable!("binding does not compile policies")
+    }
+
+    fn sign(&self, mut psbt: Psbt) -> Result<Psbt, EmulatorError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        if self.strip_scripts {
+            psbt.inputs[0].tap_scripts.clear();
+        }
+        Ok(psbt)
+    }
+}
+
+#[test]
+fn serialized_raw_artifacts_bind_all_control_blocks_and_authenticated_funding() {
+    for key_only in [false, true] {
+        let object: Compiled =
+            serde_json::from_slice(&serde_json::to_vec(&artifact(key_only)).unwrap()).unwrap();
+        object.validate().unwrap();
+        let Some(SupportedDescriptors::Taproot(raw)) = &object.descriptor else {
+            panic!("round trip lost raw Taproot spending data");
+        };
+        let previous = funding(&object);
+        let outpoint = OutPoint::new(previous.txid(), 0);
+        let index = Index::with(previous.clone());
+        let signer = Signer::default();
+        let program = object
+            .bind_psbt(outpoint, BTreeMap::new(), index.clone(), &signer)
+            .unwrap();
+        let SapioStudioFormat::LinkedPSBT { psbt, .. } =
+            &program.program.get(&object.root_path).unwrap().txs[0];
+        let psbt: Psbt = bitcoin::consensus::deserialize(&base64::decode(psbt).unwrap()).unwrap();
+        let input = &psbt.inputs[0];
+        assert_eq!(input.tap_internal_key, Some(raw.internal_key()));
+        assert_eq!(input.tap_merkle_root, raw.spend_info().merkle_root());
+        assert_eq!(input.tap_scripts.len(), if key_only { 0 } else { 3 });
+        assert_eq!(input.witness_utxo.as_ref(), Some(&previous.output[0]));
+        assert_eq!(input.non_witness_utxo.as_ref(), Some(&previous));
+        assert_eq!(psbt.unsigned_tx.input[0].previous_output, outpoint);
+        assert_eq!(
+            psbt.unsigned_tx.get_ctv_hash(0),
+            *object.ctv_to_tx.keys().next().unwrap()
+        );
+        for (control, (script, version)) in &input.tap_scripts {
+            assert_eq!(*version, LeafVersion::TapScript);
+            assert!(raw.leaves().iter().any(|(_, leaf)| leaf == script));
+            assert!(control.verify_taproot_commitment(
+                &Secp256k1::verification_only(),
+                raw.spend_info().output_key().to_inner(),
+                script,
+            ));
+        }
+        assert_eq!(signer.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(index.writes.get(), 1);
+    }
+}
+
+#[test]
+fn raw_artifacts_preserve_descriptor_and_funding_checks_before_signing() {
+    for case in 0..3 {
+        let mut object = artifact(false);
+        let mut previous = funding(&object);
+        match case {
+            0 => {
+                object.address =
+                    sapio::util::extended_address::ExtendedAddress::Unknown(Script::from(vec![
+                        0x51,
+                    ]));
+            }
+            1 => previous.output[0].script_pubkey = Script::new(),
+            2 => previous.output[0].value = 999,
+            _ => unreachable!(),
+        }
+        let outpoint = OutPoint::new(previous.txid(), 0);
+        let index = Index::with(previous);
+        let signer = Signer::default();
+        let error = object
+            .bind_psbt(outpoint, BTreeMap::new(), index.clone(), &signer)
+            .unwrap_err();
+        if case == 0 {
+            let ObjectError::InvalidArtifact(error) = error else {
+                panic!("unexpected error: {error}");
+            };
+            assert_eq!(error.kind, ArtifactErrorKind::DescriptorMismatch);
+            assert_eq!(index.lookups.get(), 0);
+        } else {
+            assert!(matches!(error, ObjectError::InvalidFunding { .. }));
+        }
+        assert_eq!(signer.calls.load(Ordering::SeqCst), 0);
+        assert_eq!(index.writes.get(), 0);
+    }
+}
+
+#[test]
+fn a_signer_cannot_strip_raw_spending_data_before_indexing() {
+    let object = artifact(false);
+    let previous = funding(&object);
+    let outpoint = OutPoint::new(previous.txid(), 0);
+    let index = Index::with(previous);
+    let signer = Signer {
+        strip_scripts: true,
+        ..Default::default()
+    };
+    assert!(matches!(
+        object.bind_psbt(outpoint, BTreeMap::new(), index.clone(), &signer),
+        Err(ObjectError::Emulator(EmulatorError::InvalidResponse))
+    ));
+    assert_eq!(signer.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(index.writes.get(), 0);
+}
+
+#[test]
+fn structured_guard_metadata_round_trips_without_stringifying_policy_sources() {
+    let mut object = artifact(false);
+    let policy = ScriptPolicy::And(vec![
+        Clause::After(100).into(),
+        ScriptFragment::new(Script::from(vec![0x51]))
+            .unwrap()
+            .into(),
+    ]);
+    object.metadata.simps_for_guards.push(GuardMetadata {
+        policy: policy.clone(),
+        protocols: BTreeMap::from([(-17, vec![serde_json::json!({"label": "raw guard"})])]),
+    });
+    let serialized = serde_json::to_value(&object).unwrap();
+    assert_eq!(
+        serialized["metadata"]["simps_for_guards"][0]["policy"],
+        serde_json::to_value(policy).unwrap()
+    );
+    let decoded: Compiled = serde_json::from_value(serialized).unwrap();
+    assert_eq!(decoded.metadata, object.metadata);
+}

--- a/sapio/tests/taproot_lowering.rs
+++ b/sapio/tests/taproot_lowering.rs
@@ -1,0 +1,317 @@
+use bitcoin::secp256k1::{Keypair, Message, Secp256k1, SecretKey};
+use bitcoin::util::psbt::PartiallySignedTransaction as Psbt;
+use bitcoin::util::schnorr::TapTweak;
+use bitcoin::util::sighash::{Prevouts, SighashCache};
+use bitcoin::util::taproot::{LeafVersion, TapLeafHash};
+use bitcoin::{Amount, Network, OutPoint, SchnorrSig, SchnorrSighashType};
+use bitcoin::{Script, Transaction, TxIn, TxOut, XOnlyPublicKey};
+use sapio::contract::abi::object::{Object, SupportedDescriptors};
+use sapio::contract::actions::Guard;
+use sapio::contract::{Compilable, Context, DynamicContract};
+use sapio_base::miniscript::descriptor::Tr;
+use sapio_base::miniscript::ord::{envelope::Envelope, Inscription};
+use sapio_base::miniscript::psbt::{interpreter_check, PsbtExt};
+use sapio_base::miniscript::{Descriptor, DescriptorTrait};
+use sapio_base::util::CTVHash;
+use sapio_base::Clause;
+use sapio_ctv_emulator_trait::CTVAvailable;
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+fn keypair(byte: u8) -> Keypair {
+    Keypair::from_secret_key(
+        &Secp256k1::new(),
+        &SecretKey::from_slice(&[byte; 32]).unwrap(),
+    )
+}
+
+fn key(byte: u8) -> XOnlyPublicKey {
+    keypair(byte).x_only_public_key().0
+}
+
+fn guard_at<const SLOT: usize>() -> Option<Guard<[Clause; 3]>> {
+    Some(Guard::Cache(|clauses| clauses[SLOT].clone(), None))
+}
+
+fn compile(clauses: [Clause; 3], order: &[usize]) -> Object {
+    let factories = [guard_at::<0>, guard_at::<1>, guard_at::<2>];
+    let contract = DynamicContract::<(), _> {
+        then: vec![],
+        finish_or: vec![],
+        finish: order.iter().map(|index| factories[*index]).collect(),
+        metadata_f: Box::new(|_, _| Ok(Default::default())),
+        ensure_amount_f: Box::new(|_, ctx| Ok(ctx.funds())),
+        data: clauses,
+    };
+    let compiled = contract
+        .compile(Context::new(
+            Network::Regtest,
+            Amount::from_sat(10_000),
+            Arc::new(CTVAvailable),
+            "lowering".try_into().unwrap(),
+            Arc::new(Default::default()),
+            None,
+        ))
+        .unwrap();
+    compiled.validate().unwrap();
+    compiled
+}
+
+fn tree(compiled: &Object) -> &Tr<XOnlyPublicKey> {
+    match compiled.descriptor.as_ref().unwrap() {
+        SupportedDescriptors::XOnly(Descriptor::Tr(tree)) => tree,
+        _ => panic!("expected a Taproot descriptor"),
+    }
+}
+
+fn assert_same_output(first: &Object, second: &Object) {
+    assert_eq!(first.address, second.address);
+    assert_eq!(first.descriptor, second.descriptor);
+}
+
+#[test]
+fn reversing_finish_key_alternatives_preserves_the_output_and_internal_key() {
+    let clauses = [
+        Clause::Key(key(1)),
+        Clause::Key(key(2)),
+        Clause::Unsatisfiable,
+    ];
+    let forward = compile(clauses.clone(), &[0, 1]);
+    let reversed = compile(clauses, &[1, 0]);
+    assert_same_output(&forward, &reversed);
+    assert_eq!(*tree(&forward).internal_key(), key(1).min(key(2)));
+    assert_eq!(tree(&forward).iter_scripts().count(), 2);
+}
+
+#[test]
+fn repeated_script_alternatives_do_not_change_the_tree_or_output() {
+    let clauses = [
+        Clause::Key(key(1)),
+        Clause::And(vec![Clause::Key(key(2)), Clause::Older(16)]),
+        Clause::Key(key(3)),
+    ];
+    let canonical = compile(clauses.clone(), &[0, 1, 2]);
+    for order in [&[2, 0, 1][..], &[1, 2, 0, 1, 0, 2][..]] {
+        let compiled = compile(clauses.clone(), order);
+        assert_same_output(&canonical, &compiled);
+        assert_eq!(tree(&compiled).iter_scripts().count(), 3);
+    }
+}
+
+fn inscribe(body: &[u8], sub: Clause) -> Clause {
+    Clause::Inscribe(
+        Box::new(Inscription::new(None, Some(body.to_vec()))),
+        Box::new(sub),
+    )
+}
+
+fn transaction() -> Transaction {
+    Transaction {
+        version: 2,
+        lock_time: 0,
+        input: vec![TxIn {
+            sequence: 16,
+            ..TxIn::default()
+        }],
+        output: vec![TxOut {
+            value: 9_000,
+            script_pubkey: Script::new(),
+        }],
+    }
+}
+
+fn psbt(compiled: &Object, mut transaction: Transaction) -> Psbt {
+    let tree = tree(compiled);
+    let info = tree.spend_info();
+    let funding = Transaction {
+        version: 2,
+        lock_time: 0,
+        input: vec![TxIn::default()],
+        output: vec![TxOut {
+            value: 10_000,
+            script_pubkey: tree.script_pubkey(),
+        }],
+    };
+    transaction.input[0].previous_output = OutPoint::new(funding.txid(), 0);
+    let mut psbt = Psbt::from_unsigned_tx(transaction).unwrap();
+    psbt.inputs[0].witness_utxo = Some(funding.output[0].clone());
+    psbt.inputs[0].tap_internal_key = Some(*tree.internal_key());
+    psbt.inputs[0].tap_merkle_root = info.merkle_root();
+    for (_, miniscript) in tree.iter_scripts() {
+        let leaf = (miniscript.encode(), LeafVersion::TapScript);
+        psbt.inputs[0]
+            .tap_scripts
+            .insert(info.control_block(&leaf).unwrap(), leaf);
+    }
+    psbt
+}
+
+// Sign only after mutations, so negative timelock/CTV cases contain fresh,
+// otherwise valid transaction signatures rather than merely stale signatures.
+fn sign_scripts(psbt: &mut Psbt, owner: u8) {
+    let secp = Secp256k1::new();
+    let prevouts = [psbt.inputs[0].witness_utxo.clone().unwrap()];
+    let leaves: Vec<_> = psbt.inputs[0]
+        .tap_scripts
+        .values()
+        .map(|(script, version)| TapLeafHash::from_script(script, *version))
+        .collect();
+    for leaf in leaves {
+        let hash_ty = SchnorrSighashType::Default;
+        let hash = SighashCache::new(&psbt.unsigned_tx)
+            .taproot_script_spend_signature_hash(0, &Prevouts::All(&prevouts), leaf, hash_ty)
+            .unwrap();
+        let sig = secp.sign_schnorr_no_aux_rand(
+            &Message::from_digest_slice(&hash[..]).unwrap(),
+            &keypair(owner),
+        );
+        psbt.inputs[0]
+            .tap_script_sigs
+            .insert((key(owner), leaf), SchnorrSig { sig, hash_ty });
+    }
+}
+
+fn finalize(mut psbt: Psbt) -> Transaction {
+    let secp = Secp256k1::new();
+    psbt.finalize_mut(&secp).unwrap();
+    interpreter_check(&psbt, &secp).unwrap();
+    psbt.extract(&secp).unwrap()
+}
+
+fn sign_key_path(psbt: &mut Psbt, owner: u8) {
+    let secp = Secp256k1::new();
+    let prevouts = [psbt.inputs[0].witness_utxo.clone().unwrap()];
+    let hash_ty = SchnorrSighashType::Default;
+    let hash = SighashCache::new(&psbt.unsigned_tx)
+        .taproot_key_spend_signature_hash(0, &Prevouts::All(&prevouts), hash_ty)
+        .unwrap();
+    let tweaked_owner = keypair(owner)
+        .tap_tweak(&secp, psbt.inputs[0].tap_merkle_root)
+        .into_inner();
+    psbt.inputs[0].tap_key_sig = Some(SchnorrSig {
+        sig: secp.sign_schnorr_no_aux_rand(
+            &Message::from_digest_slice(&hash[..]).unwrap(),
+            &tweaked_owner,
+        ),
+        hash_ty,
+    });
+}
+
+#[test]
+fn selected_bare_key_can_authorize_a_real_key_path_spend() {
+    let compiled = compile(
+        [
+            Clause::Key(key(1)),
+            Clause::Key(key(2)),
+            Clause::Unsatisfiable,
+        ],
+        &[1, 0],
+    );
+    let owner = if key(1) < key(2) { 1 } else { 2 };
+    let mut spend = psbt(&compiled, transaction());
+    spend.inputs[0].tap_scripts.clear();
+    sign_key_path(&mut spend, owner);
+    assert_eq!(finalize(spend).input[0].witness.len(), 1);
+}
+
+#[test]
+fn deduplicating_alternatives_preserves_inscription_order_and_multiplicity() {
+    let clauses = [
+        inscribe(b"a", inscribe(b"a", Clause::Key(key(1)))),
+        inscribe(b"a", inscribe(b"b", Clause::Key(key(1)))),
+        inscribe(b"b", inscribe(b"a", Clause::Key(key(1)))),
+    ];
+    let distinct = compile(clauses.clone(), &[0, 1, 2]);
+    let repeated = compile(clauses, &[2, 0, 1, 0, 2, 1]);
+    assert_same_output(&distinct, &repeated);
+    assert_eq!(tree(&repeated).iter_scripts().count(), 3);
+    let mut revealed = BTreeSet::new();
+    for (_, miniscript) in tree(&repeated).iter_scripts() {
+        let script = miniscript.encode();
+        let mut spend = psbt(&repeated, transaction());
+        spend.inputs[0]
+            .tap_scripts
+            .retain(|_, (candidate, _)| *candidate == script);
+        sign_scripts(&mut spend, 1);
+        let transaction = finalize(spend);
+        assert_eq!(transaction.input[0].witness.to_vec()[1], script.as_bytes());
+        let bodies: Vec<_> = Envelope::<Inscription>::from_transaction(&transaction)
+            .into_iter()
+            .map(|envelope| envelope.payload.body.unwrap())
+            .collect();
+        revealed.insert(bodies);
+    }
+    assert_eq!(
+        revealed,
+        BTreeSet::from([
+            vec![b"a".to_vec(), b"a".to_vec()],
+            vec![b"a".to_vec(), b"b".to_vec()],
+            vec![b"b".to_vec(), b"a".to_vec()],
+        ])
+    );
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Constraint {
+    RelativeLock,
+    Covenant,
+    Inscription,
+}
+
+#[test]
+fn constrained_signers_cannot_bypass_the_script_through_key_path_spending() {
+    let secp = Secp256k1::new();
+    for constraint in [
+        Constraint::RelativeLock,
+        Constraint::Covenant,
+        Constraint::Inscription,
+    ] {
+        let transaction = transaction();
+        let policy = match constraint {
+            Constraint::RelativeLock => Clause::And(vec![Clause::Key(key(1)), Clause::Older(16)]),
+            Constraint::Covenant => Clause::And(vec![
+                Clause::Key(key(1)),
+                Clause::TxTemplate(transaction.get_ctv_hash(0)),
+            ]),
+            Constraint::Inscription => inscribe(b"reveal", Clause::Key(key(1))),
+        };
+        let compiled = compile([policy, Clause::Unsatisfiable, Clause::Unsatisfiable], &[0]);
+        let tree = tree(&compiled);
+        // This is the original SHA256([1; 32]) fallback point, not any owner's
+        // key. Pinning it also prevents changing existing script-only outputs.
+        assert_eq!(
+            tree.internal_key().to_string(),
+            "72cd6e8422c407fb6d098690f1130b7ded7ec2f7f5e1d30bd9d521f015363793"
+        );
+        assert_ne!(*tree.internal_key(), key(1));
+        let unsigned = psbt(&compiled, transaction);
+        assert!(unsigned.clone().finalize_mut(&secp).is_err());
+
+        let mut script_spend = unsigned.clone();
+        sign_scripts(&mut script_spend, 1);
+        let valid = finalize(script_spend);
+        assert_eq!(valid.input[0].witness.len(), 3, "{constraint:?}");
+
+        let mut key_spend = unsigned.clone();
+        key_spend.inputs[0].tap_scripts.clear();
+        sign_key_path(&mut key_spend, 1);
+        assert!(key_spend.finalize_mut(&secp).is_err(), "{constraint:?}");
+
+        let mut invalid = unsigned;
+        match constraint {
+            Constraint::RelativeLock => invalid.unsigned_tx.input[0].sequence = 15,
+            Constraint::Covenant => invalid.unsigned_tx.output[0].value -= 1,
+            Constraint::Inscription => {
+                assert_eq!(
+                    Envelope::<Inscription>::from_transaction(&valid)[0]
+                        .payload
+                        .body,
+                    Some(b"reveal".to_vec())
+                );
+                invalid.inputs[0].tap_scripts.clear();
+            }
+        }
+        sign_scripts(&mut invalid, 1);
+        assert!(invalid.finalize_mut(&secp).is_err(), "{constraint:?}");
+    }
+}

--- a/sapio/tests/template_feasibility.rs
+++ b/sapio/tests/template_feasibility.rs
@@ -1,0 +1,174 @@
+use bitcoin::hashes::{sha256, Hash};
+use bitcoin::secp256k1::{Secp256k1, SecretKey};
+use bitcoin::{Amount, Network, XOnlyPublicKey};
+use sapio::contract::{Compilable, CompilationError, Contract};
+use sapio::template::Template;
+use sapio::{declare, guard, then, Context};
+use sapio_base::{CTVHash, Clause};
+use sapio_ctv_emulator_trait::{CTVAvailable, CTVEmulator, EmulatorError};
+use std::sync::Arc;
+
+fn key(index: u8) -> XOnlyPublicKey {
+    SecretKey::from_slice(&[index; 32])
+        .unwrap()
+        .keypair(&Secp256k1::new())
+        .x_only_public_key()
+        .0
+}
+
+struct Emulated;
+impl CTVEmulator for Emulated {
+    fn get_signer_for(&self, _: sha256::Hash) -> Result<Clause, EmulatorError> {
+        Ok(Clause::Key(key(4)))
+    }
+    fn sign(
+        &self,
+        _: bitcoin::util::psbt::PartiallySignedTransaction,
+    ) -> Result<bitcoin::util::psbt::PartiallySignedTransaction, EmulatorError> {
+        unreachable!("compilation must not sign")
+    }
+}
+
+fn context(emulated: bool) -> Context {
+    Context::new(
+        Network::Regtest,
+        Amount::from_sat(1_000),
+        if emulated {
+            Arc::new(Emulated)
+        } else {
+            Arc::new(CTVAvailable)
+        },
+        "compatibility".try_into().unwrap(),
+        Arc::new(Default::default()),
+        None,
+    )
+}
+
+struct Payment {
+    action_guard: Clause,
+    template_guard: Clause,
+    version: i32,
+    sequence: u32,
+    lock_time: u32,
+}
+
+impl Payment {
+    fn with_guard(guard: Clause, on_template: bool) -> Self {
+        Self {
+            action_guard: if on_template {
+                Clause::Trivial
+            } else {
+                guard.clone()
+            },
+            template_guard: if on_template { guard } else { Clause::Trivial },
+            version: 2,
+            sequence: 10,
+            lock_time: 100,
+        }
+    }
+
+    #[guard]
+    fn authorized(self, _ctx: Context) {
+        self.action_guard.clone()
+    }
+
+    #[then(guarded_by = "[Self::authorized]")]
+    fn pay(self, ctx: Context) {
+        let mut template: Template = ctx
+            .template()
+            .add_output(Amount::from_sat(1_000), &key(9), None)?
+            .add_guard(self.template_guard.clone())
+            .into();
+        template.tx.version = self.version;
+        template.tx.lock_time = self.lock_time;
+        template.tx.input[0].sequence = self.sequence;
+        template.ctv = template.tx.get_ctv_hash(0);
+        Ok(Box::new(std::iter::once(Ok(template))))
+    }
+}
+
+impl Contract for Payment {
+    declare! {then, Self::pay}
+    declare! {non updatable}
+}
+
+fn impossible(payment: &Payment, emulated: bool) {
+    let error = payment.compile(context(emulated)).unwrap_err();
+    let CompilationError::ImpossibleTemplate { at, .. } = error else {
+        panic!("{error:?}")
+    };
+    assert_eq!(String::from(at), "compatibility/@action/pay/@next");
+}
+
+#[test]
+fn fixed_transaction_must_meet_action_and_template_timelocks() {
+    for emulated in [false, true] {
+        for on_template in [false, true] {
+            for guard in [Clause::Older(10), Clause::After(100)] {
+                let mut payment = Payment::with_guard(guard.clone(), on_template);
+                payment
+                    .compile(context(emulated))
+                    .unwrap()
+                    .validate()
+                    .unwrap();
+                match guard {
+                    Clause::Older(_) => {
+                        payment.sequence = 9;
+                        impossible(&payment, emulated);
+                        payment.sequence = (1 << 22) | 10;
+                        impossible(&payment, emulated);
+                        payment.sequence = 10;
+                        payment.version = 1;
+                        impossible(&payment, emulated);
+                    }
+                    Clause::After(_) => {
+                        payment.lock_time = 99;
+                        impossible(&payment, emulated);
+                        payment.lock_time = 500_000_000;
+                        impossible(&payment, emulated);
+                        payment.lock_time = 100;
+                        payment.sequence = u32::MAX;
+                        impossible(&payment, emulated);
+                    }
+                    _ => unreachable!(),
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn viable_alternatives_remain_available_without_requiring_every_timelock() {
+    for emulated in [false, true] {
+        for on_template in [false, true] {
+            let children = vec![Clause::Older(11), Clause::Key(key(1)), Clause::After(100)];
+            for policy in [
+                Clause::Or(vec![(1, children[0].clone()), (1, children[1].clone())]),
+                Clause::Threshold(2, children.clone()),
+            ] {
+                Payment::with_guard(policy, on_template)
+                    .compile(context(emulated))
+                    .unwrap();
+            }
+            impossible(
+                &Payment::with_guard(Clause::Threshold(3, children), on_template),
+                emulated,
+            );
+        }
+    }
+}
+
+#[test]
+fn an_additional_covenant_cannot_require_a_different_transaction() {
+    for emulated in [false, true] {
+        for on_template in [false, true] {
+            impossible(
+                &Payment::with_guard(
+                    Clause::TxTemplate(sha256::Hash::hash(b"different template")),
+                    on_template,
+                ),
+                emulated,
+            );
+        }
+    }
+}

--- a/sapio/tests/template_policy_provenance.rs
+++ b/sapio/tests/template_policy_provenance.rs
@@ -1,0 +1,92 @@
+#[path = "fixtures/custom_policy.rs"]
+mod fixture;
+
+use bitcoin::blockdata::opcodes::all::OP_VERIFY;
+use bitcoin::{Amount, Script};
+use fixture::{context, key, ArithmeticSigner};
+use sapio::contract::actions::ThenFuncAsFinishOrFunc;
+use sapio::contract::object::SupportedDescriptors;
+use sapio::contract::{Compilable, Context, Contract, TxTmplIt};
+use sapio::{declare, guard, then};
+use sapio_base::miniscript::Tap;
+use sapio_base::policy::{PolicyCompiler, ScriptPolicy};
+use sapio_base::Clause;
+use std::collections::BTreeSet;
+
+fn payment(ctx: Context) -> TxTmplIt {
+    ctx.template()
+        .add_output(Amount::from_sat(1_000), &key(9), None)?
+        .into()
+}
+
+struct Payments<const REVERSED: bool>;
+
+impl<const REVERSED: bool> Payments<REVERSED> {
+    #[guard(policy)]
+    fn owner(self, _ctx: Context) -> ArithmeticSigner {
+        ArithmeticSigner(key(1))
+    }
+
+    #[then]
+    fn unguarded(self, ctx: Context) {
+        payment(ctx)
+    }
+
+    #[then(guarded_by = "[Self::owner]")]
+    fn guarded(self, ctx: Context) {
+        payment(ctx)
+    }
+}
+
+impl<const REVERSED: bool> Contract for Payments<REVERSED> {
+    const THEN_FNS: &'static [fn() -> Option<ThenFuncAsFinishOrFunc<'static, Self, ()>>] =
+        if REVERSED {
+            &[Self::guarded, Self::unguarded]
+        } else {
+            &[Self::unguarded, Self::guarded]
+        };
+    declare! {non updatable}
+}
+
+#[test]
+fn an_unguarded_duplicate_preserves_the_optional_raw_policy_and_its_script() {
+    let forward = Payments::<false>.compile(context(false)).unwrap();
+    let reverse = Payments::<true>.compile(context(false)).unwrap();
+    assert_eq!(forward.ctv_to_tx.len(), 1);
+    assert_eq!(forward.ctv_to_tx, reverse.ctv_to_tx);
+    assert_eq!(forward.descriptor, reverse.descriptor);
+    forward.validate().unwrap();
+    let template = forward.ctv_to_tx.values().next().unwrap();
+    let optional = ArithmeticSigner(key(1)).compile_policy().unwrap();
+    assert_eq!(
+        template.guards,
+        vec![ScriptPolicy::Or(vec![
+            Clause::Trivial.into(),
+            optional.clone(),
+        ])]
+    );
+    // An unknown witness bound does not prevent compilation when the contract
+    // makes no minimum-feerate claim.
+    assert_eq!(template.min_feerate_sats_vbyte, None);
+
+    let Some(SupportedDescriptors::Taproot(raw)) = &forward.descriptor else {
+        panic!("the raw authorization must retain its script spending data");
+    };
+    let covenant = Clause::TxTemplate(template.hash())
+        .compile::<Tap>()
+        .unwrap()
+        .encode();
+    let ScriptPolicy::Script(fragment) = optional else {
+        unreachable!()
+    };
+    let mut guarded = fragment.into_script().as_bytes().to_vec();
+    guarded.push(OP_VERIFY.into_u8());
+    guarded.extend_from_slice(covenant.as_bytes());
+    assert_eq!(
+        raw.leaves()
+            .iter()
+            .map(|(_, script)| script.clone())
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([covenant, Script::from(guarded)])
+    );
+}

--- a/sapio/tests/template_semantics.rs
+++ b/sapio/tests/template_semantics.rs
@@ -123,7 +123,11 @@ fn duplicate_transactions_preserve_every_authorization_and_its_action_guard() {
         };
         let compiled_policy = descriptor.lift().unwrap();
         assert_eq!(template.guards.len(), 1);
-        let stored_guards = template.guards[0].lift().unwrap();
+        let sapio_base::policy::ScriptPolicy::Miniscript(stored_guards) = &template.guards[0]
+        else {
+            panic!()
+        };
+        let stored_guards = stored_guards.lift().unwrap();
         for mask in 0..16 {
             let authorized = mask & 1 != 0 || mask & 6 == 6;
             assert_eq!(accepts(&stored_guards, mask, template.hash()), authorized);
@@ -214,7 +218,7 @@ impl Suggested {
     fn update(self, ctx: Context, _args: ()) {
         let first = payment(ctx, &[])?;
         let mut second = first.clone();
-        second.guards.push(Clause::Key(key(2)));
+        second.guards.push(Clause::Key(key(2)).into());
         Ok(Box::new([Ok(first), Ok(second)].into_iter()))
     }
 }

--- a/sapio/tests/two_guards.rs
+++ b/sapio/tests/two_guards.rs
@@ -73,5 +73,5 @@ fn compiles_both_guards_with_distinct_metadata_paths() {
     });
     assert!(keys.contains(&contract.first));
     assert!(keys.contains(&contract.second));
-    assert_eq!(compiled.metadata.simps_for_guards.len(), 2);
+    assert!(compiled.metadata.simps_for_guards.is_empty());
 }

--- a/sapio_macros/src/lib.rs
+++ b/sapio_macros/src/lib.rs
@@ -29,6 +29,11 @@ pub fn compile_if(args: TokenStream, input: TokenStream) -> TokenStream {
 /// `#[guard(cached)]` instead accepts only `self`: a cached clause cannot depend
 /// on its invocation context. `simps = "Some(Self::metadata)"` optionally supplies
 /// a metadata callback, evaluated with the context of each guard attachment.
+///
+/// `#[guard(policy)]` accepts an explicit return type implementing
+/// `sapio::sapio_base::policy::PolicyCompiler`. Its translation errors propagate
+/// through contract compilation. Combine it with `cached` for context-free
+/// policies evaluated once per compilation: `#[guard(policy, cached)]`.
 #[proc_macro_attribute]
 pub fn guard(args: TokenStream, input: TokenStream) -> TokenStream {
     expand_attribute(Action::Guard, args, input)
@@ -91,6 +96,7 @@ fn expand(action: Action, args: AttributeArgs, mut input: ItemFn) -> syn::Result
 
     let Options {
         cached,
+        policy,
         guarded_by,
         compile_if,
         coerce_args,
@@ -108,13 +114,36 @@ fn expand(action: Action, args: AttributeArgs, mut input: ItemFn) -> syn::Result
             }
         },
         Action::Guard => {
-            let variant = if cached { quote!(Cache) } else { quote!(Fresh) };
+            let (variant, callback) = if policy {
+                if cached {
+                    (
+                        quote!(CachedPolicy),
+                        quote!(|this| {
+                            ::sapio::sapio_base::policy::PolicyCompiler::compile_policy(&Self::#helper(this))
+                                .map_err(::sapio::contract::CompilationError::from)
+                        }),
+                    )
+                } else {
+                    (
+                        quote!(FreshPolicy),
+                        quote!(|this, ctx| {
+                            ::sapio::sapio_base::policy::PolicyCompiler::compile_policy(&Self::#helper(this, ctx))
+                                .map_err(::sapio::contract::CompilationError::from)
+                        }),
+                    )
+                }
+            } else {
+                (
+                    if cached { quote!(Cache) } else { quote!(Fresh) },
+                    quote!(Self::#helper),
+                )
+            };
             quote! {
                 #(#attrs)*
                 #[doc = "Guard action declaration."]
                 #vis fn #name() -> ::std::option::Option<::sapio::contract::actions::Guard<Self>> {
                     ::std::option::Option::Some(
-                        ::sapio::contract::actions::Guard::#variant(Self::#helper, #simps)
+                        ::sapio::contract::actions::Guard::#variant(#callback, #simps)
                     )
                 }
             }

--- a/sapio_macros/src/parse.rs
+++ b/sapio_macros/src/parse.rs
@@ -2,7 +2,7 @@ use proc_macro2::Span;
 use std::collections::BTreeSet;
 use syn::{
     parse_quote, spanned::Spanned, AttributeArgs, Expr, ExprArray, FnArg, Lit, LitStr, Meta,
-    NestedMeta, Signature,
+    NestedMeta, ReturnType, Signature,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -25,7 +25,7 @@ impl Action {
 
     fn accepts(self, name: &str) -> bool {
         match name {
-            "cached" => self == Self::Guard,
+            "cached" | "policy" => self == Self::Guard,
             "guarded_by" | "compile_if" => matches!(self, Self::Then | Self::Continuation),
             "coerce_args" | "web_api" => self == Self::Continuation,
             "simps" => matches!(self, Self::Guard | Self::Continuation),
@@ -36,6 +36,7 @@ impl Action {
 
 pub(crate) struct Options {
     pub cached: bool,
+    pub policy: bool,
     pub guarded_by: ExprArray,
     pub compile_if: ExprArray,
     pub coerce_args: Option<Expr>,
@@ -47,6 +48,7 @@ impl Options {
     pub(crate) fn parse(action: Action, args: AttributeArgs, span: Span) -> syn::Result<Self> {
         let mut options = Self {
             cached: false,
+            policy: false,
             guarded_by: parse_quote!([]),
             compile_if: parse_quote!([]),
             coerce_args: None,
@@ -75,7 +77,7 @@ impl Options {
                 ));
             }
             match name.as_str() {
-                "cached" | "web_api" => {
+                "cached" | "policy" | "web_api" => {
                     if !matches!(meta, Meta::Path(_)) {
                         return Err(syn::Error::new_spanned(
                             meta,
@@ -84,6 +86,8 @@ impl Options {
                     }
                     if name == "cached" {
                         options.cached = true;
+                    } else if name == "policy" {
+                        options.policy = true;
                     } else {
                         options.web_api = true;
                     }
@@ -162,6 +166,12 @@ pub(crate) fn validate_signature(
         return Err(syn::Error::new_spanned(
             variadic,
             "contract actions cannot be variadic",
+        ));
+    }
+    if options.policy && matches!(sig.output, ReturnType::Default) {
+        return Err(syn::Error::new_spanned(
+            &sig.ident,
+            "a policy guard requires an explicit return type implementing PolicyCompiler",
         ));
     }
     let count = if options.cached {

--- a/sapio_macros/src/tests.rs
+++ b/sapio_macros/src/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use syn::{
-    parse::Parser, punctuated::Punctuated, ImplItem, ItemImpl, NestedMeta, Token, Visibility,
+    parse::Parser, punctuated::Punctuated, Expr, ImplItem, ItemImpl, NestedMeta, Stmt, Token,
+    Visibility,
 };
 
 fn arguments(tokens: Tokens) -> AttributeArgs {
@@ -43,10 +44,13 @@ fn unknown_options_fail_instead_of_removing_contract_conditions() {
     }
     for (action, tokens) in [
         (Action::CompileIf, quote!(cached)),
+        (Action::CompileIf, quote!(policy)),
         (Action::Guard, quote!(guarded_by = "[]")),
         (Action::Then, quote!(web_api)),
         (Action::Then, quote!(simps = "None")),
+        (Action::Then, quote!(policy)),
         (Action::Continuation, quote!(cached)),
+        (Action::Continuation, quote!(policy)),
     ] {
         assert_eq!(
             option_error(action, tokens),
@@ -59,6 +63,7 @@ fn unknown_options_fail_instead_of_removing_contract_conditions() {
 fn duplicate_options_are_always_errors() {
     for (action, tokens, name) in [
         (Action::Guard, quote!(cached, cached), "cached"),
+        (Action::Guard, quote!(policy, policy), "policy"),
         (
             Action::Guard,
             quote!(simps = "None", simps = "None"),
@@ -96,6 +101,13 @@ fn options_require_their_documented_syntax() {
         quote!(cached()),
     ] {
         assert!(option_error(Action::Guard, tokens).contains("`cached` is a flag"));
+    }
+    for tokens in [
+        quote!(policy = true),
+        quote!(policy = "MyPolicy"),
+        quote!(policy()),
+    ] {
+        assert!(option_error(Action::Guard, tokens).contains("`policy` is a flag"));
     }
     for tokens in [
         quote!(guarded_by = 1),
@@ -242,4 +254,121 @@ fn continuation_helpers_preserve_case_and_raw_identifiers() {
     assert!(names.contains("__sapio_schema_for_pay"));
     assert!(names.contains("__sapio_schema_for_PAY"));
     assert!(names.contains("__sapio_schema_for_type"));
+}
+
+#[test]
+fn policy_guards_require_explicit_backend_types_and_respect_cached_context_rules() {
+    for (flags, input) in [
+        (
+            quote!(policy),
+            quote!(
+                fn signed(self, ctx: Context) {}
+            ),
+        ),
+        (
+            quote!(policy, cached),
+            quote!(
+                fn signed(self) {}
+            ),
+        ),
+    ] {
+        let error =
+            expand(Action::Guard, arguments(flags), syn::parse2(input).unwrap()).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "a policy guard requires an explicit return type implementing PolicyCompiler"
+        );
+    }
+    let error = expand(
+        Action::Guard,
+        arguments(quote!(cached, policy)),
+        parse_quote!(
+            fn signed(self, ctx: Context) -> CustomPolicy {}
+        ),
+    )
+    .unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("cached clauses cannot depend on Context"));
+}
+
+#[test]
+fn policy_guard_callbacks_forward_context_and_propagate_backend_errors() {
+    let cases: [(Tokens, ItemFn, Expr); 2] = [
+        (
+            quote!(policy, simps = "Some(Self::metadata)"),
+            parse_quote! {
+                pub fn signed(self, ctx: Context) -> CustomPolicy { make_policy(ctx) }
+            },
+            parse_quote!(::sapio::contract::actions::Guard::FreshPolicy),
+        ),
+        (
+            quote!(cached, policy, simps = "Some(Self::metadata)"),
+            parse_quote! {
+                pub fn signed(self) -> CustomPolicy { make_policy() }
+            },
+            parse_quote!(::sapio::contract::actions::Guard::CachedPolicy),
+        ),
+    ];
+    for (flags, source, expected_constructor) in cases {
+        let source_body = source.block.clone();
+        let source_inputs = source.sig.inputs.len();
+        let expansion = expand(Action::Guard, arguments(flags), source).unwrap();
+        let generated: ItemImpl = syn::parse2(quote!(impl Contract { #expansion })).unwrap();
+        assert_eq!(generated.items.len(), 2);
+        let ImplItem::Method(helper) = &generated.items[0] else {
+            panic!("expected a policy implementation method");
+        };
+        assert_eq!(helper.sig.ident, "guard_signed");
+        assert_eq!(helper.sig.output, parse_quote!(-> CustomPolicy));
+        assert_eq!(helper.sig.inputs.len(), source_inputs);
+        assert_eq!(&helper.block, source_body.as_ref());
+        assert!(matches!(helper.vis, Visibility::Public(_)));
+
+        let ImplItem::Method(factory) = &generated.items[1] else {
+            panic!("expected a policy guard factory");
+        };
+        let Some(Stmt::Expr(Expr::Call(some))) = factory.block.stmts.last() else {
+            panic!("expected Some(policy guard)");
+        };
+        let Expr::Call(constructor) = &some.args[0] else {
+            panic!("expected a policy guard callback");
+        };
+        assert_eq!(constructor.func.as_ref(), &expected_constructor);
+        assert_eq!(constructor.args[1], parse_quote!(Some(Self::metadata)));
+        let Expr::Closure(callback) = &constructor.args[0] else {
+            panic!("expected a policy translation callback");
+        };
+        assert_eq!(callback.inputs.len(), source_inputs);
+        let Expr::Block(body) = callback.body.as_ref() else {
+            panic!("expected the translation callback body");
+        };
+        let Some(Stmt::Expr(Expr::MethodCall(result))) = body.block.stmts.last() else {
+            panic!("expected a returned policy compilation result");
+        };
+        assert_eq!(result.method, "map_err");
+        assert_eq!(
+            result.args[0],
+            parse_quote!(::sapio::contract::CompilationError::from)
+        );
+        let Expr::Call(compile) = result.receiver.as_ref() else {
+            panic!("expected a policy compiler invocation");
+        };
+        assert_eq!(
+            compile.func.as_ref(),
+            &parse_quote!(::sapio::sapio_base::policy::PolicyCompiler::compile_policy)
+        );
+        let Expr::Reference(policy) = &compile.args[0] else {
+            panic!("expected the source policy to be borrowed for translation");
+        };
+        let Expr::Call(invoke) = policy.expr.as_ref() else {
+            panic!("expected the preserved source helper to be called");
+        };
+        assert_eq!(invoke.func.as_ref(), &parse_quote!(Self::guard_signed));
+        assert_eq!(invoke.args.len(), source_inputs);
+        assert_eq!(invoke.args[0], parse_quote!(this));
+        if source_inputs == 2 {
+            assert_eq!(invoke.args[1], parse_quote!(ctx));
+        }
+    }
 }


### PR DESCRIPTION
Sapio can now use custom Rust policy compilers for contract guards and template preconditions. Backends return native policy source, checked Tapscript predicates, or ordered combinations of both. This carries forward the direction of #269 on current master.

- Add `PolicyCompiler`, `ScriptPolicy`, `#[guard(policy)]`, cached and fallible backend support, trait declarations, and `Builder::add_policy`.
- Preserve action authorization, transaction covenants and raw script order through bounded recursive lowering. Validate source before simplification, check known CLTV/CSV/CTV requirements against fixed templates, and canonicalize native key selection and identical complete leaves.
- Carry checked raw Taproot trees and control blocks through artifact serialization and PSBT binding. Retain guard caching, contextual metadata, funding checks and duplicate-template provenance.
- Add a real WASM backend example, node-executed custom witnesses, and documentation covering the API and artifact schema migration.

Opaque scripts require backend-owned witness construction and have no inferred maximum satisfaction weight. Minimum-feerate claims therefore fail explicitly for these contracts. A failed native finalization identifies unsupported leaves while preserving the unfinished PSBT. The native Clause API remains available.

Artifact consumers must regenerate schemas: guard metadata is now a list of typed policy records, template preconditions contain tagged policies, and descriptors include checked raw Taproot trees. See `docs/POLICY_BACKENDS.md` for the migration and composition contract.

Validation completed locally:

- 336 workspace tests and 22 plugin workspace tests pass.
- Feature checks, Clippy, API docs, formatting and book build pass; existing warnings remain.
- All optimized WASM guests build. All 19 guest modules pass real host schema, artifact and repeatability checks; both shared interfaces are inventoried.
- CLI direct, cross-module, inscription and mock-binding checks pass.
- Bitcoin Core 31.1 accepts 2 valid custom-script spends and rejects 10 invalid variants, including removal of each required signer and changed outputs. The same oracle is wired into Ubuntu CI. These are ordinary Taproot checks with an emulator key clause; they do not validate native CTV enforcement or an emulator service's approval rule.

All four [CI jobs](https://github.com/sapio-lang/sapio/actions/runs/34395711159) pass on `4dd6ff3`: Linux tests and the Core oracle, macOS tests, quality checks, and the complete WASM suite.
